### PR TITLE
feat: implement phase 4 activity logging

### DIFF
--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -20,6 +20,10 @@ jest.mock('../public/js/activities/renderer.js', () => ({
     renderActivities: jest.fn()
 }));
 
+jest.mock('../public/js/modal-manager.js', () => ({
+    showActivityEditModal: jest.fn(() => Promise.resolve(null))
+}));
+
 import {
     syncActivitiesUI,
     renderTodayActivities,
@@ -34,6 +38,7 @@ import {
 } from '../public/js/activities/handlers.js';
 import { getTodaysActivities } from '../public/js/activities/manager.js';
 import { renderActivities } from '../public/js/activities/renderer.js';
+import { showActivityEditModal } from '../public/js/modal-manager.js';
 
 describe('activity app integration', () => {
     beforeEach(() => {
@@ -172,8 +177,8 @@ describe('activity app integration', () => {
         expect(focusTaskDescriptionInputMock).toHaveBeenCalled();
     });
 
-    test('handles activity edit clicks and trims prompt output', async () => {
-        const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('  Updated  ');
+    test('handles activity edit clicks through the edit modal result', async () => {
+        showActivityEditModal.mockResolvedValue('  Updated  ');
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
             <article data-activity-id="activity-1">
@@ -189,12 +194,13 @@ describe('activity app integration', () => {
                 resetAllConfirmingDeleteFlags: jest.fn()
             }
         );
+        await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(handled).toBe(true);
+        expect(showActivityEditModal).toHaveBeenCalledWith('Current');
         expect(handleEditActivity).toHaveBeenCalledWith('activity-1', {
             description: 'Updated'
         });
-        promptSpy.mockRestore();
     });
 
     test('handles activity delete clicks', async () => {
@@ -231,5 +237,39 @@ describe('activity app integration', () => {
         expect(handled).toBe(false);
         expect(resetAllConfirmingDeleteFlagsMock).toHaveBeenCalled();
         expect(refreshUIMock).toHaveBeenCalled();
+    });
+
+    test('does not edit activity when modal result is null blank or unchanged', async () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article data-activity-id="activity-3">
+                <span class="text-sm text-slate-200">Current</span>
+                <button class="btn-edit-activity"><span>Edit</span></button>
+            </article>
+        `;
+        const target = activityList.querySelector('.btn-edit-activity span');
+
+        showActivityEditModal.mockResolvedValueOnce(null);
+        await handleActivityListClick(target, {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        showActivityEditModal.mockResolvedValueOnce('   ');
+        await handleActivityListClick(target, {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        showActivityEditModal.mockResolvedValueOnce('Current');
+        await handleActivityListClick(target, {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(handleEditActivity).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -1,0 +1,235 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/activities/form-utils.js', () => ({
+    extractActivityFormData: jest.fn()
+}));
+
+jest.mock('../public/js/activities/handlers.js', () => ({
+    handleAddActivity: jest.fn(() => Promise.resolve()),
+    handleEditActivity: jest.fn(() => Promise.resolve()),
+    handleDeleteActivity: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('../public/js/activities/manager.js', () => ({
+    getTodaysActivities: jest.fn(() => [])
+}));
+
+jest.mock('../public/js/activities/renderer.js', () => ({
+    renderActivities: jest.fn()
+}));
+
+import {
+    syncActivitiesUI,
+    renderTodayActivities,
+    handleActivityAwareFormSubmit,
+    handleActivityListClick
+} from '../public/js/activities/ui-handlers.js';
+import { extractActivityFormData } from '../public/js/activities/form-utils.js';
+import {
+    handleAddActivity,
+    handleEditActivity,
+    handleDeleteActivity
+} from '../public/js/activities/handlers.js';
+import { getTodaysActivities } from '../public/js/activities/manager.js';
+import { renderActivities } from '../public/js/activities/renderer.js';
+
+describe('activity app integration', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = `
+            <div id="activity-toggle-option" class="hidden"></div>
+            <div id="activities-container" class="hidden"></div>
+            <input id="scheduled" type="radio" name="task-type" checked />
+            <input id="activity" type="radio" name="task-type" />
+            <div id="activity-list"></div>
+            <div id="end-time-hint"></div>
+            <div id="overlap-warning"></div>
+            <button id="add-task-btn" type="submit">Add Task</button>
+            <select id="category-select"></select>
+            <form id="task-form">
+                <input name="description" />
+                <input type="radio" name="task-type" value="scheduled" checked />
+                <input type="radio" name="task-type" value="activity" />
+            </form>
+        `;
+    });
+
+    test('shows activity UI when enabled', () => {
+        syncActivitiesUI(true);
+
+        expect(document.getElementById('activity-toggle-option').classList.contains('hidden')).toBe(
+            false
+        );
+        expect(document.getElementById('activities-container').classList.contains('hidden')).toBe(
+            false
+        );
+    });
+
+    test('hides activity UI and restores scheduled mode when disabled', () => {
+        document.getElementById('activity').checked = true;
+        document.getElementById('scheduled').checked = false;
+
+        syncActivitiesUI(false);
+
+        expect(document.getElementById('activity-toggle-option').classList.contains('hidden')).toBe(
+            true
+        );
+        expect(document.getElementById('activities-container').classList.contains('hidden')).toBe(
+            true
+        );
+        expect(document.getElementById('activity').checked).toBe(false);
+        expect(document.getElementById('scheduled').checked).toBe(true);
+    });
+
+    test('renders today activities into the default list when enabled', () => {
+        const activities = [{ id: 'activity-1', description: 'Focus' }];
+        getTodaysActivities.mockReturnValue(activities);
+
+        renderTodayActivities(true);
+
+        expect(getTodaysActivities).toHaveBeenCalled();
+        expect(renderActivities).toHaveBeenCalledWith(
+            activities,
+            document.getElementById('activity-list')
+        );
+    });
+
+    test('does not render today activities when disabled', () => {
+        renderTodayActivities(false);
+
+        expect(getTodaysActivities).not.toHaveBeenCalled();
+        expect(renderActivities).not.toHaveBeenCalled();
+    });
+
+    test('submits activity forms through the activity flow', async () => {
+        const form = document.getElementById('task-form');
+        form.querySelector('input[value="scheduled"]').checked = false;
+        form.querySelector('input[value="activity"]').checked = true;
+        extractActivityFormData.mockReturnValue({
+            description: 'Pairing',
+            startDateTime: '2026-04-07T10:00:00.000Z',
+            endDateTime: '2026-04-07T11:00:00.000Z',
+            duration: 60,
+            source: 'manual'
+        });
+        const resetTaskFormPreviewStateMock = jest.fn();
+        const initializeTaskTypeToggleMock = jest.fn();
+        const focusTaskDescriptionInputMock = jest.fn();
+        const handleTaskSubmitMock = jest.fn();
+
+        await handleActivityAwareFormSubmit(form, {
+            activitiesEnabled: true,
+            resetTaskFormPreviewState: resetTaskFormPreviewStateMock,
+            initializeTaskTypeToggle: initializeTaskTypeToggleMock,
+            focusTaskDescriptionInput: focusTaskDescriptionInputMock,
+            handleTaskSubmit: handleTaskSubmitMock
+        });
+
+        expect(handleAddActivity).toHaveBeenCalledWith(
+            expect.objectContaining({ description: 'Pairing' })
+        );
+        expect(resetTaskFormPreviewStateMock).toHaveBeenCalled();
+        expect(initializeTaskTypeToggleMock).toHaveBeenCalled();
+        expect(focusTaskDescriptionInputMock).toHaveBeenCalled();
+        expect(handleTaskSubmitMock).not.toHaveBeenCalled();
+        expect(form.querySelector('input[value="activity"]').checked).toBe(true);
+    });
+
+    test('falls back to task submission for non-activity forms', async () => {
+        const form = document.getElementById('task-form');
+        const handleTaskSubmitMock = jest.fn();
+
+        await handleActivityAwareFormSubmit(form, {
+            activitiesEnabled: true,
+            resetTaskFormPreviewState: jest.fn(),
+            initializeTaskTypeToggle: jest.fn(),
+            focusTaskDescriptionInput: jest.fn(),
+            handleTaskSubmit: handleTaskSubmitMock
+        });
+
+        expect(handleTaskSubmitMock).toHaveBeenCalledWith(form);
+        expect(handleAddActivity).not.toHaveBeenCalled();
+    });
+
+    test('returns after focusing description when activity extraction fails', async () => {
+        const form = document.getElementById('task-form');
+        form.querySelector('input[value="scheduled"]').checked = false;
+        form.querySelector('input[value="activity"]').checked = true;
+        extractActivityFormData.mockReturnValue(null);
+        const focusTaskDescriptionInputMock = jest.fn();
+
+        await handleActivityAwareFormSubmit(form, {
+            activitiesEnabled: true,
+            resetTaskFormPreviewState: jest.fn(),
+            initializeTaskTypeToggle: jest.fn(),
+            focusTaskDescriptionInput: focusTaskDescriptionInputMock,
+            handleTaskSubmit: jest.fn()
+        });
+
+        expect(handleAddActivity).not.toHaveBeenCalled();
+        expect(focusTaskDescriptionInputMock).toHaveBeenCalled();
+    });
+
+    test('handles activity edit clicks and trims prompt output', async () => {
+        const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('  Updated  ');
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article data-activity-id="activity-1">
+                <span class="text-sm text-slate-200">Current</span>
+                <button class="btn-edit-activity"><span>Edit</span></button>
+            </article>
+        `;
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-edit-activity span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+
+        expect(handled).toBe(true);
+        expect(handleEditActivity).toHaveBeenCalledWith('activity-1', {
+            description: 'Updated'
+        });
+        promptSpy.mockRestore();
+    });
+
+    test('handles activity delete clicks', async () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article data-activity-id="activity-2">
+                <button class="btn-delete-activity"><span>Delete</span></button>
+            </article>
+        `;
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-delete-activity span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+
+        expect(handled).toBe(true);
+        expect(handleDeleteActivity).toHaveBeenCalledWith('activity-2');
+    });
+
+    test('clears confirming delete state for non-task non-activity clicks', async () => {
+        const refreshUIMock = jest.fn();
+        const resetAllConfirmingDeleteFlagsMock = jest.fn(() => true);
+        const outside = document.createElement('div');
+        document.body.appendChild(outside);
+
+        const handled = await handleActivityListClick(outside, {
+            refreshUI: refreshUIMock,
+            resetAllConfirmingDeleteFlags: resetAllConfirmingDeleteFlagsMock
+        });
+
+        expect(handled).toBe(false);
+        expect(resetAllConfirmingDeleteFlagsMock).toHaveBeenCalled();
+        expect(refreshUIMock).toHaveBeenCalled();
+    });
+});

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -212,9 +212,9 @@ describe('activity app integration', () => {
         showActivityEditModal.mockResolvedValue('  Updated  ');
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
-            <article data-activity-id="activity-1">
+            <article class="activity-item" data-activity-id="activity-1">
                 <span class="text-sm text-slate-200">Current</span>
-                <button class="btn-edit-activity"><span>Edit</span></button>
+                <button class="btn-edit-activity" data-activity-id="activity-1"><span>Edit</span></button>
             </article>
         `;
 
@@ -239,10 +239,32 @@ describe('activity app integration', () => {
         });
     });
 
+    test('activity edit resolves current description from the row when the button also has a data-activity-id', async () => {
+        showActivityEditModal.mockResolvedValue('Updated');
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article class="activity-item" data-activity-id="activity-11">
+                <span class="text-sm text-slate-200">Row description</span>
+                <button class="btn-edit-activity" data-activity-id="activity-11"><span>Edit</span></button>
+            </article>
+        `;
+
+        await handleActivityListClick(activityList.querySelector('.btn-edit-activity span'), {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(showActivityEditModal).toHaveBeenCalledWith('Row description');
+        expect(handleEditActivity).toHaveBeenCalledWith('activity-11', {
+            description: 'Updated'
+        });
+    });
+
     test('handles activity delete clicks', async () => {
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
-            <article data-activity-id="activity-2">
+            <article class="activity-item" data-activity-id="activity-2">
                 <button class="btn-delete-activity"><span>Delete</span></button>
             </article>
         `;
@@ -267,7 +289,7 @@ describe('activity app integration', () => {
         showActivityEditModal.mockResolvedValue('Updated after rerender');
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
-            <article data-activity-id="activity-9">
+            <article class="activity-item" data-activity-id="activity-9">
                 <span class="text-sm text-slate-200">Before rerender</span>
                 <button class="btn-edit-activity"><span>Edit</span></button>
                 <button class="btn-delete-activity"><span>Delete</span></button>
@@ -289,7 +311,7 @@ describe('activity app integration', () => {
         });
 
         activityList.innerHTML = `
-            <article data-activity-id="activity-10">
+            <article class="activity-item" data-activity-id="activity-10">
                 <button class="btn-delete-activity"><span>Delete</span></button>
             </article>
         `;
@@ -324,7 +346,7 @@ describe('activity app integration', () => {
     test('does not edit activity when modal result is null blank or unchanged', async () => {
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
-            <article data-activity-id="activity-3">
+            <article class="activity-item" data-activity-id="activity-3">
                 <span class="text-sm text-slate-200">Current</span>
                 <button class="btn-edit-activity"><span>Edit</span></button>
             </article>

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -9,7 +9,8 @@ jest.mock('../public/js/activities/form-utils.js', () => ({
 jest.mock('../public/js/activities/handlers.js', () => ({
     handleAddActivity: jest.fn(() => Promise.resolve({ success: true })),
     handleEditActivity: jest.fn(() => Promise.resolve()),
-    handleDeleteActivity: jest.fn(() => Promise.resolve())
+    handleDeleteActivity: jest.fn(() => Promise.resolve()),
+    handleSaveActivityEdit: jest.fn(() => Promise.resolve({ success: true }))
 }));
 
 jest.mock('../public/js/activities/manager.js', () => ({
@@ -20,29 +21,26 @@ jest.mock('../public/js/activities/renderer.js', () => ({
     renderActivities: jest.fn()
 }));
 
-jest.mock('../public/js/modal-manager.js', () => ({
-    showActivityEditModal: jest.fn(() => Promise.resolve(null))
-}));
-
 import {
     syncActivitiesUI,
     renderTodayActivities,
     handleActivityAwareFormSubmit,
-    handleActivityListClick
+    handleActivityListClick,
+    resetActivityInlineEditState
 } from '../public/js/activities/ui-handlers.js';
 import { extractActivityFormData } from '../public/js/activities/form-utils.js';
 import {
     handleAddActivity,
-    handleEditActivity,
-    handleDeleteActivity
+    handleDeleteActivity,
+    handleSaveActivityEdit
 } from '../public/js/activities/handlers.js';
 import { getTodaysActivities } from '../public/js/activities/manager.js';
 import { renderActivities } from '../public/js/activities/renderer.js';
-import { showActivityEditModal } from '../public/js/modal-manager.js';
 
 describe('activity app integration', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        resetActivityInlineEditState();
         document.body.innerHTML = `
             <div id="activity-toggle-option" class="hidden"></div>
             <div id="activities-container" class="hidden"></div>
@@ -97,7 +95,8 @@ describe('activity app integration', () => {
         expect(getTodaysActivities).toHaveBeenCalled();
         expect(renderActivities).toHaveBeenCalledWith(
             activities,
-            document.getElementById('activity-list')
+            document.getElementById('activity-list'),
+            expect.objectContaining({ editingActivityId: null })
         );
     });
 
@@ -208,8 +207,7 @@ describe('activity app integration', () => {
         expect(focusTaskDescriptionInputMock).toHaveBeenCalled();
     });
 
-    test('handles activity edit clicks through the edit modal result', async () => {
-        showActivityEditModal.mockResolvedValue('  Updated  ');
+    test('clicking activity edit enters inline edit mode for that row', async () => {
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
             <article class="activity-item" data-activity-id="activity-1">
@@ -217,6 +215,7 @@ describe('activity app integration', () => {
                 <button class="btn-edit-activity" data-activity-id="activity-1"><span>Edit</span></button>
             </article>
         `;
+        getTodaysActivities.mockReturnValue([{ id: 'activity-1', description: 'Current' }]);
 
         const refreshUIMock = jest.fn();
         const resetAllConfirmingDeleteFlagsMock = jest.fn(() => true);
@@ -228,24 +227,56 @@ describe('activity app integration', () => {
                 resetAllConfirmingDeleteFlags: resetAllConfirmingDeleteFlagsMock
             }
         );
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        renderTodayActivities(true);
 
         expect(handled).toBe(true);
         expect(resetAllConfirmingDeleteFlagsMock).toHaveBeenCalled();
         expect(refreshUIMock).toHaveBeenCalled();
-        expect(showActivityEditModal).toHaveBeenCalledWith('Current');
-        expect(handleEditActivity).toHaveBeenCalledWith('activity-1', {
-            description: 'Updated'
-        });
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            [{ id: 'activity-1', description: 'Current' }],
+            document.getElementById('activity-list'),
+            expect.objectContaining({ editingActivityId: 'activity-1' })
+        );
     });
 
-    test('activity edit resolves current description from the row when the button also has a data-activity-id', async () => {
-        showActivityEditModal.mockResolvedValue('Updated');
+    test('saving inline activity edits delegates the form to the activity edit handler', async () => {
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
-            <article class="activity-item" data-activity-id="activity-11">
-                <span class="text-sm text-slate-200">Row description</span>
-                <button class="btn-edit-activity" data-activity-id="activity-11"><span>Edit</span></button>
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <input name="duration-hours" value="1" />
+                <input name="duration-minutes" value="15" />
+                <select name="category"><option value="work/deep" selected>Deep Work</option></select>
+                <button class="btn-save-activity-edit" type="button"><span>Save</span></button>
+            </form>
+        `;
+        const refreshUIMock = jest.fn();
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-save-activity-edit span'),
+            {
+                refreshUI: refreshUIMock,
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(handled).toBe(true);
+        expect(handleSaveActivityEdit).toHaveBeenCalledWith(
+            'activity-11',
+            activityList.querySelector('form')
+        );
+        expect(refreshUIMock).toHaveBeenCalled();
+    });
+
+    test('canceling inline activity edit clears the inline edit state', async () => {
+        getTodaysActivities.mockReturnValue([{ id: 'activity-12', description: 'Current' }]);
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article class="activity-item" data-activity-id="activity-12">
+                <span class="text-sm text-slate-200">Current</span>
+                <button class="btn-edit-activity"><span>Edit</span></button>
             </article>
         `;
 
@@ -253,12 +284,71 @@ describe('activity app integration', () => {
             refreshUI: jest.fn(),
             resetAllConfirmingDeleteFlags: jest.fn()
         });
-        await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(showActivityEditModal).toHaveBeenCalledWith('Row description');
-        expect(handleEditActivity).toHaveBeenCalledWith('activity-11', {
-            description: 'Updated'
-        });
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-12" data-activity-date="2026-04-07">
+                <button class="btn-cancel-activity-edit" type="button"><span>Cancel</span></button>
+            </form>
+        `;
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-cancel-activity-edit span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
+
+        expect(handled).toBe(true);
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            [{ id: 'activity-12', description: 'Current' }],
+            document.getElementById('activity-list'),
+            expect.objectContaining({ editingActivityId: null })
+        );
+    });
+
+    test('handles auto activity edit clicks while preserving provenance in the ui path', async () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article class="activity-item" data-activity-id="activity-auto-1">
+                <span class="text-sm text-slate-200">Auto activity</span>
+                <span class="activity-source-link" data-source-task-id="sched-1">auto</span>
+                <button class="btn-edit-activity" data-activity-id="activity-auto-1"><span>Edit</span></button>
+                <button class="btn-delete-activity" data-activity-id="activity-auto-1"><span>Delete</span></button>
+            </article>
+        `;
+        getTodaysActivities.mockReturnValue([
+            {
+                id: 'activity-auto-1',
+                description: 'Auto activity',
+                source: 'auto',
+                sourceTaskId: 'sched-1'
+            }
+        ]);
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-edit-activity span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
+
+        expect(handled).toBe(true);
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            [
+                {
+                    id: 'activity-auto-1',
+                    description: 'Auto activity',
+                    source: 'auto',
+                    sourceTaskId: 'sched-1'
+                }
+            ],
+            document.getElementById('activity-list'),
+            expect.objectContaining({ editingActivityId: 'activity-auto-1' })
+        );
     });
 
     test('handles activity delete clicks', async () => {
@@ -285,8 +375,7 @@ describe('activity app integration', () => {
         expect(handleDeleteActivity).toHaveBeenCalledWith('activity-2');
     });
 
-    test('activity actions still resolve ids and descriptions when refresh rerenders the list', async () => {
-        showActivityEditModal.mockResolvedValue('Updated after rerender');
+    test('activity actions still resolve ids when refresh rerenders the list', async () => {
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
             <article class="activity-item" data-activity-id="activity-9">
@@ -303,12 +392,8 @@ describe('activity app integration', () => {
             refreshUI: rerenderingRefreshMock,
             resetAllConfirmingDeleteFlags: jest.fn(() => true)
         });
-        await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(showActivityEditModal).toHaveBeenCalledWith('Before rerender');
-        expect(handleEditActivity).toHaveBeenCalledWith('activity-9', {
-            description: 'Updated after rerender'
-        });
+        expect(rerenderingRefreshMock).toHaveBeenCalled();
 
         activityList.innerHTML = `
             <article class="activity-item" data-activity-id="activity-10">
@@ -343,37 +428,49 @@ describe('activity app integration', () => {
         expect(refreshUIMock).toHaveBeenCalled();
     });
 
-    test('does not edit activity when modal result is null blank or unchanged', async () => {
+    test('save failure keeps the activity row in inline edit mode', async () => {
+        handleSaveActivityEdit.mockResolvedValue({
+            success: false,
+            reason: 'Could not update activity.'
+        });
+        getTodaysActivities.mockReturnValue([{ id: 'activity-3', description: 'Current' }]);
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `
             <article class="activity-item" data-activity-id="activity-3">
-                <span class="text-sm text-slate-200">Current</span>
-                <button class="btn-edit-activity"><span>Edit</span></button>
+                <button class="btn-edit-activity" type="button"><span>Edit</span></button>
             </article>
         `;
-        const target = activityList.querySelector('.btn-edit-activity span');
 
-        showActivityEditModal.mockResolvedValueOnce(null);
-        await handleActivityListClick(target, {
+        await handleActivityListClick(activityList.querySelector('.btn-edit-activity span'), {
             refreshUI: jest.fn(),
             resetAllConfirmingDeleteFlags: jest.fn()
         });
-        await new Promise((resolve) => setTimeout(resolve, 0));
 
-        showActivityEditModal.mockResolvedValueOnce('   ');
-        await handleActivityListClick(target, {
-            refreshUI: jest.fn(),
-            resetAllConfirmingDeleteFlags: jest.fn()
-        });
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-3" data-activity-date="2026-04-07">
+                <input name="description" value="Current" />
+                <input name="start-time" value="09:00" />
+                <input name="duration-hours" value="1" />
+                <input name="duration-minutes" value="0" />
+                <select name="category"></select>
+                <button class="btn-save-activity-edit" type="button"><span>Save</span></button>
+            </form>
+        `;
 
-        showActivityEditModal.mockResolvedValueOnce('Current');
-        await handleActivityListClick(target, {
-            refreshUI: jest.fn(),
-            resetAllConfirmingDeleteFlags: jest.fn()
-        });
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-save-activity-edit span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
 
-        expect(handleEditActivity).not.toHaveBeenCalled();
+        expect(handled).toBe(true);
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            [{ id: 'activity-3', description: 'Current' }],
+            document.getElementById('activity-list'),
+            expect.objectContaining({ editingActivityId: 'activity-3' })
+        );
     });
 });

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -7,7 +7,7 @@ jest.mock('../public/js/activities/form-utils.js', () => ({
 }));
 
 jest.mock('../public/js/activities/handlers.js', () => ({
-    handleAddActivity: jest.fn(() => Promise.resolve()),
+    handleAddActivity: jest.fn(() => Promise.resolve({ success: true })),
     handleEditActivity: jest.fn(() => Promise.resolve()),
     handleDeleteActivity: jest.fn(() => Promise.resolve())
 }));
@@ -142,6 +142,37 @@ describe('activity app integration', () => {
         expect(form.querySelector('input[value="activity"]').checked).toBe(true);
     });
 
+    test('preserves activity form input when activity save fails', async () => {
+        const form = document.getElementById('task-form');
+        const descriptionInput = form.querySelector('input[name="description"]');
+        form.querySelector('input[value="scheduled"]').checked = false;
+        form.querySelector('input[value="activity"]').checked = true;
+        descriptionInput.value = 'Pairing';
+        extractActivityFormData.mockReturnValue({
+            description: 'Pairing',
+            startDateTime: '2026-04-07T10:00:00.000Z',
+            endDateTime: '2026-04-07T11:00:00.000Z',
+            duration: 60,
+            source: 'manual'
+        });
+        handleAddActivity.mockResolvedValue({ success: false, reason: 'Could not log activity.' });
+        const resetTaskFormPreviewStateMock = jest.fn();
+        const initializeTaskTypeToggleMock = jest.fn();
+        const focusTaskDescriptionInputMock = jest.fn();
+
+        await handleActivityAwareFormSubmit(form, {
+            activitiesEnabled: true,
+            resetTaskFormPreviewState: resetTaskFormPreviewStateMock,
+            initializeTaskTypeToggle: initializeTaskTypeToggleMock,
+            focusTaskDescriptionInput: focusTaskDescriptionInputMock,
+            handleTaskSubmit: jest.fn()
+        });
+
+        expect(descriptionInput.value).toBe('Pairing');
+        expect(resetTaskFormPreviewStateMock).not.toHaveBeenCalled();
+        expect(initializeTaskTypeToggleMock).not.toHaveBeenCalled();
+    });
+
     test('falls back to task submission for non-activity forms', async () => {
         const form = document.getElementById('task-form');
         const handleTaskSubmitMock = jest.fn();
@@ -187,16 +218,21 @@ describe('activity app integration', () => {
             </article>
         `;
 
+        const refreshUIMock = jest.fn();
+        const resetAllConfirmingDeleteFlagsMock = jest.fn(() => true);
+
         const handled = await handleActivityListClick(
             activityList.querySelector('.btn-edit-activity span'),
             {
-                refreshUI: jest.fn(),
-                resetAllConfirmingDeleteFlags: jest.fn()
+                refreshUI: refreshUIMock,
+                resetAllConfirmingDeleteFlags: resetAllConfirmingDeleteFlagsMock
             }
         );
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(handled).toBe(true);
+        expect(resetAllConfirmingDeleteFlagsMock).toHaveBeenCalled();
+        expect(refreshUIMock).toHaveBeenCalled();
         expect(showActivityEditModal).toHaveBeenCalledWith('Current');
         expect(handleEditActivity).toHaveBeenCalledWith('activity-1', {
             description: 'Updated'
@@ -210,17 +246,63 @@ describe('activity app integration', () => {
                 <button class="btn-delete-activity"><span>Delete</span></button>
             </article>
         `;
+        const refreshUIMock = jest.fn();
+        const resetAllConfirmingDeleteFlagsMock = jest.fn(() => true);
 
         const handled = await handleActivityListClick(
             activityList.querySelector('.btn-delete-activity span'),
             {
-                refreshUI: jest.fn(),
-                resetAllConfirmingDeleteFlags: jest.fn()
+                refreshUI: refreshUIMock,
+                resetAllConfirmingDeleteFlags: resetAllConfirmingDeleteFlagsMock
             }
         );
 
         expect(handled).toBe(true);
+        expect(resetAllConfirmingDeleteFlagsMock).toHaveBeenCalled();
+        expect(refreshUIMock).toHaveBeenCalled();
         expect(handleDeleteActivity).toHaveBeenCalledWith('activity-2');
+    });
+
+    test('activity actions still resolve ids and descriptions when refresh rerenders the list', async () => {
+        showActivityEditModal.mockResolvedValue('Updated after rerender');
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article data-activity-id="activity-9">
+                <span class="text-sm text-slate-200">Before rerender</span>
+                <button class="btn-edit-activity"><span>Edit</span></button>
+                <button class="btn-delete-activity"><span>Delete</span></button>
+            </article>
+        `;
+        const rerenderingRefreshMock = jest.fn(() => {
+            activityList.innerHTML = '<div>rerendered</div>';
+        });
+
+        await handleActivityListClick(activityList.querySelector('.btn-edit-activity span'), {
+            refreshUI: rerenderingRefreshMock,
+            resetAllConfirmingDeleteFlags: jest.fn(() => true)
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(showActivityEditModal).toHaveBeenCalledWith('Before rerender');
+        expect(handleEditActivity).toHaveBeenCalledWith('activity-9', {
+            description: 'Updated after rerender'
+        });
+
+        activityList.innerHTML = `
+            <article data-activity-id="activity-10">
+                <button class="btn-delete-activity"><span>Delete</span></button>
+            </article>
+        `;
+        const deleteRefreshMock = jest.fn(() => {
+            activityList.innerHTML = '<div>rerendered again</div>';
+        });
+
+        await handleActivityListClick(activityList.querySelector('.btn-delete-activity span'), {
+            refreshUI: deleteRefreshMock,
+            resetAllConfirmingDeleteFlags: jest.fn(() => true)
+        });
+
+        expect(handleDeleteActivity).toHaveBeenCalledWith('activity-10');
     });
 
     test('clears confirming delete state for non-task non-activity clicks', async () => {

--- a/__tests__/activity-form-utils.test.js
+++ b/__tests__/activity-form-utils.test.js
@@ -10,7 +10,10 @@ jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
     resolveCategoryKey: jest.fn()
 }));
 
-import { extractActivityFormData } from '../public/js/activities/form-utils.js';
+import {
+    extractActivityFormData,
+    extractActivityEditFormData
+} from '../public/js/activities/form-utils.js';
 import { showAlert } from '../public/js/modal-manager.js';
 import { resolveCategoryKey } from '../public/js/taxonomy/taxonomy-selectors.js';
 import { calculateEndDateTime, timeToDateTime } from '../public/js/utils.js';
@@ -116,5 +119,30 @@ describe('activity form utils', () => {
 
         expect(result).toBeNull();
         expect(showAlert).toHaveBeenCalledWith('Selected category is no longer available.', 'sky');
+    });
+
+    test('extracts inline activity edit form data using the activity date instead of today', () => {
+        const form = createActivityForm({
+            description: 'Edited deep work',
+            startTime: '13:15',
+            durationHours: '1',
+            durationMinutes: '30',
+            category: 'work/deep'
+        });
+        form.dataset.activityDate = '2026-04-05';
+        resolveCategoryKey.mockReturnValue({
+            kind: 'category',
+            record: { key: 'work/deep', color: '#0ea5e9' }
+        });
+
+        const result = extractActivityEditFormData(form);
+
+        expect(result).toEqual({
+            description: 'Edited deep work',
+            category: 'work/deep',
+            startDateTime: timeToDateTime('13:15', '2026-04-05'),
+            endDateTime: calculateEndDateTime(timeToDateTime('13:15', '2026-04-05'), 90),
+            duration: 90
+        });
     });
 });

--- a/__tests__/activity-form-utils.test.js
+++ b/__tests__/activity-form-utils.test.js
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn()
+}));
+
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    resolveCategoryKey: jest.fn()
+}));
+
+import { extractActivityFormData } from '../public/js/activities/form-utils.js';
+import { showAlert } from '../public/js/modal-manager.js';
+import { resolveCategoryKey } from '../public/js/taxonomy/taxonomy-selectors.js';
+import { calculateEndDateTime, timeToDateTime } from '../public/js/utils.js';
+
+function createActivityForm({
+    description = 'Deep work',
+    startTime = '09:00',
+    durationHours = '1',
+    durationMinutes = '0',
+    category = ''
+} = {}) {
+    document.body.innerHTML = `
+        <form id="task-form">
+            <input type="text" name="description" value="${description}" />
+            <input type="radio" name="task-type" value="activity" checked />
+            <input type="time" name="start-time" value="${startTime}" />
+            <input type="number" name="duration-hours" value="${durationHours}" />
+            <input type="number" name="duration-minutes" value="${durationMinutes}" />
+            <select name="category">
+                <option value="">No category</option>
+                <option value="work/deep" ${category === 'work/deep' ? 'selected' : ''}>Deep Work</option>
+            </select>
+        </form>
+    `;
+
+    return document.getElementById('task-form');
+}
+
+describe('activity form utils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-07T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    test('extracts activity form data correctly', () => {
+        const form = createActivityForm();
+        const expectedStart = timeToDateTime('09:00', '2026-04-07');
+        const expectedEnd = calculateEndDateTime(expectedStart, 60);
+
+        const result = extractActivityFormData(form);
+
+        expect(result).toEqual({
+            description: 'Deep work',
+            category: null,
+            startDateTime: expectedStart,
+            endDateTime: expectedEnd,
+            duration: 60,
+            source: 'manual',
+            sourceTaskId: null
+        });
+    });
+
+    test('includes category when selected', () => {
+        resolveCategoryKey.mockReturnValue({
+            kind: 'category',
+            record: { key: 'work/deep', color: '#0ea5e9' }
+        });
+        const form = createActivityForm({ category: 'work/deep' });
+
+        const result = extractActivityFormData(form);
+
+        expect(result.category).toBe('work/deep');
+    });
+
+    test('rejects empty description', () => {
+        const form = createActivityForm({ description: '' });
+
+        const result = extractActivityFormData(form);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith('Activity description cannot be empty.', 'sky');
+    });
+
+    test('rejects missing start time', () => {
+        const form = createActivityForm({ startTime: '' });
+
+        const result = extractActivityFormData(form);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith('Start time is required for activities.', 'sky');
+    });
+
+    test('rejects zero duration', () => {
+        const form = createActivityForm({ durationHours: '0', durationMinutes: '0' });
+
+        const result = extractActivityFormData(form);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith('Duration must be greater than 0.', 'sky');
+    });
+
+    test('rejects stale category keys', () => {
+        resolveCategoryKey.mockReturnValue(null);
+        const form = createActivityForm({ category: 'work/deep' });
+
+        const result = extractActivityFormData(form);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith('Selected category is no longer available.', 'sky');
+    });
+});

--- a/__tests__/activity-handlers.test.js
+++ b/__tests__/activity-handlers.test.js
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/activities/manager.js', () => ({
+    addActivity: jest.fn(),
+    editActivity: jest.fn(),
+    removeActivity: jest.fn()
+}));
+
+jest.mock('../public/js/app-coordinator.js', () => ({
+    onActivityCreated: jest.fn(),
+    onActivityEdited: jest.fn(),
+    onActivityDeleted: jest.fn()
+}));
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn()
+}));
+
+jest.mock('../public/js/toast-manager.js', () => ({
+    showToast: jest.fn()
+}));
+
+import {
+    handleAddActivity,
+    handleEditActivity,
+    handleDeleteActivity,
+    handleSaveActivityEdit,
+    createActivityCallbacks
+} from '../public/js/activities/handlers.js';
+import { addActivity, editActivity, removeActivity } from '../public/js/activities/manager.js';
+import {
+    onActivityCreated,
+    onActivityEdited,
+    onActivityDeleted
+} from '../public/js/app-coordinator.js';
+import { showAlert } from '../public/js/modal-manager.js';
+import { showToast } from '../public/js/toast-manager.js';
+
+describe('activity handlers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('handleAddActivity routes success through coordinator and toast', async () => {
+        addActivity.mockResolvedValue({
+            success: true,
+            activity: { id: 'activity-1', description: 'Deep work' }
+        });
+
+        await handleAddActivity({
+            description: 'Deep work',
+            startDateTime: '2026-04-07T09:00:00.000Z',
+            endDateTime: '2026-04-07T10:00:00.000Z',
+            duration: 60,
+            category: null,
+            source: 'manual',
+            sourceTaskId: null
+        });
+
+        expect(onActivityCreated).toHaveBeenCalledWith({
+            activity: { id: 'activity-1', description: 'Deep work' }
+        });
+        expect(showToast).toHaveBeenCalledWith('Activity logged.', { theme: 'sky' });
+    });
+
+    test('handleAddActivity shows alert on failure', async () => {
+        addActivity.mockResolvedValue({
+            success: false,
+            reason: 'Activity description is required.'
+        });
+
+        await handleAddActivity({});
+
+        expect(showAlert).toHaveBeenCalledWith('Activity description is required.', 'sky');
+        expect(onActivityCreated).not.toHaveBeenCalled();
+    });
+
+    test('handleAddActivity returns early when payload resolves to null', async () => {
+        await handleAddActivity(null);
+
+        expect(addActivity).not.toHaveBeenCalled();
+        expect(showAlert).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    test('handleEditActivity routes success through coordinator and toast', async () => {
+        editActivity.mockResolvedValue({
+            success: true,
+            activity: { id: 'activity-1', description: 'Updated work' }
+        });
+
+        await handleEditActivity('activity-1', { description: 'Updated work' });
+
+        expect(editActivity).toHaveBeenCalledWith('activity-1', { description: 'Updated work' });
+        expect(onActivityEdited).toHaveBeenCalledWith({
+            activity: { id: 'activity-1', description: 'Updated work' }
+        });
+        expect(showToast).toHaveBeenCalledWith('Activity updated.', { theme: 'sky' });
+    });
+
+    test('handleEditActivity shows fallback alert message on failure without reason', async () => {
+        editActivity.mockResolvedValue({
+            success: false
+        });
+
+        await handleEditActivity('activity-1', { description: 'Updated work' });
+
+        expect(showAlert).toHaveBeenCalledWith('Could not update activity.', 'sky');
+        expect(onActivityEdited).not.toHaveBeenCalled();
+    });
+
+    test('handleSaveActivityEdit proxies to edit flow', async () => {
+        editActivity.mockResolvedValue({
+            success: true,
+            activity: { id: 'activity-1', description: 'Updated work' }
+        });
+
+        await handleSaveActivityEdit('activity-1', { description: 'Updated work' });
+
+        expect(editActivity).toHaveBeenCalledWith(
+            'activity-1',
+            expect.objectContaining({ description: 'Updated work' })
+        );
+    });
+
+    test('handleDeleteActivity routes success through coordinator and toast', async () => {
+        removeActivity.mockResolvedValue({
+            success: true,
+            activity: { id: 'activity-1', description: 'Deep work' }
+        });
+
+        await handleDeleteActivity('activity-1');
+
+        expect(removeActivity).toHaveBeenCalledWith('activity-1');
+        expect(onActivityDeleted).toHaveBeenCalledWith({
+            activity: { id: 'activity-1', description: 'Deep work' }
+        });
+        expect(showToast).toHaveBeenCalledWith('Activity deleted.', { theme: 'sky' });
+    });
+
+    test('handleDeleteActivity shows fallback alert message on failure without reason', async () => {
+        removeActivity.mockResolvedValue({
+            success: false
+        });
+
+        await handleDeleteActivity('activity-1');
+
+        expect(showAlert).toHaveBeenCalledWith('Could not delete activity.', 'sky');
+        expect(onActivityDeleted).not.toHaveBeenCalled();
+    });
+
+    test('createActivityCallbacks exposes handler references', () => {
+        expect(createActivityCallbacks()).toEqual({
+            onAddActivity: handleAddActivity,
+            onEditActivity: handleEditActivity,
+            onDeleteActivity: handleDeleteActivity,
+            onSaveActivityEdit: handleSaveActivityEdit
+        });
+    });
+});

--- a/__tests__/activity-handlers.test.js
+++ b/__tests__/activity-handlers.test.js
@@ -49,14 +49,19 @@ describe('activity handlers', () => {
             activity: { id: 'activity-1', description: 'Deep work' }
         });
 
-        await handleAddActivity({
-            description: 'Deep work',
-            startDateTime: '2026-04-07T09:00:00.000Z',
-            endDateTime: '2026-04-07T10:00:00.000Z',
-            duration: 60,
-            category: null,
-            source: 'manual',
-            sourceTaskId: null
+        await expect(
+            handleAddActivity({
+                description: 'Deep work',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                category: null,
+                source: 'manual',
+                sourceTaskId: null
+            })
+        ).resolves.toEqual({
+            success: true,
+            activity: { id: 'activity-1', description: 'Deep work' }
         });
 
         expect(onActivityCreated).toHaveBeenCalledWith({
@@ -65,20 +70,43 @@ describe('activity handlers', () => {
         expect(showToast).toHaveBeenCalledWith('Activity logged.', { theme: 'sky' });
     });
 
-    test('handleAddActivity shows alert on failure', async () => {
+    test('handleAddActivity shows alert on validation failure and returns it', async () => {
         addActivity.mockResolvedValue({
             success: false,
             reason: 'Activity description is required.'
         });
 
-        await handleAddActivity({});
+        await expect(handleAddActivity({})).resolves.toEqual({
+            success: false,
+            reason: 'Activity description is required.'
+        });
 
         expect(showAlert).toHaveBeenCalledWith('Activity description is required.', 'sky');
         expect(onActivityCreated).not.toHaveBeenCalled();
     });
 
+    test('handleAddActivity catches storage rejections and returns fallback failure', async () => {
+        addActivity.mockRejectedValue(new Error('disk full'));
+
+        await expect(
+            handleAddActivity({
+                description: 'Deep work',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60
+            })
+        ).resolves.toEqual({
+            success: false,
+            reason: 'Could not log activity.'
+        });
+
+        expect(showAlert).toHaveBeenCalledWith('Could not log activity.', 'sky');
+        expect(onActivityCreated).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
     test('handleAddActivity returns early when payload resolves to null', async () => {
-        await handleAddActivity(null);
+        await expect(handleAddActivity(null)).resolves.toBeUndefined();
 
         expect(addActivity).not.toHaveBeenCalled();
         expect(showAlert).not.toHaveBeenCalled();
@@ -91,7 +119,12 @@ describe('activity handlers', () => {
             activity: { id: 'activity-1', description: 'Updated work' }
         });
 
-        await handleEditActivity('activity-1', { description: 'Updated work' });
+        await expect(
+            handleEditActivity('activity-1', { description: 'Updated work' })
+        ).resolves.toEqual({
+            success: true,
+            activity: { id: 'activity-1', description: 'Updated work' }
+        });
 
         expect(editActivity).toHaveBeenCalledWith('activity-1', { description: 'Updated work' });
         expect(onActivityEdited).toHaveBeenCalledWith({
@@ -105,10 +138,30 @@ describe('activity handlers', () => {
             success: false
         });
 
-        await handleEditActivity('activity-1', { description: 'Updated work' });
+        await expect(
+            handleEditActivity('activity-1', { description: 'Updated work' })
+        ).resolves.toEqual({
+            success: false,
+            reason: 'Could not update activity.'
+        });
 
         expect(showAlert).toHaveBeenCalledWith('Could not update activity.', 'sky');
         expect(onActivityEdited).not.toHaveBeenCalled();
+    });
+
+    test('handleEditActivity catches storage rejections and returns fallback failure', async () => {
+        editActivity.mockRejectedValue(new Error('write failed'));
+
+        await expect(
+            handleEditActivity('activity-1', { description: 'Updated work' })
+        ).resolves.toEqual({
+            success: false,
+            reason: 'Could not update activity.'
+        });
+
+        expect(showAlert).toHaveBeenCalledWith('Could not update activity.', 'sky');
+        expect(onActivityEdited).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
     });
 
     test('handleSaveActivityEdit proxies to edit flow', async () => {
@@ -131,7 +184,10 @@ describe('activity handlers', () => {
             activity: { id: 'activity-1', description: 'Deep work' }
         });
 
-        await handleDeleteActivity('activity-1');
+        await expect(handleDeleteActivity('activity-1')).resolves.toEqual({
+            success: true,
+            activity: { id: 'activity-1', description: 'Deep work' }
+        });
 
         expect(removeActivity).toHaveBeenCalledWith('activity-1');
         expect(onActivityDeleted).toHaveBeenCalledWith({
@@ -145,10 +201,26 @@ describe('activity handlers', () => {
             success: false
         });
 
-        await handleDeleteActivity('activity-1');
+        await expect(handleDeleteActivity('activity-1')).resolves.toEqual({
+            success: false,
+            reason: 'Could not delete activity.'
+        });
 
         expect(showAlert).toHaveBeenCalledWith('Could not delete activity.', 'sky');
         expect(onActivityDeleted).not.toHaveBeenCalled();
+    });
+
+    test('handleDeleteActivity catches storage rejections and returns fallback failure', async () => {
+        removeActivity.mockRejectedValue(new Error('delete failed'));
+
+        await expect(handleDeleteActivity('activity-1')).resolves.toEqual({
+            success: false,
+            reason: 'Could not delete activity.'
+        });
+
+        expect(showAlert).toHaveBeenCalledWith('Could not delete activity.', 'sky');
+        expect(onActivityDeleted).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
     });
 
     test('createActivityCallbacks exposes handler references', () => {

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -1,0 +1,369 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/storage.js', () => ({
+    putActivity: jest.fn(() => Promise.resolve()),
+    loadActivities: jest.fn(() => Promise.resolve([])),
+    deleteActivity: jest.fn(() => Promise.resolve())
+}));
+
+import {
+    addActivity,
+    getActivityState,
+    getActivityById,
+    getTodaysActivities,
+    loadActivitiesState,
+    loadActivityState,
+    removeActivity,
+    editActivity,
+    updateActivity,
+    deleteActivity as deleteActivityAlias,
+    resetActivityState,
+    updateActivityState,
+    createActivityFromTask
+} from '../public/js/activities/manager.js';
+import { putActivity, loadActivities, deleteActivity } from '../public/js/storage.js';
+
+describe('activity manager', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+    });
+
+    describe('addActivity', () => {
+        test('creates activity with generated id and stores it', async () => {
+            const result = await addActivity({
+                description: 'Deep work session',
+                category: 'work/deep',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.activity.id).toMatch(/^activity-/);
+            expect(result.activity.description).toBe('Deep work session');
+            expect(result.activity.docType).toBe('activity');
+            expect(putActivity).toHaveBeenCalledWith(result.activity);
+            expect(getActivityState()).toContainEqual(result.activity);
+        });
+
+        test('rejects activity with empty description', async () => {
+            const result = await addActivity({
+                description: '',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/description/i);
+            expect(putActivity).not.toHaveBeenCalled();
+        });
+
+        test('rejects activity with zero duration', async () => {
+            const result = await addActivity({
+                description: 'Test',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:00:00.000Z',
+                duration: 0,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/duration/i);
+        });
+
+        test('rejects activity with missing times', async () => {
+            const result = await addActivity({
+                description: 'Test',
+                duration: 30,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/start and end/i);
+        });
+    });
+
+    describe('getActivityById', () => {
+        test('returns activity when found', async () => {
+            const { activity } = await addActivity({
+                description: 'Test',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            expect(getActivityById(activity.id)).toEqual(activity);
+        });
+
+        test('returns null when not found', () => {
+            expect(getActivityById('activity-missing')).toBeNull();
+        });
+    });
+
+    describe('getTodaysActivities', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-07T12:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('returns only activities from today sorted by start time', async () => {
+            await addActivity({
+                description: 'Yesterday',
+                startDateTime: '2026-04-06T09:00:00.000Z',
+                endDateTime: '2026-04-06T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+            await addActivity({
+                description: 'Today later',
+                startDateTime: '2026-04-07T14:00:00.000Z',
+                endDateTime: '2026-04-07T15:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+            await addActivity({
+                description: 'Today earlier',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const todays = getTodaysActivities();
+
+            expect(todays).toHaveLength(2);
+            expect(todays[0].description).toBe('Today earlier');
+            expect(todays[1].description).toBe('Today later');
+        });
+    });
+
+    describe('removeActivity', () => {
+        test('removes activity from state and storage', async () => {
+            const { activity } = await addActivity({
+                description: 'To remove',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await removeActivity(activity.id);
+
+            expect(result.success).toBe(true);
+            expect(deleteActivity).toHaveBeenCalledWith(activity.id);
+            expect(getActivityById(activity.id)).toBeNull();
+        });
+
+        test('returns failure for nonexistent activity', async () => {
+            const result = await removeActivity('activity-fake');
+
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe('editActivity', () => {
+        test('updates editable fields and persists', async () => {
+            const { activity } = await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await editActivity(activity.id, {
+                description: 'Updated',
+                duration: 90,
+                endDateTime: '2026-04-07T10:30:00.000Z'
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.activity.description).toBe('Updated');
+            expect(result.activity.duration).toBe(90);
+            expect(putActivity).toHaveBeenCalledWith(result.activity);
+        });
+
+        test('rejects edit of auto-logged activity', async () => {
+            const { activity } = await addActivity({
+                description: 'Auto',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'auto',
+                sourceTaskId: 'sched-123'
+            });
+
+            const result = await editActivity(activity.id, { description: 'Changed' });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/auto/i);
+        });
+
+        test('rejects edit when trimmed description becomes empty', async () => {
+            const { activity } = await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await editActivity(activity.id, { description: '   ' });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/description/i);
+        });
+    });
+
+    describe('loadActivitiesState', () => {
+        test('populates state from storage', async () => {
+            loadActivities.mockResolvedValueOnce([
+                {
+                    id: 'activity-1',
+                    docType: 'activity',
+                    description: 'Stored',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ]);
+
+            await loadActivitiesState();
+
+            expect(getActivityState()).toHaveLength(1);
+            expect(getActivityState()[0].description).toBe('Stored');
+        });
+
+        test('falls back to empty state when loader is not a function', async () => {
+            updateActivityState([
+                {
+                    id: 'activity-1',
+                    description: 'Stored',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60
+                }
+            ]);
+
+            const result = await loadActivitiesState(null);
+
+            expect(result).toEqual([]);
+            expect(getActivityState()).toEqual([]);
+        });
+
+        test('normalizes non-array storage responses to empty state', async () => {
+            const result = await loadActivitiesState(async () => null);
+
+            expect(result).toEqual([]);
+            expect(getActivityState()).toEqual([]);
+        });
+
+        test('loadActivityState aliases loadActivitiesState', async () => {
+            const result = await loadActivityState(async () => [
+                {
+                    id: 'activity-1',
+                    description: 'Stored',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60
+                }
+            ]);
+
+            expect(result).toHaveLength(1);
+            expect(getActivityState()[0].id).toBe('activity-1');
+        });
+    });
+
+    describe('aliases', () => {
+        test('updateActivity proxies to editActivity', async () => {
+            const { activity } = await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await updateActivity(activity.id, { description: 'Updated' });
+
+            expect(result.success).toBe(true);
+            expect(result.activity.description).toBe('Updated');
+        });
+
+        test('deleteActivity proxies to removeActivity', async () => {
+            const { activity } = await addActivity({
+                description: 'To remove',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await deleteActivityAlias(activity.id);
+
+            expect(result.success).toBe(true);
+            expect(getActivityById(activity.id)).toBeNull();
+        });
+    });
+
+    describe('createActivityFromTask', () => {
+        test('maps a scheduled task into auto activity data', () => {
+            const activity = createActivityFromTask({
+                id: 'sched-1',
+                description: 'Standup',
+                category: 'work/meetings',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:30:00.000Z',
+                duration: 30
+            });
+
+            expect(activity).toEqual({
+                description: 'Standup',
+                category: 'work/meetings',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:30:00.000Z',
+                duration: 30,
+                source: 'auto',
+                sourceTaskId: 'sched-1'
+            });
+        });
+
+        test('defaults missing category and id to null', () => {
+            const activity = createActivityFromTask({
+                description: 'Standup',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:30:00.000Z',
+                duration: 30
+            });
+
+            expect(activity.category).toBeNull();
+            expect(activity.sourceTaskId).toBeNull();
+        });
+    });
+});

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -112,6 +112,53 @@ describe('activity manager', () => {
         });
     });
 
+    describe('state management', () => {
+        test('updateActivityState normalizes defaults and sorts by start time', () => {
+            const state = updateActivityState([
+                {
+                    id: 'activity-2',
+                    description: 'Later',
+                    startDateTime: '2026-04-07T10:00:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 30
+                },
+                {
+                    id: 'activity-1',
+                    description: 'Earlier',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30
+                }
+            ]);
+
+            expect(state.map((activity) => activity.id)).toEqual(['activity-1', 'activity-2']);
+            expect(state[0]).toEqual(
+                expect.objectContaining({
+                    docType: 'activity',
+                    category: null,
+                    source: 'manual',
+                    sourceTaskId: null
+                })
+            );
+        });
+
+        test('getActivityState returns clones instead of mutable internal references', async () => {
+            await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const state = getActivityState();
+            state[0].description = 'Mutated externally';
+
+            expect(getActivityState()[0].description).toBe('Original');
+        });
+    });
+
     describe('getTodaysActivities', () => {
         beforeEach(() => {
             jest.useFakeTimers();
@@ -234,6 +281,39 @@ describe('activity manager', () => {
 
             expect(result.success).toBe(false);
             expect(result.reason).toMatch(/description/i);
+        });
+
+        test('rejects edit when duration becomes zero', async () => {
+            const { activity } = await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await editActivity(activity.id, { duration: 0 });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/duration/i);
+        });
+
+        test('preserves the existing description when edit updates omit it', async () => {
+            const { activity } = await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await editActivity(activity.id, { duration: 90 });
+
+            expect(result.success).toBe(true);
+            expect(result.activity.description).toBe('Original');
+            expect(result.activity.duration).toBe(90);
         });
     });
 

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -8,17 +8,15 @@ jest.mock('../public/js/storage.js', () => ({
     deleteActivity: jest.fn(() => Promise.resolve())
 }));
 
+import * as activityManager from '../public/js/activities/manager.js';
 import {
     addActivity,
     getActivityState,
     getActivityById,
     getTodaysActivities,
     loadActivitiesState,
-    loadActivityState,
     removeActivity,
     editActivity,
-    updateActivity,
-    deleteActivity as deleteActivityAlias,
     resetActivityState,
     updateActivityState,
     createActivityFromTask
@@ -362,53 +360,13 @@ describe('activity manager', () => {
             expect(getActivityState()).toEqual([]);
         });
 
-        test('loadActivityState aliases loadActivitiesState', async () => {
-            const result = await loadActivityState(async () => [
-                {
-                    id: 'activity-1',
-                    description: 'Stored',
-                    startDateTime: '2026-04-07T09:00:00.000Z',
-                    endDateTime: '2026-04-07T10:00:00.000Z',
-                    duration: 60
-                }
-            ]);
-
-            expect(result).toHaveLength(1);
-            expect(getActivityState()[0].id).toBe('activity-1');
-        });
-    });
-
-    describe('aliases', () => {
-        test('updateActivity proxies to editActivity', async () => {
-            const { activity } = await addActivity({
-                description: 'Original',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
-
-            const result = await updateActivity(activity.id, { description: 'Updated' });
-
-            expect(result.success).toBe(true);
-            expect(result.activity.description).toBe('Updated');
-        });
-
-        test('deleteActivity proxies to removeActivity', async () => {
-            const { activity } = await addActivity({
-                description: 'To remove',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
-
-            const result = await deleteActivityAlias(activity.id);
-
-            expect(result.success).toBe(true);
-            expect(getActivityById(activity.id)).toBeNull();
+        test('exports only the canonical activity CRUD and loading names', () => {
+            expect(activityManager.loadActivitiesState).toBe(loadActivitiesState);
+            expect(activityManager.editActivity).toBe(editActivity);
+            expect(activityManager.removeActivity).toBe(removeActivity);
+            expect(activityManager.loadActivityState).toBeUndefined();
+            expect(activityManager.updateActivity).toBeUndefined();
+            expect(activityManager.deleteActivity).toBeUndefined();
         });
     });
 

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -249,7 +249,7 @@ describe('activity manager', () => {
             expect(putActivity).toHaveBeenCalledWith(result.activity);
         });
 
-        test('rejects edit of auto-logged activity', async () => {
+        test('allows edit of auto-logged activity while preserving provenance fields', async () => {
             const { activity } = await addActivity({
                 description: 'Auto',
                 startDateTime: '2026-04-07T09:00:00.000Z',
@@ -259,10 +259,17 @@ describe('activity manager', () => {
                 sourceTaskId: 'sched-123'
             });
 
-            const result = await editActivity(activity.id, { description: 'Changed' });
+            const result = await editActivity(activity.id, {
+                description: 'Changed',
+                duration: 75,
+                endDateTime: '2026-04-07T10:15:00.000Z'
+            });
 
-            expect(result.success).toBe(false);
-            expect(result.reason).toMatch(/auto/i);
+            expect(result.success).toBe(true);
+            expect(result.activity.description).toBe('Changed');
+            expect(result.activity.duration).toBe(75);
+            expect(result.activity.source).toBe('auto');
+            expect(result.activity.sourceTaskId).toBe('sched-123');
         });
 
         test('rejects edit when trimmed description becomes empty', async () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -3,7 +3,10 @@
  */
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
-    renderCategoryBadge: jest.fn(() => '<span class="category-badge">Deep Work</span>')
+    renderCategoryBadge: jest.fn(() => '<span class="category-badge">Deep Work</span>'),
+    getSelectableCategoryOptions: jest.fn(() => [
+        { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+    ])
 }));
 
 import { renderActivities } from '../public/js/activities/renderer.js';
@@ -60,7 +63,7 @@ describe('activity renderer', () => {
         expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
     });
 
-    test('renders auto activity with source indicator and no edit/delete actions', () => {
+    test('renders auto activity with source indicator and edit/delete actions', () => {
         const container = document.getElementById('activity-list');
 
         renderActivities(
@@ -81,8 +84,44 @@ describe('activity renderer', () => {
 
         expect(container.textContent).toContain('auto');
         expect(container.querySelector('.activity-source-link')).not.toBeNull();
-        expect(container.querySelector('.btn-edit-activity')).toBeNull();
-        expect(container.querySelector('.btn-delete-activity')).toBeNull();
+        expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
+        expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
+    });
+
+    test('renders inline edit form instead of the summary row for the editing activity', () => {
+        const container = document.getElementById('activity-list');
+        const displayStartTime = extractTimeFromDateTime(new Date('2026-04-07T09:00:00.000Z'));
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-editing',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 90,
+                    source: 'auto',
+                    sourceTaskId: 'sched-1'
+                }
+            ],
+            container,
+            { editingActivityId: 'activity-editing' }
+        );
+
+        const editForm = container.querySelector('form.activity-inline-edit-form');
+        expect(editForm).not.toBeNull();
+        expect(editForm.dataset.activityId).toBe('activity-editing');
+        expect(editForm.dataset.activityDate).toBe('2026-04-07');
+        expect(editForm.querySelector('input[name="description"]').value).toBe('Deep work');
+        expect(editForm.querySelector('input[name="start-time"]').value).toBe(displayStartTime);
+        expect(editForm.querySelector('input[name="duration-hours"]').value).toBe('1');
+        expect(editForm.querySelector('input[name="duration-minutes"]').value).toBe('30');
+        expect(editForm.querySelector('select[name="category"]').value).toBe('work/deep');
+        expect(editForm.textContent).toContain('auto');
+        expect(editForm.querySelector('.btn-delete-activity')).toBeNull();
+        expect(editForm.querySelector('.btn-cancel-activity-edit')).not.toBeNull();
+        expect(editForm.querySelector('.btn-save-activity-edit')).not.toBeNull();
     });
 
     test('escapes activity descriptions', () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -107,4 +107,64 @@ describe('activity renderer', () => {
         expect(container.innerHTML).not.toContain('<script>');
         expect(container.textContent).toContain('<script>alert("x")</script>');
     });
+
+    test('uses the default activity-list container when none is provided', () => {
+        renderActivities([
+            {
+                id: 'activity-default',
+                description: 'Default target',
+                category: null,
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:30:00.000Z',
+                duration: 30,
+                source: 'manual',
+                sourceTaskId: null
+            }
+        ]);
+
+        expect(document.getElementById('activity-list').textContent).toContain('Default target');
+    });
+
+    test('returns cleanly when no container can be resolved', () => {
+        document.body.innerHTML = '';
+
+        expect(() =>
+            renderActivities([
+                {
+                    id: 'activity-missing-target',
+                    description: 'No target',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ])
+        ).not.toThrow();
+    });
+
+    test('escapes activity ids and auto source task ids in attributes', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-"><bad',
+                    description: 'Standup',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'auto',
+                    sourceTaskId: 'sched-"><bad'
+                }
+            ],
+            container
+        );
+
+        expect(container.innerHTML).not.toContain('data-source-task-id="sched-"><bad"');
+        expect(container.innerHTML).not.toContain('data-activity-id="activity-"><bad"');
+        expect(container.querySelector('.activity-source-link')).not.toBeNull();
+    });
 });

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    renderCategoryBadge: jest.fn(() => '<span class="category-badge">Deep Work</span>')
+}));
+
+import { renderActivities } from '../public/js/activities/renderer.js';
+import { convertTo12HourTime, extractTimeFromDateTime } from '../public/js/utils.js';
+
+describe('activity renderer', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="activity-list"></div>';
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('renders empty state when no activities exist', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities([], container);
+
+        expect(container.textContent).toContain('No activities tracked today');
+    });
+
+    test('renders manual activity with edit and delete actions', () => {
+        const container = document.getElementById('activity-list');
+        const startText = convertTo12HourTime(
+            extractTimeFromDateTime(new Date('2026-04-07T09:00:00.000Z'))
+        );
+        const endText = convertTo12HourTime(
+            extractTimeFromDateTime(new Date('2026-04-07T10:00:00.000Z'))
+        );
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        expect(container.querySelector('[data-activity-id="activity-1"]')).not.toBeNull();
+        expect(container.textContent).toContain('Deep work');
+        expect(container.textContent).toContain(startText);
+        expect(container.textContent).toContain(endText);
+        expect(container.textContent).toContain('1h');
+        expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
+        expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
+    });
+
+    test('renders auto activity with source indicator and no edit/delete actions', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-2',
+                    description: 'Standup',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'auto',
+                    sourceTaskId: 'sched-1'
+                }
+            ],
+            container
+        );
+
+        expect(container.textContent).toContain('auto');
+        expect(container.querySelector('.activity-source-link')).not.toBeNull();
+        expect(container.querySelector('.btn-edit-activity')).toBeNull();
+        expect(container.querySelector('.btn-delete-activity')).toBeNull();
+    });
+
+    test('escapes activity descriptions', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-3',
+                    description: '<script>alert("x")</script>',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        expect(container.innerHTML).not.toContain('<script>');
+        expect(container.textContent).toContain('<script>alert("x")</script>');
+    });
+});

--- a/__tests__/activity-smoke-hooks.test.js
+++ b/__tests__/activity-smoke-hooks.test.js
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+    consumeActivitySmokeFailure,
+    queueActivitySmokeFailure
+} from '../public/js/activities/smoke-hooks.js';
+
+describe('activity smoke hooks', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    test('queues and consumes a manual add failure on supported smoke hosts', () => {
+        expect(
+            queueActivitySmokeFailure('manual-add', 2, {
+                storage: window.localStorage,
+                hostname: 'fortudo--pr60.web.app'
+            })
+        ).toBe(true);
+
+        expect(
+            consumeActivitySmokeFailure('manual-add', {
+                storage: window.localStorage,
+                hostname: 'fortudo--pr60.web.app'
+            })
+        ).toBe(true);
+        expect(
+            consumeActivitySmokeFailure('manual-add', {
+                storage: window.localStorage,
+                hostname: 'fortudo--pr60.web.app'
+            })
+        ).toBe(true);
+        expect(
+            consumeActivitySmokeFailure('manual-add', {
+                storage: window.localStorage,
+                hostname: 'fortudo--pr60.web.app'
+            })
+        ).toBe(false);
+    });
+
+    test('does not queue or consume on unsupported hosts', () => {
+        expect(
+            queueActivitySmokeFailure('auto-log', 1, {
+                storage: window.localStorage,
+                hostname: 'fortudo.app'
+            })
+        ).toBe(false);
+        expect(
+            consumeActivitySmokeFailure('auto-log', {
+                storage: window.localStorage,
+                hostname: 'fortudo.app'
+            })
+        ).toBe(false);
+    });
+
+    test('ignores malformed stored smoke hook state', () => {
+        window.localStorage.setItem('fortudo-smoke-activity-failures', '{not-json');
+
+        expect(
+            consumeActivitySmokeFailure('manual-add', {
+                storage: window.localStorage,
+                hostname: 'localhost'
+            })
+        ).toBe(false);
+    });
+});

--- a/__tests__/app-coordinator.test.js
+++ b/__tests__/app-coordinator.test.js
@@ -8,7 +8,18 @@ jest.mock('../public/js/dom-renderer.js', () => ({
 }));
 
 jest.mock('../public/js/activities/manager.js', () => ({
-    addActivity: jest.fn(() => Promise.resolve()),
+    addActivity: jest.fn(() =>
+        Promise.resolve({
+            success: true,
+            activity: {
+                id: 'activity-from-task',
+                docType: 'activity',
+                description: 'Generated activity',
+                source: 'auto',
+                sourceTaskId: 'task-1'
+            }
+        })
+    ),
     createActivityFromTask: jest.fn((task) => ({
         id: 'activity-from-task',
         docType: 'activity',
@@ -20,6 +31,10 @@ jest.mock('../public/js/activities/manager.js', () => ({
 
 jest.mock('../public/js/settings-manager.js', () => ({
     isActivitiesEnabled: jest.fn(() => false)
+}));
+
+jest.mock('../public/js/toast-manager.js', () => ({
+    showToast: jest.fn()
 }));
 
 jest.mock('../public/js/tasks/scheduled-renderer.js', () => ({
@@ -38,6 +53,7 @@ import { addActivity, createActivityFromTask } from '../public/js/activities/man
 import { refreshUI, updateStartTimeField } from '../public/js/dom-renderer.js';
 import { isActivitiesEnabled } from '../public/js/settings-manager.js';
 import { triggerConfettiAnimation } from '../public/js/tasks/scheduled-renderer.js';
+import { showToast } from '../public/js/toast-manager.js';
 
 describe('app-coordinator', () => {
     beforeEach(() => {
@@ -119,13 +135,14 @@ describe('app-coordinator', () => {
         expect(refreshUI).toHaveBeenCalledTimes(1);
     });
 
-    test('onTaskCompleted auto-logs scheduled tasks when activities are enabled', () => {
+    test('onTaskCompleted auto-logs scheduled tasks when activities are enabled', async () => {
         isActivitiesEnabled.mockReturnValue(true);
 
         const task = { id: 'task-9', type: 'scheduled', description: 'Write notes' };
         appCoordinator.onTaskCompleted({ task });
+        await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(refreshUI).toHaveBeenCalledTimes(1);
+        expect(refreshUI).toHaveBeenCalledTimes(2);
         expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-9');
         expect(createActivityFromTask).toHaveBeenCalledWith(task);
         expect(addActivity).toHaveBeenCalledWith({
@@ -151,6 +168,30 @@ describe('app-coordinator', () => {
         expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-9b');
         expect(createActivityFromTask).toHaveBeenCalled();
         expect(addActivity).toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith('Task completed, but activity auto-log failed.', {
+            theme: 'amber'
+        });
+    });
+
+    test('onTaskCompleted refreshes again after a successful auto-log write', async () => {
+        isActivitiesEnabled.mockReturnValue(true);
+        addActivity.mockResolvedValueOnce({
+            success: true,
+            activity: {
+                id: 'activity-42',
+                docType: 'activity',
+                description: 'Write notes',
+                source: 'auto',
+                sourceTaskId: 'task-42'
+            }
+        });
+
+        appCoordinator.onTaskCompleted({
+            task: { id: 'task-42', type: 'scheduled', description: 'Write notes' }
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(refreshUI).toHaveBeenCalledTimes(2);
     });
 
     test('onTaskCompleted does not auto-log scheduled tasks when activities are disabled', () => {

--- a/__tests__/app-coordinator.test.js
+++ b/__tests__/app-coordinator.test.js
@@ -7,6 +7,21 @@ jest.mock('../public/js/dom-renderer.js', () => ({
     updateStartTimeField: jest.fn()
 }));
 
+jest.mock('../public/js/activities/manager.js', () => ({
+    addActivity: jest.fn(() => Promise.resolve()),
+    createActivityFromTask: jest.fn((task) => ({
+        id: 'activity-from-task',
+        docType: 'activity',
+        description: task.description,
+        source: 'auto',
+        sourceTaskId: task.id
+    }))
+}));
+
+jest.mock('../public/js/settings-manager.js', () => ({
+    isActivitiesEnabled: jest.fn(() => false)
+}));
+
 jest.mock('../public/js/tasks/scheduled-renderer.js', () => ({
     triggerConfettiAnimation: jest.fn(),
     refreshActiveTaskColor: jest.fn(),
@@ -19,27 +34,36 @@ jest.mock('../public/js/tasks/manager.js', () => ({
 }));
 
 import * as appCoordinator from '../public/js/app-coordinator.js';
+import { addActivity, createActivityFromTask } from '../public/js/activities/manager.js';
 import { refreshUI, updateStartTimeField } from '../public/js/dom-renderer.js';
+import { isActivitiesEnabled } from '../public/js/settings-manager.js';
 import { triggerConfettiAnimation } from '../public/js/tasks/scheduled-renderer.js';
 
 describe('app-coordinator', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        isActivitiesEnabled.mockReturnValue(false);
     });
 
     test('onTaskCompleted refreshes UI and triggers confetti for scheduled tasks without directly updating start time', () => {
+        isActivitiesEnabled.mockReturnValue(false);
         appCoordinator.onTaskCompleted({ task: { id: 'task-1', type: 'scheduled' } });
 
         expect(refreshUI).toHaveBeenCalledTimes(1);
         expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-1');
+        expect(createActivityFromTask).not.toHaveBeenCalled();
+        expect(addActivity).not.toHaveBeenCalled();
         expect(updateStartTimeField).not.toHaveBeenCalled();
     });
 
     test('onTaskCompleted skips confetti and start-time updates for unscheduled tasks', () => {
+        isActivitiesEnabled.mockReturnValue(true);
         appCoordinator.onTaskCompleted({ task: { id: 'task-2', type: 'unscheduled' } });
 
         expect(refreshUI).toHaveBeenCalledTimes(1);
         expect(triggerConfettiAnimation).not.toHaveBeenCalled();
+        expect(createActivityFromTask).not.toHaveBeenCalled();
+        expect(addActivity).not.toHaveBeenCalled();
         expect(updateStartTimeField).not.toHaveBeenCalled();
     });
 
@@ -75,6 +99,68 @@ describe('app-coordinator', () => {
 
         expect(refreshUI).toHaveBeenCalledTimes(1);
         expect(updateStartTimeField).not.toHaveBeenCalled();
+    });
+
+    test('onActivityCreated refreshes UI when given an activity', () => {
+        appCoordinator.onActivityCreated({ activity: { id: 'activity-1' } });
+
+        expect(refreshUI).toHaveBeenCalledTimes(1);
+    });
+
+    test('onActivityEdited refreshes UI when given an activity', () => {
+        appCoordinator.onActivityEdited({ activity: { id: 'activity-2' } });
+
+        expect(refreshUI).toHaveBeenCalledTimes(1);
+    });
+
+    test('onActivityDeleted refreshes UI when given an activity', () => {
+        appCoordinator.onActivityDeleted({ activity: { id: 'activity-3' } });
+
+        expect(refreshUI).toHaveBeenCalledTimes(1);
+    });
+
+    test('onTaskCompleted auto-logs scheduled tasks when activities are enabled', () => {
+        isActivitiesEnabled.mockReturnValue(true);
+
+        const task = { id: 'task-9', type: 'scheduled', description: 'Write notes' };
+        appCoordinator.onTaskCompleted({ task });
+
+        expect(refreshUI).toHaveBeenCalledTimes(1);
+        expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-9');
+        expect(createActivityFromTask).toHaveBeenCalledWith(task);
+        expect(addActivity).toHaveBeenCalledWith({
+            id: 'activity-from-task',
+            docType: 'activity',
+            description: 'Write notes',
+            source: 'auto',
+            sourceTaskId: 'task-9'
+        });
+    });
+
+    test('onTaskCompleted does not auto-log scheduled tasks when activities are disabled', () => {
+        isActivitiesEnabled.mockReturnValue(false);
+
+        appCoordinator.onTaskCompleted({ task: { id: 'task-10', type: 'scheduled' } });
+
+        expect(refreshUI).toHaveBeenCalledTimes(1);
+        expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-10');
+        expect(createActivityFromTask).not.toHaveBeenCalled();
+        expect(addActivity).not.toHaveBeenCalled();
+    });
+
+    test('onTaskCompleted ignores missing task payloads', () => {
+        appCoordinator.onTaskCompleted({ task: null });
+
+        expect(refreshUI).not.toHaveBeenCalled();
+        expect(triggerConfettiAnimation).not.toHaveBeenCalled();
+        expect(createActivityFromTask).not.toHaveBeenCalled();
+        expect(addActivity).not.toHaveBeenCalled();
+    });
+
+    test('onActivityCreated ignores missing activity payloads', () => {
+        appCoordinator.onActivityCreated({ activity: null });
+
+        expect(refreshUI).not.toHaveBeenCalled();
     });
 
     test('onScheduledTasksCleared refreshes UI without directly updating start time', () => {

--- a/__tests__/app-coordinator.test.js
+++ b/__tests__/app-coordinator.test.js
@@ -137,6 +137,22 @@ describe('app-coordinator', () => {
         });
     });
 
+    test('onTaskCompleted tolerates auto-log persistence failures', async () => {
+        isActivitiesEnabled.mockReturnValue(true);
+        addActivity.mockRejectedValueOnce(new Error('storage failed'));
+
+        appCoordinator.onTaskCompleted({
+            task: { id: 'task-9b', type: 'scheduled', description: 'Write notes' }
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(refreshUI).toHaveBeenCalledTimes(1);
+        expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-9b');
+        expect(createActivityFromTask).toHaveBeenCalled();
+        expect(addActivity).toHaveBeenCalled();
+    });
+
     test('onTaskCompleted does not auto-log scheduled tasks when activities are disabled', () => {
         isActivitiesEnabled.mockReturnValue(false);
 

--- a/__tests__/app-coordinator.test.js
+++ b/__tests__/app-coordinator.test.js
@@ -179,6 +179,19 @@ describe('app-coordinator', () => {
         expect(refreshUI).not.toHaveBeenCalled();
     });
 
+    test('payload-based refresh handlers ignore missing task or activity payloads', () => {
+        appCoordinator.onTaskCreated({ task: null });
+        appCoordinator.onTaskEdited({ task: null });
+        appCoordinator.onTaskScheduled({ task: null });
+        appCoordinator.onTaskUnscheduled({ task: null });
+        appCoordinator.onTaskDeleted({ task: null });
+        appCoordinator.onActivityEdited({ activity: null });
+        appCoordinator.onActivityDeleted({ activity: null });
+
+        expect(refreshUI).not.toHaveBeenCalled();
+        expect(updateStartTimeField).not.toHaveBeenCalled();
+    });
+
     test('onScheduledTasksCleared refreshes UI without directly updating start time', () => {
         appCoordinator.onScheduledTasksCleared();
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -50,15 +50,9 @@ jest.mock('../public/js/activities/renderer.js', () => ({
 jest.mock('../public/js/activities/handlers.js', () => ({
     handleAddActivity: jest.fn(() => Promise.resolve()),
     handleEditActivity: jest.fn(),
-    handleDeleteActivity: jest.fn(() => Promise.resolve())
+    handleDeleteActivity: jest.fn(() => Promise.resolve()),
+    handleSaveActivityEdit: jest.fn(() => Promise.resolve({ success: true }))
 }));
-jest.mock('../public/js/modal-manager.js', () => {
-    const actual = jest.requireActual('../public/js/modal-manager.js');
-    return {
-        ...actual,
-        showActivityEditModal: jest.fn(() => Promise.resolve(null))
-    };
-});
 import {
     prepareStorage as mockPrepareStorageInternal,
     initStorage as mockInitStorageInternal,
@@ -83,10 +77,10 @@ import { renderActivities as mockRenderActivitiesInternal } from '../public/js/a
 import {
     handleAddActivity as mockHandleAddActivityInternal,
     handleEditActivity as mockHandleEditActivityInternal,
-    handleDeleteActivity as mockHandleDeleteActivityInternal
+    handleDeleteActivity as mockHandleDeleteActivityInternal,
+    handleSaveActivityEdit as mockHandleSaveActivityEditInternal
 } from '../public/js/activities/handlers.js';
 import * as appCoordinator from '../public/js/app-coordinator.js';
-import { showActivityEditModal as mockShowActivityEditModalInternal } from '../public/js/modal-manager.js';
 
 const mockPrepareStorage = jest.mocked(mockPrepareStorageInternal);
 const mockInitStorage = jest.mocked(mockInitStorageInternal);
@@ -106,7 +100,7 @@ const mockRenderActivities = jest.mocked(mockRenderActivitiesInternal);
 const mockHandleAddActivity = jest.mocked(mockHandleAddActivityInternal);
 const mockHandleEditActivity = jest.mocked(mockHandleEditActivityInternal);
 const mockHandleDeleteActivity = jest.mocked(mockHandleDeleteActivityInternal);
-const mockShowActivityEditModal = jest.mocked(mockShowActivityEditModalInternal);
+const mockHandleSaveActivityEdit = jest.mocked(mockHandleSaveActivityEditInternal);
 
 describe('App.js Callback Functions', () => {
     let alertSpy;
@@ -179,7 +173,7 @@ describe('App.js Callback Functions', () => {
         mockHandleAddActivity.mockClear();
         mockHandleEditActivity.mockClear();
         mockHandleDeleteActivity.mockClear();
-        mockShowActivityEditModal.mockClear();
+        mockHandleSaveActivityEdit.mockClear();
         mockPrepareStorage.mockClear();
         mockInitStorage.mockClear();
         updateTaskState([]);
@@ -323,7 +317,8 @@ describe('App.js Callback Functions', () => {
             expect(mockLoadActivitiesState).toHaveBeenCalled();
             expect(mockRenderActivities).toHaveBeenCalledWith(
                 [activity],
-                document.getElementById('activity-list')
+                document.getElementById('activity-list'),
+                expect.objectContaining({ editingActivityId: null })
             );
             expect(
                 document.getElementById('activity-toggle-option')?.classList.contains('hidden')
@@ -372,7 +367,7 @@ describe('App.js Callback Functions', () => {
             expect(descriptionInput.getAttribute('placeholder')).toBe('What did you work on?');
         });
 
-        test('activity list delegates edit and delete controls to the activity handlers', async () => {
+        test('activity list delegates inline activity save and delete controls to the activity handlers', async () => {
             mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
 
             await setupAppWithTasks([]);
@@ -380,29 +375,43 @@ describe('App.js Callback Functions', () => {
             const activityList = document.getElementById('activity-list');
             activityList.innerHTML = `
                 <article class="activity-item" data-activity-id="activity-42">
-                    <span class="text-sm text-slate-200">Renderer-shaped activity</span>
                     <button type="button" class="btn-edit-activity" data-activity-id="activity-42">Edit</button>
                     <button type="button" class="btn-delete-activity" data-activity-id="activity-42">Delete</button>
                 </article>
             `;
-            mockShowActivityEditModal.mockResolvedValue('Updated activity');
 
             activityList
                 .querySelector('.btn-edit-activity')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            activityList.innerHTML = `
+                <form class="activity-inline-edit-form" data-activity-id="activity-42" data-activity-date="2026-04-07">
+                    <input name="description" value="Updated activity" />
+                    <input name="start-time" value="09:00" />
+                    <input name="duration-hours" value="1" />
+                    <input name="duration-minutes" value="0" />
+                    <select name="category"></select>
+                    <button type="button" class="btn-save-activity-edit">Save</button>
+                </form>
+                <article class="activity-item" data-activity-id="activity-42">
+                    <button type="button" class="btn-delete-activity" data-activity-id="activity-42">Delete</button>
+                </article>
+            `;
+            activityList
+                .querySelector('.btn-save-activity-edit')
                 .dispatchEvent(new Event('click', { bubbles: true }));
             activityList
                 .querySelector('.btn-delete-activity')
                 .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(mockShowActivityEditModal).toHaveBeenCalledWith('Renderer-shaped activity');
-            expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-42', {
-                description: 'Updated activity'
-            });
+            expect(mockHandleSaveActivityEdit).toHaveBeenCalledWith(
+                'activity-42',
+                expect.any(HTMLFormElement)
+            );
             expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-42');
         });
 
-        test('activity edit does nothing for cancelled blank or unchanged modal responses', async () => {
+        test('activity cancel exits inline edit mode without saving', async () => {
             mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
 
             await setupAppWithTasks([]);
@@ -410,23 +419,23 @@ describe('App.js Callback Functions', () => {
             const activityList = document.getElementById('activity-list');
             activityList.innerHTML = `
                 <article class="activity-item" data-activity-id="activity-43">
-                    <span class="text-sm text-slate-200">Current activity</span>
                     <button type="button" class="btn-edit-activity">Edit</button>
                 </article>
             `;
-            mockShowActivityEditModal
-                .mockResolvedValueOnce(null)
-                .mockResolvedValueOnce('   ')
-                .mockResolvedValueOnce('Current activity');
 
             const editButton = activityList.querySelector('.btn-edit-activity');
             editButton.dispatchEvent(new Event('click', { bubbles: true }));
-            editButton.dispatchEvent(new Event('click', { bubbles: true }));
-            editButton.dispatchEvent(new Event('click', { bubbles: true }));
+            activityList.innerHTML = `
+                <form class="activity-inline-edit-form" data-activity-id="activity-43" data-activity-date="2026-04-07">
+                    <button type="button" class="btn-cancel-activity-edit">Cancel</button>
+                </form>
+            `;
+            activityList
+                .querySelector('.btn-cancel-activity-edit')
+                .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(mockShowActivityEditModal).toHaveBeenCalledTimes(3);
-            expect(mockHandleEditActivity).not.toHaveBeenCalled();
+            expect(mockHandleSaveActivityEdit).not.toHaveBeenCalled();
         });
 
         test('activity actions can resolve ids from the ancestor activity element', async () => {
@@ -437,25 +446,34 @@ describe('App.js Callback Functions', () => {
             const activityList = document.getElementById('activity-list');
             activityList.innerHTML = `
                 <article class="activity-item" data-activity-id="activity-44">
-                    <span class="text-sm text-slate-200">Ancestor id activity</span>
                     <button type="button" class="btn-edit-activity"><span>Edit</span></button>
                     <button type="button" class="btn-delete-activity"><span>Delete</span></button>
                 </article>
             `;
-            mockShowActivityEditModal.mockResolvedValue('Changed from ancestor');
 
             activityList
                 .querySelector('.btn-edit-activity span')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            activityList.innerHTML = `
+                <form class="activity-inline-edit-form" data-activity-id="activity-44" data-activity-date="2026-04-07">
+                    <button type="button" class="btn-save-activity-edit"><span>Save</span></button>
+                </form>
+                <article class="activity-item" data-activity-id="activity-44">
+                    <button type="button" class="btn-delete-activity"><span>Delete</span></button>
+                </article>
+            `;
+            activityList
+                .querySelector('.btn-save-activity-edit span')
                 .dispatchEvent(new Event('click', { bubbles: true }));
             activityList
                 .querySelector('.btn-delete-activity span')
                 .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(mockShowActivityEditModal).toHaveBeenCalledWith('Ancestor id activity');
-            expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-44', {
-                description: 'Changed from ancestor'
-            });
+            expect(mockHandleSaveActivityEdit).toHaveBeenCalledWith(
+                'activity-44',
+                expect.any(HTMLFormElement)
+            );
             expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-44');
         });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -379,7 +379,8 @@ describe('App.js Callback Functions', () => {
 
             const activityList = document.getElementById('activity-list');
             activityList.innerHTML = `
-                <article class="activity-card" data-activity-id="activity-42">
+                <article class="activity-item" data-activity-id="activity-42">
+                    <span class="text-sm text-slate-200">Renderer-shaped activity</span>
                     <button type="button" class="btn-edit-activity" data-activity-id="activity-42">Edit</button>
                     <button type="button" class="btn-delete-activity" data-activity-id="activity-42">Delete</button>
                 </article>
@@ -394,7 +395,7 @@ describe('App.js Callback Functions', () => {
                 .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(mockShowActivityEditModal).toHaveBeenCalledWith('');
+            expect(mockShowActivityEditModal).toHaveBeenCalledWith('Renderer-shaped activity');
             expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-42', {
                 description: 'Updated activity'
             });
@@ -408,7 +409,7 @@ describe('App.js Callback Functions', () => {
 
             const activityList = document.getElementById('activity-list');
             activityList.innerHTML = `
-                <article class="activity-card" data-activity-id="activity-43">
+                <article class="activity-item" data-activity-id="activity-43">
                     <span class="text-sm text-slate-200">Current activity</span>
                     <button type="button" class="btn-edit-activity">Edit</button>
                 </article>
@@ -435,7 +436,7 @@ describe('App.js Callback Functions', () => {
 
             const activityList = document.getElementById('activity-list');
             activityList.innerHTML = `
-                <article class="activity-card" data-activity-id="activity-44">
+                <article class="activity-item" data-activity-id="activity-44">
                     <span class="text-sm text-slate-200">Ancestor id activity</span>
                     <button type="button" class="btn-edit-activity"><span>Edit</span></button>
                     <button type="button" class="btn-delete-activity"><span>Delete</span></button>

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -53,6 +53,13 @@ jest.mock('../public/js/activities/handlers.js', () => ({
     handleEditActivity: jest.fn(),
     handleDeleteActivity: jest.fn(() => Promise.resolve())
 }));
+jest.mock('../public/js/modal-manager.js', () => {
+    const actual = jest.requireActual('../public/js/modal-manager.js');
+    return {
+        ...actual,
+        showActivityEditModal: jest.fn(() => Promise.resolve(null))
+    };
+});
 import {
     prepareStorage as mockPrepareStorageInternal,
     initStorage as mockInitStorageInternal,
@@ -81,6 +88,7 @@ import {
     handleDeleteActivity as mockHandleDeleteActivityInternal
 } from '../public/js/activities/handlers.js';
 import * as appCoordinator from '../public/js/app-coordinator.js';
+import { showActivityEditModal as mockShowActivityEditModalInternal } from '../public/js/modal-manager.js';
 
 const mockPrepareStorage = jest.mocked(mockPrepareStorageInternal);
 const mockInitStorage = jest.mocked(mockInitStorageInternal);
@@ -101,6 +109,7 @@ const mockRenderActivities = jest.mocked(mockRenderActivitiesInternal);
 const mockHandleAddActivity = jest.mocked(mockHandleAddActivityInternal);
 const mockHandleEditActivity = jest.mocked(mockHandleEditActivityInternal);
 const mockHandleDeleteActivity = jest.mocked(mockHandleDeleteActivityInternal);
+const mockShowActivityEditModal = jest.mocked(mockShowActivityEditModalInternal);
 
 describe('App.js Callback Functions', () => {
     let alertSpy;
@@ -173,6 +182,7 @@ describe('App.js Callback Functions', () => {
         mockHandleAddActivity.mockClear();
         mockHandleEditActivity.mockClear();
         mockHandleDeleteActivity.mockClear();
+        mockShowActivityEditModal.mockClear();
         mockPrepareStorage.mockClear();
         mockInitStorage.mockClear();
         updateTaskState([]);
@@ -377,7 +387,7 @@ describe('App.js Callback Functions', () => {
                     <button type="button" class="btn-delete-activity" data-activity-id="activity-42">Delete</button>
                 </article>
             `;
-            jest.spyOn(window, 'prompt').mockReturnValue('Updated activity');
+            mockShowActivityEditModal.mockResolvedValue('Updated activity');
 
             activityList
                 .querySelector('.btn-edit-activity')
@@ -387,13 +397,14 @@ describe('App.js Callback Functions', () => {
                 .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
+            expect(mockShowActivityEditModal).toHaveBeenCalledWith('');
             expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-42', {
                 description: 'Updated activity'
             });
             expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-42');
         });
 
-        test('activity edit does nothing for cancelled blank or unchanged prompt responses', async () => {
+        test('activity edit does nothing for cancelled blank or unchanged modal responses', async () => {
             mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
 
             await setupAppWithTasks([]);
@@ -405,11 +416,10 @@ describe('App.js Callback Functions', () => {
                     <button type="button" class="btn-edit-activity">Edit</button>
                 </article>
             `;
-            const promptSpy = jest
-                .spyOn(window, 'prompt')
-                .mockReturnValueOnce(null)
-                .mockReturnValueOnce('   ')
-                .mockReturnValueOnce('Current activity');
+            mockShowActivityEditModal
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce('   ')
+                .mockResolvedValueOnce('Current activity');
 
             const editButton = activityList.querySelector('.btn-edit-activity');
             editButton.dispatchEvent(new Event('click', { bubbles: true }));
@@ -417,9 +427,8 @@ describe('App.js Callback Functions', () => {
             editButton.dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(promptSpy).toHaveBeenCalledTimes(3);
+            expect(mockShowActivityEditModal).toHaveBeenCalledTimes(3);
             expect(mockHandleEditActivity).not.toHaveBeenCalled();
-            promptSpy.mockRestore();
         });
 
         test('activity actions can resolve ids from the ancestor activity element', async () => {
@@ -435,7 +444,7 @@ describe('App.js Callback Functions', () => {
                     <button type="button" class="btn-delete-activity"><span>Delete</span></button>
                 </article>
             `;
-            const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('Changed from ancestor');
+            mockShowActivityEditModal.mockResolvedValue('Changed from ancestor');
 
             activityList
                 .querySelector('.btn-edit-activity span')
@@ -445,11 +454,11 @@ describe('App.js Callback Functions', () => {
                 .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
+            expect(mockShowActivityEditModal).toHaveBeenCalledWith('Ancestor id activity');
             expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-44', {
                 description: 'Changed from ancestor'
             });
             expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-44');
-            promptSpy.mockRestore();
         });
 
         test('invalid activity form submission keeps focus flow and skips add handler', async () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -28,6 +28,7 @@ jest.mock('../public/js/storage.js', () => ({
     putConfig: jest.fn(() => Promise.resolve()),
     deleteTask: jest.fn(),
     loadTasks: jest.fn(() => []),
+    loadActivities: jest.fn(() => []),
     loadConfig: jest.fn(() => Promise.resolve(null))
 }));
 
@@ -38,6 +39,20 @@ jest.mock('../public/js/sync-manager.js', () => ({
     debouncedSync: jest.fn(),
     triggerSync: jest.fn(() => Promise.resolve())
 }));
+jest.mock('../public/js/activities/manager.js', () => ({
+    loadActivityState: jest.fn(() => Promise.resolve([])),
+    loadActivitiesState: jest.fn(() => Promise.resolve([])),
+    getActivityState: jest.fn(() => []),
+    getTodaysActivities: jest.fn(() => [])
+}));
+jest.mock('../public/js/activities/renderer.js', () => ({
+    renderActivities: jest.fn()
+}));
+jest.mock('../public/js/activities/handlers.js', () => ({
+    handleAddActivity: jest.fn(() => Promise.resolve()),
+    handleEditActivity: jest.fn(),
+    handleDeleteActivity: jest.fn(() => Promise.resolve())
+}));
 import {
     prepareStorage as mockPrepareStorageInternal,
     initStorage as mockInitStorageInternal,
@@ -46,12 +61,25 @@ import {
     putConfig as mockPutConfigInternal,
     deleteTask as mockDeleteTaskFromStorageInternal,
     loadTasks as mockLoadTasksFromStorageInternal,
+    loadActivities as mockLoadActivitiesFromStorageInternal,
     loadConfig as mockLoadConfigInternal
 } from '../public/js/storage.js';
 import {
     onSyncStatusChange as mockOnSyncStatusChangeInternal,
     triggerSync as mockTriggerSyncInternal
 } from '../public/js/sync-manager.js';
+import {
+    loadActivityState as mockLoadActivityStateInternal,
+    loadActivitiesState as mockLoadActivitiesStateInternal,
+    getActivityState as mockGetActivityStateInternal,
+    getTodaysActivities as mockGetTodaysActivitiesInternal
+} from '../public/js/activities/manager.js';
+import { renderActivities as mockRenderActivitiesInternal } from '../public/js/activities/renderer.js';
+import {
+    handleAddActivity as mockHandleAddActivityInternal,
+    handleEditActivity as mockHandleEditActivityInternal,
+    handleDeleteActivity as mockHandleDeleteActivityInternal
+} from '../public/js/activities/handlers.js';
 import * as appCoordinator from '../public/js/app-coordinator.js';
 
 const mockPrepareStorage = jest.mocked(mockPrepareStorageInternal);
@@ -61,9 +89,18 @@ const mockSaveTasks = jest.mocked(mockSaveTasksInternal);
 const mockPutConfig = jest.mocked(mockPutConfigInternal);
 const mockDeleteTaskFromStorage = jest.mocked(mockDeleteTaskFromStorageInternal);
 const mockLoadTasksFromStorage = jest.mocked(mockLoadTasksFromStorageInternal);
+const mockLoadActivitiesFromStorage = jest.mocked(mockLoadActivitiesFromStorageInternal);
 const mockLoadConfig = jest.mocked(mockLoadConfigInternal);
 const mockOnSyncStatusChange = jest.mocked(mockOnSyncStatusChangeInternal);
 const mockTriggerSync = jest.mocked(mockTriggerSyncInternal);
+const mockLoadActivityState = jest.mocked(mockLoadActivityStateInternal);
+const mockLoadActivitiesState = jest.mocked(mockLoadActivitiesStateInternal);
+const mockGetActivityState = jest.mocked(mockGetActivityStateInternal);
+const mockGetTodaysActivities = jest.mocked(mockGetTodaysActivitiesInternal);
+const mockRenderActivities = jest.mocked(mockRenderActivitiesInternal);
+const mockHandleAddActivity = jest.mocked(mockHandleAddActivityInternal);
+const mockHandleEditActivity = jest.mocked(mockHandleEditActivityInternal);
+const mockHandleDeleteActivity = jest.mocked(mockHandleDeleteActivityInternal);
 
 describe('App.js Callback Functions', () => {
     let alertSpy;
@@ -127,8 +164,15 @@ describe('App.js Callback Functions', () => {
         jest.clearAllMocks();
         resetEventDelegation();
         mockLoadTasksFromStorage.mockReturnValue([]);
+        mockLoadActivitiesFromStorage.mockReturnValue([]);
         mockLoadConfig.mockResolvedValue(null);
         mockPutConfig.mockResolvedValue(undefined);
+        mockLoadActivityState.mockResolvedValue([]);
+        mockGetActivityState.mockReturnValue([]);
+        mockRenderActivities.mockClear();
+        mockHandleAddActivity.mockClear();
+        mockHandleEditActivity.mockClear();
+        mockHandleDeleteActivity.mockClear();
         mockPrepareStorage.mockClear();
         mockInitStorage.mockClear();
         updateTaskState([]);
@@ -259,6 +303,94 @@ describe('App.js Callback Functions', () => {
             await setupAppWithTasks([]);
 
             expect(mockPrepareStorage).toHaveBeenCalledWith(expect.any(String), {}, null);
+        });
+
+        test('when activities are enabled, boot loads activity state and reveals activity UI', async () => {
+            const activity = { id: 'activity-1', description: 'Focus block' };
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+            mockLoadActivitiesState.mockResolvedValue([activity]);
+            mockGetTodaysActivities.mockReturnValue([activity]);
+
+            await setupAppWithTasks([]);
+
+            expect(mockLoadActivitiesState).toHaveBeenCalled();
+            expect(mockRenderActivities).toHaveBeenCalledWith(
+                [activity],
+                document.getElementById('activity-list')
+            );
+            expect(
+                document.getElementById('activity-toggle-option')?.classList.contains('hidden')
+            ).toBe(false);
+            expect(
+                document.getElementById('activities-container')?.classList.contains('hidden')
+            ).toBe(false);
+        });
+
+        test('activity mode submits through the activity handler and uses activity UI state', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityRadio = document.getElementById('activity');
+            const descriptionInput = document.querySelector('#task-form input[name="description"]');
+            const startTimeInput = document.querySelector('#task-form input[name="start-time"]');
+            const durationHoursInput = document.querySelector(
+                '#task-form input[name="duration-hours"]'
+            );
+            const durationMinutesInput = document.querySelector(
+                '#task-form input[name="duration-minutes"]'
+            );
+            const addTaskButton = document.getElementById('add-task-btn');
+
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+            descriptionInput.value = 'Pairing session';
+            startTimeInput.value = '10:00';
+            durationHoursInput.value = '1';
+            durationMinutesInput.value = '30';
+
+            getTaskFormElement().dispatchEvent(
+                new Event('submit', { bubbles: true, cancelable: true })
+            );
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockHandleAddActivity).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    description: 'Pairing session',
+                    duration: 90,
+                    source: 'manual'
+                })
+            );
+            expect(addTaskButton.textContent).toContain('Log Activity');
+            expect(descriptionInput.getAttribute('placeholder')).toBe('What did you work on?');
+        });
+
+        test('activity list delegates edit and delete controls to the activity handlers', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityList = document.getElementById('activity-list');
+            activityList.innerHTML = `
+                <article class="activity-card" data-activity-id="activity-42">
+                    <button type="button" class="btn-edit-activity" data-activity-id="activity-42">Edit</button>
+                    <button type="button" class="btn-delete-activity" data-activity-id="activity-42">Delete</button>
+                </article>
+            `;
+            jest.spyOn(window, 'prompt').mockReturnValue('Updated activity');
+
+            activityList
+                .querySelector('.btn-edit-activity')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            activityList
+                .querySelector('.btn-delete-activity')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-42', {
+                description: 'Updated activity'
+            });
+            expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-42');
         });
 
         test('shows and populates the category dropdown with flattened taxonomy options when Activities are enabled', async () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -40,7 +40,6 @@ jest.mock('../public/js/sync-manager.js', () => ({
     triggerSync: jest.fn(() => Promise.resolve())
 }));
 jest.mock('../public/js/activities/manager.js', () => ({
-    loadActivityState: jest.fn(() => Promise.resolve([])),
     loadActivitiesState: jest.fn(() => Promise.resolve([])),
     getActivityState: jest.fn(() => []),
     getTodaysActivities: jest.fn(() => [])
@@ -76,7 +75,6 @@ import {
     triggerSync as mockTriggerSyncInternal
 } from '../public/js/sync-manager.js';
 import {
-    loadActivityState as mockLoadActivityStateInternal,
     loadActivitiesState as mockLoadActivitiesStateInternal,
     getActivityState as mockGetActivityStateInternal,
     getTodaysActivities as mockGetTodaysActivitiesInternal
@@ -101,7 +99,6 @@ const mockLoadActivitiesFromStorage = jest.mocked(mockLoadActivitiesFromStorageI
 const mockLoadConfig = jest.mocked(mockLoadConfigInternal);
 const mockOnSyncStatusChange = jest.mocked(mockOnSyncStatusChangeInternal);
 const mockTriggerSync = jest.mocked(mockTriggerSyncInternal);
-const mockLoadActivityState = jest.mocked(mockLoadActivityStateInternal);
 const mockLoadActivitiesState = jest.mocked(mockLoadActivitiesStateInternal);
 const mockGetActivityState = jest.mocked(mockGetActivityStateInternal);
 const mockGetTodaysActivities = jest.mocked(mockGetTodaysActivitiesInternal);
@@ -176,7 +173,7 @@ describe('App.js Callback Functions', () => {
         mockLoadActivitiesFromStorage.mockReturnValue([]);
         mockLoadConfig.mockResolvedValue(null);
         mockPutConfig.mockResolvedValue(undefined);
-        mockLoadActivityState.mockResolvedValue([]);
+        mockLoadActivitiesState.mockResolvedValue([]);
         mockGetActivityState.mockReturnValue([]);
         mockRenderActivities.mockClear();
         mockHandleAddActivity.mockClear();

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -393,6 +393,89 @@ describe('App.js Callback Functions', () => {
             expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-42');
         });
 
+        test('activity edit does nothing for cancelled blank or unchanged prompt responses', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityList = document.getElementById('activity-list');
+            activityList.innerHTML = `
+                <article class="activity-card" data-activity-id="activity-43">
+                    <span class="text-sm text-slate-200">Current activity</span>
+                    <button type="button" class="btn-edit-activity">Edit</button>
+                </article>
+            `;
+            const promptSpy = jest
+                .spyOn(window, 'prompt')
+                .mockReturnValueOnce(null)
+                .mockReturnValueOnce('   ')
+                .mockReturnValueOnce('Current activity');
+
+            const editButton = activityList.querySelector('.btn-edit-activity');
+            editButton.dispatchEvent(new Event('click', { bubbles: true }));
+            editButton.dispatchEvent(new Event('click', { bubbles: true }));
+            editButton.dispatchEvent(new Event('click', { bubbles: true }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(promptSpy).toHaveBeenCalledTimes(3);
+            expect(mockHandleEditActivity).not.toHaveBeenCalled();
+            promptSpy.mockRestore();
+        });
+
+        test('activity actions can resolve ids from the ancestor activity element', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityList = document.getElementById('activity-list');
+            activityList.innerHTML = `
+                <article class="activity-card" data-activity-id="activity-44">
+                    <span class="text-sm text-slate-200">Ancestor id activity</span>
+                    <button type="button" class="btn-edit-activity"><span>Edit</span></button>
+                    <button type="button" class="btn-delete-activity"><span>Delete</span></button>
+                </article>
+            `;
+            const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('Changed from ancestor');
+
+            activityList
+                .querySelector('.btn-edit-activity span')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            activityList
+                .querySelector('.btn-delete-activity span')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockHandleEditActivity).toHaveBeenCalledWith('activity-44', {
+                description: 'Changed from ancestor'
+            });
+            expect(mockHandleDeleteActivity).toHaveBeenCalledWith('activity-44');
+            promptSpy.mockRestore();
+        });
+
+        test('invalid activity form submission keeps focus flow and skips add handler', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityRadio = document.getElementById('activity');
+            const descriptionInput = document.querySelector('#task-form input[name="description"]');
+            const addTaskButton = document.getElementById('add-task-btn');
+
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+            descriptionInput.value = '';
+
+            getTaskFormElement().dispatchEvent(
+                new Event('submit', { bubbles: true, cancelable: true })
+            );
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockHandleAddActivity).not.toHaveBeenCalled();
+            expect(document.activeElement).toBe(descriptionInput);
+            expect(activityRadio.checked).toBe(true);
+            expect(addTaskButton.textContent).toContain('Log Activity');
+        });
+
         test('shows and populates the category dropdown with flattened taxonomy options when Activities are enabled', async () => {
             await setupAppWithTasks([]);
             localStorage.setItem('fortudo-activities-enabled', 'true');

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -1158,6 +1158,33 @@ describe('DOM Handler Interaction Tests', () => {
             expect(startTimeInput.hasAttribute('required')).toBe(true);
         });
 
+        test('switching to unscheduled applies the backlog-specific form styling and requirements', () => {
+            const unscheduledRadio = document.getElementById('unscheduled');
+            const timeInputs = document.getElementById('time-inputs');
+            const priorityInput = document.getElementById('priority-input');
+            const startTimeInput = document.querySelector('input[name="start-time"]');
+            const descriptionInput = document.querySelector('input[name="description"]');
+            const durationHoursInput = document.querySelector('input[name="duration-hours"]');
+            const durationMinutesInput = document.querySelector('input[name="duration-minutes"]');
+            const addTaskButton = document.querySelector('#task-form button[type="submit"]');
+
+            if (!(unscheduledRadio instanceof HTMLInputElement)) {
+                throw new Error('Unscheduled radio not found');
+            }
+
+            unscheduledRadio.checked = true;
+            unscheduledRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+            expect(timeInputs.classList.contains('hidden')).toBe(true);
+            expect(priorityInput.classList.contains('hidden')).toBe(false);
+            expect(startTimeInput.hasAttribute('required')).toBe(false);
+            expect(addTaskButton.textContent).toContain('Add Task');
+            expect(descriptionInput.getAttribute('placeholder')).toBe('Describe your task...');
+            expect(descriptionInput.classList.contains('focus:border-indigo-400')).toBe(true);
+            expect(durationHoursInput.classList.contains('focus:border-indigo-400')).toBe(true);
+            expect(durationMinutesInput.classList.contains('focus:border-indigo-400')).toBe(true);
+        });
+
         test('can submit form multiple times in unscheduled mode without validation error', () => {
             // This test ensures the fix for the "invalid form control not focusable" error
             const unscheduledRadio = document.getElementById('unscheduled');

--- a/__tests__/form-utils.test.js
+++ b/__tests__/form-utils.test.js
@@ -213,6 +213,24 @@ describe('Form Utils Tests', () => {
             expect(showAlert).toHaveBeenCalledWith('Invalid task type selected.', 'indigo');
         });
 
+        test('rejects activity mode when extracting task creation data', () => {
+            document.body.innerHTML = `
+                <form id="task-form">
+                    <input type="text" name="description" value="Deep work session" />
+                    <input type="radio" name="task-type" value="activity" checked />
+                    <input type="time" name="start-time" value="10:30" />
+                    <input type="number" name="duration-hours" value="1" />
+                    <input type="number" name="duration-minutes" value="15" />
+                </form>
+            `;
+            const form = document.getElementById('task-form');
+
+            const result = extractTaskFormData(form);
+
+            expect(result).toBeNull();
+            expect(showAlert).toHaveBeenCalledWith('Invalid task type selected.', 'sky');
+        });
+
         test('trims description whitespace', () => {
             const form = createScheduledTaskForm('  Test task  ', '10:30', '1', '0');
             const result = extractTaskFormData(form);

--- a/__tests__/modal-manager.test.js
+++ b/__tests__/modal-manager.test.js
@@ -7,6 +7,7 @@
 describe('Modal Manager Tests', () => {
     let showAlert, askConfirmation, showCustomAlert, showCustomConfirm;
     let hideCustomAlert, hideCustomConfirm, hideScheduleModal, showScheduleModal;
+    let showActivityEditModal, hideActivityEditModal;
     let initializeModalEventListeners;
     let showGapTaskPicker, hideGapTaskPicker;
     let alertSpy, confirmSpy;
@@ -52,6 +53,17 @@ describe('Modal Manager Tests', () => {
                 <button id="close-gap-task-picker-modal">X</button>
                 <button id="cancel-gap-task-picker-modal">Cancel</button>
             </div>
+
+            <!-- Activity Edit Modal -->
+            <div id="activity-edit-modal" class="hidden">
+                <h2 id="activity-edit-title"></h2>
+                <button id="close-activity-edit-modal">X</button>
+                <form id="activity-edit-form">
+                    <input id="activity-edit-description" name="activity-description" type="text" />
+                    <button id="cancel-activity-edit-modal" type="button">Cancel</button>
+                    <button id="save-activity-edit-modal" type="submit">Save</button>
+                </form>
+            </div>
         `;
 
         // Clear module cache and re-import to pick up new DOM
@@ -82,6 +94,8 @@ describe('Modal Manager Tests', () => {
             hideCustomConfirm = module.hideCustomConfirm;
             hideScheduleModal = module.hideScheduleModal;
             showScheduleModal = module.showScheduleModal;
+            showActivityEditModal = module.showActivityEditModal;
+            hideActivityEditModal = module.hideActivityEditModal;
         });
 
         test('showAlert falls back to window.alert when modal not found', () => {
@@ -115,6 +129,17 @@ describe('Modal Manager Tests', () => {
         test('showScheduleModal returns early when form not found', () => {
             expect(() => showScheduleModal('Task', '1h', 'id-1', '10:00')).not.toThrow();
         });
+
+        test('showActivityEditModal falls back to window.prompt when modal not found', async () => {
+            alertSpy.mockRestore();
+            const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('Updated');
+
+            const result = await showActivityEditModal('Current');
+
+            expect(promptSpy).toHaveBeenCalledWith('Edit activity description:', 'Current');
+            expect(result).toBe('Updated');
+            promptSpy.mockRestore();
+        });
     });
 
     describe('with DOM elements', () => {
@@ -131,6 +156,8 @@ describe('Modal Manager Tests', () => {
             hideGapTaskPicker = module.hideGapTaskPicker;
             hideScheduleModal = module.hideScheduleModal;
             showScheduleModal = module.showScheduleModal;
+            showActivityEditModal = module.showActivityEditModal;
+            hideActivityEditModal = module.hideActivityEditModal;
             initializeModalEventListeners = module.initializeModalEventListeners;
         });
 
@@ -309,6 +336,57 @@ describe('Modal Manager Tests', () => {
 
                 const modal = document.getElementById('schedule-modal');
                 expect(modal.classList.contains('hidden')).toBe(true);
+            });
+        });
+
+        describe('Activity Edit Modal', () => {
+            test('showActivityEditModal shows modal with the current description', async () => {
+                const resultPromise = showActivityEditModal('Current activity');
+
+                const modal = document.getElementById('activity-edit-modal');
+                const input = document.getElementById('activity-edit-description');
+
+                expect(modal.classList.contains('hidden')).toBe(false);
+                expect(input.value).toBe('Current activity');
+
+                document.getElementById('cancel-activity-edit-modal').click();
+                await expect(resultPromise).resolves.toBeNull();
+            });
+
+            test('saving activity edit resolves with trimmed input and hides modal', async () => {
+                const resultPromise = showActivityEditModal('Current activity');
+                const form = document.getElementById('activity-edit-form');
+                const input = document.getElementById('activity-edit-description');
+                input.value = '  Updated activity  ';
+
+                form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+                await expect(resultPromise).resolves.toBe('Updated activity');
+                expect(
+                    document.getElementById('activity-edit-modal').classList.contains('hidden')
+                ).toBe(true);
+            });
+
+            test('cancel and close both resolve null', async () => {
+                const cancelPromise = showActivityEditModal('Current activity');
+                document.getElementById('cancel-activity-edit-modal').click();
+                await expect(cancelPromise).resolves.toBeNull();
+
+                const closePromise = showActivityEditModal('Current activity');
+                document.getElementById('close-activity-edit-modal').click();
+                await expect(closePromise).resolves.toBeNull();
+            });
+
+            test('hideActivityEditModal hides the modal', async () => {
+                const resultPromise = showActivityEditModal('Current activity');
+                hideActivityEditModal();
+
+                expect(
+                    document.getElementById('activity-edit-modal').classList.contains('hidden')
+                ).toBe(true);
+
+                document.getElementById('cancel-activity-edit-modal').click();
+                await expect(resultPromise).resolves.toBeNull();
             });
         });
 

--- a/__tests__/settings-renderer.test.js
+++ b/__tests__/settings-renderer.test.js
@@ -96,6 +96,20 @@ async function clickAndWait(element) {
     await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+async function waitForCondition(predicate, { timeoutMs = 1000, intervalMs = 10 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (predicate()) {
+            return;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw new Error('Timed out waiting for expected condition.');
+}
+
 async function openInlineGroupEditor(key) {
     const editButton = document.querySelector(`.btn-edit-group[data-key="${key}"]`);
     await clickAndWait(editButton);
@@ -251,7 +265,10 @@ describe('settings-renderer', () => {
             const toggle = document.getElementById('activities-toggle');
             toggle.checked = true;
             toggle.dispatchEvent(new Event('change'));
-            await new Promise((resolve) => setTimeout(resolve, 25));
+            await waitForCondition(() => {
+                const reloadPrompt = document.getElementById('reload-prompt');
+                return reloadPrompt && !reloadPrompt.classList.contains('hidden');
+            });
 
             const reloadPrompt = document.getElementById('reload-prompt');
             expect(reloadPrompt).not.toBeNull();
@@ -267,7 +284,11 @@ describe('settings-renderer', () => {
 
             toggle.checked = false;
             toggle.dispatchEvent(new Event('change'));
-            await new Promise((resolve) => setTimeout(resolve, 25));
+            await waitForCondition(
+                () =>
+                    taxonomySection.classList.contains('hidden') &&
+                    message.textContent.includes('Activities disabled')
+            );
 
             expect(taxonomySection.classList.contains('hidden')).toBe(true);
             expect(message.textContent).toContain('Activities disabled');
@@ -285,7 +306,7 @@ describe('settings-renderer', () => {
 
             toggle.checked = true;
             toggle.dispatchEvent(new Event('change'));
-            await new Promise((resolve) => setTimeout(resolve, 25));
+            await waitForCondition(() => showToast.mock.calls.length > 0);
 
             expect(toggle.checked).toBe(false);
             expect(taxonomySection.classList.contains('hidden')).toBe(true);

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -131,6 +131,18 @@ function setupDOM() {
         </div>
       </div>
 
+      <div id="activity-edit-modal" class="hidden">
+        <div class="modal-content">
+          <h2 id="activity-edit-title"></h2>
+          <button id="close-activity-edit-modal" type="button">X</button>
+          <form id="activity-edit-form">
+            <input id="activity-edit-description" name="activity-description" type="text" />
+            <button id="cancel-activity-edit-modal" type="button">Cancel</button>
+            <button id="save-activity-edit-modal" type="submit">Save</button>
+          </form>
+        </div>
+      </div>
+
       <div id="settings-modal" class="hidden">
         <div id="settings-content"></div>
         <button id="close-settings-modal" type="button"></button>

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -58,6 +58,10 @@ function setupDOM() {
           <label for="scheduled">Scheduled</label>
           <input type="radio" id="unscheduled" name="task-type" value="unscheduled" />
           <label for="unscheduled">Unscheduled</label>
+          <div id="activity-toggle-option" class="hidden">
+            <input type="radio" id="activity" name="task-type" value="activity" />
+            <label for="activity">Activity</label>
+          </div>
         </div>
         <div id="time-inputs">
           <div class="form-group">
@@ -81,6 +85,9 @@ function setupDOM() {
       <span id="overlap-warning"></span>
       <div id="scheduled-task-list" class="task-list"></div>
       <div id="unscheduled-task-list" class="unscheduled-task-list"></div>
+      <div id="activities-container" class="hidden">
+        <div id="activity-list"></div>
+      </div>
       <button id="clear-schedule-button" class="btn-clear-schedule">Clear Schedule</button>
       <div id="clear-tasks-dropdown" style="display: none;">
         <button id="clear-completed-tasks-option">Clear Completed</button>

--- a/__tests__/time-utils.test.js
+++ b/__tests__/time-utils.test.js
@@ -379,6 +379,10 @@ describe('Time Utility Functions', () => {
             expect(getThemeForTask({ type: 'unscheduled' })).toBe('indigo');
         });
 
+        test('getThemeForTask returns sky for activity task', () => {
+            expect(getThemeForTask({ type: 'activity' })).toBe('sky');
+        });
+
         test('getThemeForTask returns indigo for null task', () => {
             expect(getThemeForTask(null)).toBe('indigo');
         });
@@ -389,6 +393,10 @@ describe('Time Utility Functions', () => {
 
         test('getThemeForTaskType returns indigo for unscheduled type', () => {
             expect(getThemeForTaskType('unscheduled')).toBe('indigo');
+        });
+
+        test('getThemeForTaskType returns sky for activity type', () => {
+            expect(getThemeForTaskType('activity')).toBe('sky');
         });
     });
 });

--- a/__tests__/toast-manager.test.js
+++ b/__tests__/toast-manager.test.js
@@ -51,6 +51,12 @@ describe('toast-manager', () => {
         expect(toast.className).toContain('teal');
     });
 
+    test('showToast accepts the sky theme color', () => {
+        showToast('Sky message', { theme: 'sky' });
+        const toast = getToastContainer().children[0];
+        expect(toast.className).toContain('sky');
+    });
+
     test('multiple toasts stack in the container', () => {
         showToast('First');
         showToast('Second');

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -319,7 +319,7 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 
 ### Phase 4 Design Decisions (resolved)
 
-1. **Activities visible from Phase 4.** A simple chronological list of today's activities renders below the task list. This becomes the "Activity Log" section of Phase 5 Insights, so the renderer work isn't throwaway. Edit/delete on manual entries ships in Phase 4; auto entries show source task link.
+1. **Activities visible from Phase 4.** A simple chronological list of today's activities renders below the task list. This becomes the "Activity Log" section of Phase 5 Insights, so the renderer work isn't throwaway. Edit/delete ships in Phase 4 for both manual and auto-logged activities; auto entries retain visible provenance and `sourceTaskId` metadata as an edited copy of the completed task.
 
 2. **Third form mode routing.** `extractActivityFormData()` lives in `activities/form-utils.js` (separate from tasks). Submit routes through `activities/handlers.js`, not the task `add-handler.js`. `dom-renderer.js` gains a three-way mode toggle but delegates to the appropriate module. Manual activity creation flows through `coordinator.onActivityCreated({ activity })`, keeping the coordinator as the consistent post-mutation boundary.
 
@@ -391,6 +391,14 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 - Wire auto-logging into scheduled task completion via `coordinator.onTaskCompleted`
 - Add `activities/renderer.js` with chronological today's-activities list (edit/delete for manual, source link for auto)
 - Add empty states for activity views
+
+**Phase 4.5: Category editing parity**
+
+- Keep full-field inline editing on activities, including category changes
+- Add category editing to scheduled task inline edit forms
+- Add category editing to unscheduled task inline edit forms
+- Align task and activity edit layouts so category editing no longer exists only on activities
+- Add renderer, form-utils, handler, app, and smoke coverage for task category edit flows
 
 **Phase 5: Insights view**
 

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -17,7 +17,7 @@ Fortudo handles the planning side of daily time management by scheduling tasks i
 ### Fortudo Architecture
 
 - **Storage:** PouchDB with per-room databases (`fortudo-{roomCode}`). Storage now supports typed documents (`task`, `activity`, `config`) in the same room database. Legacy task docs are migrated to `docType: 'task'` during boot-time storage preparation. Task bulk replace is scoped to task documents only. Revision tracking is type-scoped internally. Preview deploys use isolated room/database names so preview testing never touches live room data.
-- **Task schema:** `id`, `type` (`scheduled` / `unscheduled`), `description`, `startDateTime`, `endDateTime`, `duration`, `status`, `locked`, `editing`, `confirmingDelete`, `priority` (unscheduled only), `estDuration` (unscheduled only).
+- **Task schema:** `id`, `type` (`scheduled` / `unscheduled`), `description`, `startDateTime`, `endDateTime`, `duration`, `status`, `locked`, `editing`, `confirmingDelete`, `priority` (unscheduled only), `estDuration` (unscheduled only), `category` (optional, taxonomy key).
 - **ID conventions:** `sched-{timestamp}` for scheduled, `unsched-{timestamp}` for unscheduled.
 - **Module architecture:** `app.js` now focuses on boot, storage wiring, room lifecycle, and top-level event setup. Feature handlers live under `tasks/`. Successful task mutations are reported through `app-coordinator.js` as semantic post-mutation events. Render-time callback threading still exists through `dom-renderer.js`.
 - **Sync:** Bidirectional CouchDB replication via `sync-manager.js` with debounced sync and status callbacks. Room-switch sync handoff is now session-aware so in-flight sync from one room does not mutate the next room.
@@ -139,6 +139,11 @@ export function onTaskDeleted({ task }) { ... }
 export function onScheduledTasksCleared() { ... }
 export function onCompletedTasksCleared() { ... }
 export function onAllTasksCleared() { ... }
+
+// Phase 4 additions:
+export function onActivityCreated({ activity }) { ... }
+export function onActivityEdited({ activity }) { ... }
+export function onActivityDeleted({ activity }) { ... }
 ```
 
 Before:
@@ -197,7 +202,11 @@ public/js/
 |   |-- taxonomy-store.js        # taxonomy load/persist, seeding, normalization
 |   |-- taxonomy-selectors.js    # taxonomy snapshot queries, option helpers, badge rendering
 |   `-- taxonomy-mutations.js    # taxonomy CRUD and task-reference safety checks
-|-- settings-manager.js           # Activities toggle and related settings
+|-- settings/
+|   `-- taxonomy-settings.js     # taxonomy management UI inside settings modal
+|-- category-colors.js            # color family palettes and helpers
+|-- settings-manager.js           # Activities toggle (PouchDB config doc + in-memory cache)
+|-- settings-renderer.js          # settings modal shell, toggle wiring, delegates to taxonomy-settings
 |-- utils.js                      # shared utilities
 `-- config.js                     # CouchDB URL config
 ```
@@ -308,6 +317,18 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 - **Charts:** Hand-rolled HTML/CSS/SVG for v1. If that looks too plain, evaluate either a lightweight library such as uPlot or Frappe Charts, or Chart.js for full interactivity.
 - **Legacy settings migration cleanup:** remove the one-time `fortudo-activities-enabled` migration path after a later release, once it is acceptable to stop supporting users skipping directly from pre-3.9 builds.
 
+### Phase 4 Design Decisions (resolved)
+
+1. **Activities visible from Phase 4.** A simple chronological list of today's activities renders below the task list. This becomes the "Activity Log" section of Phase 5 Insights, so the renderer work isn't throwaway. Edit/delete on manual entries ships in Phase 4; auto entries show source task link.
+
+2. **Third form mode routing.** `extractActivityFormData()` lives in `activities/form-utils.js` (separate from tasks). Submit routes through `activities/handlers.js`, not the task `add-handler.js`. `dom-renderer.js` gains a three-way mode toggle but delegates to the appropriate module. Manual activity creation flows through `coordinator.onActivityCreated({ activity })`, keeping the coordinator as the consistent post-mutation boundary.
+
+3. **Auto-logging: scheduled tasks only.** Unscheduled tasks lack real start/end times; synthesizing timestamps from estimated duration produces misleading plan-vs-actual data. Users who want to track unscheduled work can either schedule it first (giving it real times, then completing auto-logs naturally) or manually log it.
+
+4. **Phase 4 file boundary.** Phase 4 ships: `activities/manager.js`, `activities/handlers.js`, `activities/form-utils.js`, `activities/renderer.js`. Phase 5 ships: `activities/insights-renderer.js`.
+
+5. **`isActivitiesEnabled()` stays synchronous.** Boot-time `loadSettings()` populates an in-memory cache from the PouchDB config doc. `isActivitiesEnabled()` remains a synchronous read. Same pattern as `loadTaxonomy()`. No call sites become async.
+
 ## Implementation Phases
 
 ### Completed Foundation Work
@@ -363,9 +384,12 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 
 **Phase 4: Activity logging**
 
-- Add `activities/manager.js` with CRUD and `createActivityFromTask`
-- Add third form mode ("Activity") on the main task form
-- Wire auto-logging into task completion via the coordinator
+- Add `activities/manager.js` with CRUD and `createActivityFromTask` (scheduled tasks only)
+- Add `activities/form-utils.js` for activity form extraction (separate from task form-utils)
+- Add `activities/handlers.js` with submit handler routing through `coordinator.onActivityCreated`
+- Add third form mode ("Activity") on the main task form via three-way toggle in `dom-renderer.js`
+- Wire auto-logging into scheduled task completion via `coordinator.onTaskCompleted`
+- Add `activities/renderer.js` with chronological today's-activities list (edit/delete for manual, source link for auto)
 - Add empty states for activity views
 
 **Phase 5: Insights view**

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -392,7 +392,7 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 - Add `activities/renderer.js` with chronological today's-activities list (edit/delete for manual, source link for auto)
 - Add empty states for activity views
 
-**Phase 4.5: Category editing parity**
+**Phase 4.7: Category editing parity**
 
 - Keep full-field inline editing on activities, including category changes
 - Add category editing to scheduled task inline edit forms

--- a/docs/plans/2026-04-07-fortudo-activities-phase4.md
+++ b/docs/plans/2026-04-07-fortudo-activities-phase4.md
@@ -1,0 +1,1773 @@
+# Phase 4: Activity Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add activity logging to Fortudo: an activity manager with CRUD and auto-logging from scheduled task completion, a third "Activity" form mode, an activity renderer showing today's log, and coordinator wiring for activity events.
+
+**Architecture:** Activities are PouchDB documents (`docType: 'activity'`) using the existing `putActivity`/`loadActivities`/`deleteActivity` storage primitives shipped in Phase 2. The activity manager owns in-memory state and CRUD. Auto-logging fires as fire-and-forget async work inside the synchronous `onTaskCompleted` coordinator event. A three-way form toggle (scheduled/unscheduled/activity) routes submission to either `tasks/add-handler.js` or `activities/handlers.js`. The activity list renders below the unscheduled task list, gated by `isActivitiesEnabled()`. The entire activity UI container is hidden when Activities are disabled in settings.
+
+**Tech Stack:** Vanilla JS ES modules, PouchDB (memory adapter in tests), Jest 30, Tailwind CSS
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `public/js/activities/manager.js` | Activity state management, CRUD, `createActivityFromTask` |
+| Create | `public/js/activities/form-utils.js` | Activity form data extraction and validation |
+| Create | `public/js/activities/handlers.js` | Activity add/edit/delete handler functions |
+| Create | `public/js/activities/renderer.js` | Renders chronological activity list for today |
+| Create | `__tests__/activity-manager.test.js` | Tests for activity manager CRUD + auto-logging |
+| Create | `__tests__/activity-form-utils.test.js` | Tests for activity form extraction |
+| Create | `__tests__/activity-handlers.test.js` | Tests for activity handlers |
+| Create | `__tests__/activity-renderer.test.js` | Tests for activity list rendering |
+| Modify | `public/js/app-coordinator.js` | Add `onActivityCreated`, `onActivityEdited`, `onActivityDeleted` + auto-logging in `onTaskCompleted` |
+| Modify | `__tests__/app-coordinator.test.js` | Test new activity events + auto-logging |
+| Modify | `public/js/utils.js` | Add `'activity'` branch to `getThemeForTaskType` and `getThemeForTask` |
+| Modify | `public/js/toast-manager.js` | Add `sky` theme to `THEME_CLASSES` |
+| Modify | `public/index.html` | Add Activity radio option, activity list container |
+| Modify | `public/js/dom-renderer.js` | Three-way form toggle, activity list event delegation |
+| Modify | `public/js/tasks/form-utils.js` | Guard `extractTaskFormData` against `'activity'` task-type |
+| Modify | `public/js/app.js` | Boot wiring: load activities, activity form routing, activity event listeners, show/hide activity UI |
+| Modify | `__tests__/test-utils.js` | Add activity radio + activity list container to `setupDOM` |
+
+---
+
+## Chunk 1: Activity Manager + Coordinator Wiring
+
+### Task 1: Activity manager — failing tests for core CRUD
+
+**Files:**
+- Create: `__tests__/activity-manager.test.js`
+
+- [ ] **Step 1: Write failing tests for addActivity, getActivityState, getActivityById, getTodaysActivities**
+
+```js
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/storage.js', () => ({
+    putActivity: jest.fn(() => Promise.resolve()),
+    loadActivities: jest.fn(() => Promise.resolve([])),
+    deleteActivity: jest.fn(() => Promise.resolve())
+}));
+
+import {
+    addActivity,
+    getActivityState,
+    getActivityById,
+    getTodaysActivities,
+    loadActivitiesState,
+    removeActivity,
+    editActivity,
+    resetActivityState
+} from '../public/js/activities/manager.js';
+import { putActivity, loadActivities, deleteActivity } from '../public/js/storage.js';
+
+describe('activity manager', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+    });
+
+    describe('addActivity', () => {
+        test('creates activity with generated id and stores it', async () => {
+            const data = {
+                description: 'Deep work session',
+                category: 'work/deep',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            };
+
+            const result = await addActivity(data);
+
+            expect(result.success).toBe(true);
+            expect(result.activity.id).toMatch(/^activity-/);
+            expect(result.activity.description).toBe('Deep work session');
+            expect(result.activity.docType).toBe('activity');
+            expect(putActivity).toHaveBeenCalledWith(result.activity);
+            expect(getActivityState()).toContain(result.activity);
+        });
+
+        test('rejects activity with empty description', async () => {
+            const data = {
+                description: '',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            };
+
+            const result = await addActivity(data);
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/description/i);
+            expect(putActivity).not.toHaveBeenCalled();
+        });
+
+        test('rejects activity with zero duration', async () => {
+            const data = {
+                description: 'Test',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:00:00.000Z',
+                duration: 0,
+                source: 'manual',
+                sourceTaskId: null
+            };
+
+            const result = await addActivity(data);
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/duration/i);
+        });
+    });
+
+    describe('getActivityById', () => {
+        test('returns activity when found', async () => {
+            const { activity } = await addActivity({
+                description: 'Test',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            expect(getActivityById(activity.id)).toBe(activity);
+        });
+
+        test('returns null when not found', () => {
+            expect(getActivityById('activity-nonexistent')).toBeNull();
+        });
+    });
+
+    describe('getTodaysActivities', () => {
+        test('returns only activities from today sorted by start time', async () => {
+            const today = new Date();
+            const todayISO = today.toISOString().slice(0, 10);
+            const yesterdayDate = new Date(today);
+            yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+            const yesterdayISO = yesterdayDate.toISOString().slice(0, 10);
+
+            await addActivity({
+                description: 'Yesterday',
+                startDateTime: `${yesterdayISO}T09:00:00.000Z`,
+                endDateTime: `${yesterdayISO}T10:00:00.000Z`,
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            await addActivity({
+                description: 'Today later',
+                startDateTime: `${todayISO}T14:00:00.000Z`,
+                endDateTime: `${todayISO}T15:00:00.000Z`,
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            await addActivity({
+                description: 'Today earlier',
+                startDateTime: `${todayISO}T09:00:00.000Z`,
+                endDateTime: `${todayISO}T10:00:00.000Z`,
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const todays = getTodaysActivities();
+            expect(todays).toHaveLength(2);
+            expect(todays[0].description).toBe('Today earlier');
+            expect(todays[1].description).toBe('Today later');
+        });
+    });
+
+    describe('removeActivity', () => {
+        test('removes activity from state and storage', async () => {
+            const { activity } = await addActivity({
+                description: 'To remove',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await removeActivity(activity.id);
+
+            expect(result.success).toBe(true);
+            expect(deleteActivity).toHaveBeenCalledWith(activity.id);
+            expect(getActivityById(activity.id)).toBeNull();
+        });
+
+        test('returns failure for nonexistent activity', async () => {
+            const result = await removeActivity('activity-fake');
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe('editActivity', () => {
+        test('updates editable fields and persists', async () => {
+            const { activity } = await addActivity({
+                description: 'Original',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            });
+
+            const result = await editActivity(activity.id, {
+                description: 'Updated',
+                duration: 90
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.activity.description).toBe('Updated');
+            expect(result.activity.duration).toBe(90);
+            expect(putActivity).toHaveBeenCalled();
+        });
+
+        test('rejects edit of auto-logged activity', async () => {
+            const { activity } = await addActivity({
+                description: 'Auto',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'auto',
+                sourceTaskId: 'sched-123'
+            });
+
+            const result = await editActivity(activity.id, { description: 'Changed' });
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toMatch(/auto/i);
+        });
+    });
+
+    describe('loadActivitiesState', () => {
+        test('populates state from storage', async () => {
+            loadActivities.mockResolvedValueOnce([
+                {
+                    id: 'activity-1',
+                    docType: 'activity',
+                    description: 'Stored',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ]);
+
+            await loadActivitiesState();
+
+            expect(getActivityState()).toHaveLength(1);
+            expect(getActivityState()[0].description).toBe('Stored');
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-manager.test.js --no-coverage 2>&1 | tail -5`
+Expected: FAIL — cannot find module `../public/js/activities/manager.js`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/activity-manager.test.js
+git commit -m "test: add failing tests for activity manager CRUD"
+```
+
+### Task 2: Activity manager — implementation
+
+**Files:**
+- Create: `public/js/activities/manager.js`
+
+- [ ] **Step 1: Implement the activity manager**
+
+```js
+import { putActivity, loadActivities, deleteActivity } from '../storage.js';
+import { logger } from '../utils.js';
+
+/** @type {Array} */
+let activities = [];
+
+export function resetActivityState() {
+    activities = [];
+}
+
+export function getActivityState() {
+    return activities;
+}
+
+export function getActivityById(id) {
+    return activities.find((a) => a.id === id) || null;
+}
+
+export function getTodaysActivities(now = new Date()) {
+    const todayStr = now.toISOString().slice(0, 10);
+    return activities
+        .filter((a) => a.startDateTime && a.startDateTime.slice(0, 10) === todayStr)
+        .sort((a, b) => new Date(a.startDateTime) - new Date(b.startDateTime));
+}
+
+export async function loadActivitiesState() {
+    activities = await loadActivities();
+}
+
+export async function addActivity(data) {
+    if (!data.description || data.description.trim() === '') {
+        return { success: false, reason: 'Activity description is required.' };
+    }
+
+    if (!data.duration || data.duration <= 0) {
+        return { success: false, reason: 'Activity duration must be greater than 0.' };
+    }
+
+    if (!data.startDateTime || !data.endDateTime) {
+        return { success: false, reason: 'Activity start and end times are required.' };
+    }
+
+    const activity = {
+        id: `activity-${Date.now()}`,
+        docType: 'activity',
+        description: data.description.trim(),
+        category: data.category || null,
+        startDateTime: data.startDateTime,
+        endDateTime: data.endDateTime,
+        duration: data.duration,
+        source: data.source || 'manual',
+        sourceTaskId: data.sourceTaskId || null
+    };
+
+    await putActivity(activity);
+    activities.push(activity);
+
+    return { success: true, activity };
+}
+
+export async function removeActivity(id) {
+    const index = activities.findIndex((a) => a.id === id);
+    if (index === -1) {
+        return { success: false, reason: 'Activity not found.' };
+    }
+
+    const activity = activities[index];
+    await deleteActivity(id);
+    activities.splice(index, 1);
+
+    return { success: true, activity };
+}
+
+export async function editActivity(id, updates) {
+    const activity = getActivityById(id);
+    if (!activity) {
+        return { success: false, reason: 'Activity not found.' };
+    }
+
+    if (activity.source === 'auto') {
+        return { success: false, reason: 'Auto-logged activities cannot be edited.' };
+    }
+
+    const editableFields = ['description', 'category', 'startDateTime', 'endDateTime', 'duration'];
+    for (const field of editableFields) {
+        if (Object.prototype.hasOwnProperty.call(updates, field)) {
+            activity[field] = updates[field];
+        }
+    }
+
+    await putActivity(activity);
+
+    return { success: true, activity };
+}
+
+export function createActivityFromTask(task) {
+    return {
+        description: task.description,
+        category: task.category || null,
+        startDateTime: task.startDateTime,
+        endDateTime: task.endDateTime,
+        duration: task.duration,
+        source: 'auto',
+        sourceTaskId: task.id
+    };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-manager.test.js --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/activities/manager.js
+git commit -m "feat: add activity manager with CRUD and createActivityFromTask"
+```
+
+### Task 3: Coordinator activity events + auto-logging — failing tests
+
+**Files:**
+- Modify: `__tests__/app-coordinator.test.js`
+
+- [ ] **Step 1: Add failing tests for activity events and auto-logging**
+
+Add these tests to the existing `describe('app-coordinator', ...)` block:
+
+```js
+// Add to the existing mock block at the top:
+jest.mock('../public/js/activities/manager.js', () => ({
+    addActivity: jest.fn(() => Promise.resolve({ success: true, activity: {} })),
+    createActivityFromTask: jest.fn((task) => ({
+        description: task.description,
+        startDateTime: task.startDateTime,
+        endDateTime: task.endDateTime,
+        duration: task.duration,
+        category: task.category || null,
+        source: 'auto',
+        sourceTaskId: task.id
+    })),
+    getTodaysActivities: jest.fn(() => [])
+}));
+
+jest.mock('../public/js/settings-manager.js', () => ({
+    isActivitiesEnabled: jest.fn(() => false)
+}));
+
+// Add imports:
+import { addActivity, createActivityFromTask } from '../public/js/activities/manager.js';
+import { isActivitiesEnabled } from '../public/js/settings-manager.js';
+
+// Add these test cases inside describe('app-coordinator'):
+
+test('onActivityCreated refreshes UI', () => {
+    appCoordinator.onActivityCreated({
+        activity: { id: 'activity-1', description: 'Test' }
+    });
+    expect(refreshUI).toHaveBeenCalledTimes(1);
+});
+
+test('onActivityEdited refreshes UI', () => {
+    appCoordinator.onActivityEdited({
+        activity: { id: 'activity-1', description: 'Test' }
+    });
+    expect(refreshUI).toHaveBeenCalledTimes(1);
+});
+
+test('onActivityDeleted refreshes UI', () => {
+    appCoordinator.onActivityDeleted({
+        activity: { id: 'activity-1', description: 'Test' }
+    });
+    expect(refreshUI).toHaveBeenCalledTimes(1);
+});
+
+test('onActivityCreated does nothing when activity is null', () => {
+    appCoordinator.onActivityCreated({ activity: null });
+    expect(refreshUI).not.toHaveBeenCalled();
+});
+
+test('onTaskCompleted auto-logs when activities are enabled and task is scheduled', () => {
+    isActivitiesEnabled.mockReturnValue(true);
+    const task = {
+        id: 'sched-123',
+        type: 'scheduled',
+        description: 'Standup',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T09:30:00.000Z',
+        duration: 30,
+        category: 'work/meetings'
+    };
+
+    appCoordinator.onTaskCompleted({ task });
+
+    expect(createActivityFromTask).toHaveBeenCalledWith(task);
+    expect(addActivity).toHaveBeenCalled();
+});
+
+test('onTaskCompleted does not auto-log when activities are disabled', () => {
+    isActivitiesEnabled.mockReturnValue(false);
+    const task = { id: 'sched-456', type: 'scheduled' };
+
+    appCoordinator.onTaskCompleted({ task });
+
+    expect(createActivityFromTask).not.toHaveBeenCalled();
+    expect(addActivity).not.toHaveBeenCalled();
+});
+
+test('onTaskCompleted does not auto-log unscheduled tasks even when activities enabled', () => {
+    isActivitiesEnabled.mockReturnValue(true);
+    const task = { id: 'unsched-789', type: 'unscheduled' };
+
+    appCoordinator.onTaskCompleted({ task });
+
+    expect(createActivityFromTask).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run tests to verify new tests fail**
+
+Run: `npx jest __tests__/app-coordinator.test.js --no-coverage 2>&1 | tail -10`
+Expected: FAIL — `onActivityCreated` is not a function, auto-logging assertions fail
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/app-coordinator.test.js
+git commit -m "test: add failing tests for coordinator activity events and auto-logging"
+```
+
+### Task 4: Coordinator activity events + auto-logging — implementation
+
+**Files:**
+- Modify: `public/js/app-coordinator.js`
+
+- [ ] **Step 1: Add activity events and auto-logging to the coordinator**
+
+Add imports at the top of `app-coordinator.js`:
+
+```js
+import { isActivitiesEnabled } from './settings-manager.js';
+import { addActivity, createActivityFromTask } from './activities/manager.js';
+```
+
+Add new event functions after the existing task events:
+
+```js
+// --- Activity Events ---
+
+export function onActivityCreated({ activity }) {
+    if (!activity) {
+        return;
+    }
+    refreshUI();
+}
+
+export function onActivityEdited({ activity }) {
+    if (!activity) {
+        return;
+    }
+    refreshUI();
+}
+
+export function onActivityDeleted({ activity }) {
+    if (!activity) {
+        return;
+    }
+    refreshUI();
+}
+```
+
+Modify the existing `onTaskCompleted` to add auto-logging. Replace the entire function:
+
+```js
+export function onTaskCompleted({ task }) {
+    if (!task) {
+        return;
+    }
+    refreshUI();
+    if (task.type === 'scheduled') {
+        triggerConfettiAnimation(task.id);
+
+        // Auto-log activity (fire-and-forget)
+        if (isActivitiesEnabled()) {
+            const activityData = createActivityFromTask(task);
+            addActivity(activityData).catch((err) => {
+                logger.warn('Auto-logging activity failed:', err);
+            });
+        }
+    }
+}
+```
+
+Add the `logger` import to the existing import from `./utils.js` (if not already present — check existing imports first):
+
+```js
+import { logger } from './utils.js';
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx jest __tests__/app-coordinator.test.js --no-coverage`
+Expected: All tests PASS (both old and new)
+
+- [ ] **Step 3: Run full test suite to check for regressions**
+
+Run: `npx jest --no-coverage 2>&1 | tail -10`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/app-coordinator.js
+git commit -m "feat: add coordinator activity events and auto-logging on task completion"
+```
+
+---
+
+## Chunk 2: Theme + Utility Updates
+
+### Task 5: Add sky theme to toast-manager and activity theme mapping
+
+**Files:**
+- Modify: `public/js/toast-manager.js`
+- Modify: `public/js/utils.js`
+
+- [ ] **Step 1: Add sky theme to THEME_CLASSES in toast-manager.js**
+
+In `public/js/toast-manager.js`, add `sky` to the `THEME_CLASSES` object:
+
+```js
+const THEME_CLASSES = {
+    teal: 'bg-teal-900/90 border-teal-700 text-teal-200',
+    indigo: 'bg-indigo-900/90 border-indigo-700 text-indigo-200',
+    sky: 'bg-sky-900/90 border-sky-700 text-sky-200',
+    amber: 'bg-amber-900/90 border-amber-700 text-amber-200',
+    rose: 'bg-rose-900/90 border-rose-700 text-rose-200',
+    default: 'bg-slate-800/90 border-slate-600 text-slate-200'
+};
+```
+
+- [ ] **Step 2: Update getThemeForTaskType and getThemeForTask in utils.js**
+
+In `public/js/utils.js`, update both functions:
+
+```js
+export function getThemeForTask(task) {
+    if (task?.type === 'activity' || task?.docType === 'activity') return 'sky';
+    return task?.type === 'scheduled' ? 'teal' : 'indigo';
+}
+
+export function getThemeForTaskType(taskType) {
+    if (taskType === 'activity') return 'sky';
+    return taskType === 'scheduled' ? 'teal' : 'indigo';
+}
+```
+
+- [ ] **Step 3: Run existing tests to check for regressions**
+
+Run: `npx jest --no-coverage 2>&1 | tail -5`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/toast-manager.js public/js/utils.js
+git commit -m "feat: add sky theme for activities and update theme helpers"
+```
+
+---
+
+## Chunk 3: Activity Form
+
+### Task 6: Activity form-utils — failing tests
+
+**Files:**
+- Create: `__tests__/activity-form-utils.test.js`
+
+- [ ] **Step 1: Write failing tests for extractActivityFormData**
+
+```js
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn()
+}));
+
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    resolveCategoryKey: jest.fn((key) => (key ? { kind: 'category', record: { key } } : null))
+}));
+
+import { extractActivityFormData } from '../public/js/activities/form-utils.js';
+import { showAlert } from '../public/js/modal-manager.js';
+
+describe('extractActivityFormData', () => {
+    let formElement;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = `
+            <form id="task-form">
+                <input type="text" name="description" value="Deep work" />
+                <input type="radio" name="task-type" value="activity" checked />
+                <select name="category" id="category-select">
+                    <option value="">No category</option>
+                    <option value="work/deep" selected>Deep Work</option>
+                </select>
+                <input type="time" name="start-time" value="09:00" />
+                <input type="number" name="duration-hours" value="1" />
+                <input type="number" name="duration-minutes" value="30" />
+            </form>
+        `;
+        formElement = document.getElementById('task-form');
+    });
+
+    test('extracts valid activity form data', () => {
+        const result = extractActivityFormData(formElement);
+
+        expect(result).not.toBeNull();
+        expect(result.description).toBe('Deep work');
+        expect(result.category).toBe('work/deep');
+        expect(result.startTime).toBe('09:00');
+        expect(result.duration).toBe(90);
+    });
+
+    test('returns null and alerts for empty description', () => {
+        formElement.querySelector('input[name="description"]').value = '';
+
+        const result = extractActivityFormData(formElement);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith(
+            expect.stringMatching(/description/i),
+            'sky'
+        );
+    });
+
+    test('returns null and alerts for missing start time', () => {
+        formElement.querySelector('input[name="start-time"]').value = '';
+
+        const result = extractActivityFormData(formElement);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith(
+            expect.stringMatching(/start time/i),
+            'sky'
+        );
+    });
+
+    test('returns null and alerts for zero duration', () => {
+        formElement.querySelector('input[name="duration-hours"]').value = '0';
+        formElement.querySelector('input[name="duration-minutes"]').value = '0';
+
+        const result = extractActivityFormData(formElement);
+
+        expect(result).toBeNull();
+        expect(showAlert).toHaveBeenCalledWith(
+            expect.stringMatching(/duration/i),
+            'sky'
+        );
+    });
+
+    test('returns null category when none selected', () => {
+        formElement.querySelector('#category-select').value = '';
+
+        const result = extractActivityFormData(formElement);
+
+        expect(result).not.toBeNull();
+        expect(result.category).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-form-utils.test.js --no-coverage 2>&1 | tail -5`
+Expected: FAIL — cannot find module `../public/js/activities/form-utils.js`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/activity-form-utils.test.js
+git commit -m "test: add failing tests for activity form-utils"
+```
+
+### Task 7: Activity form-utils — implementation
+
+**Files:**
+- Create: `public/js/activities/form-utils.js`
+
+- [ ] **Step 1: Implement extractActivityFormData**
+
+```js
+import { parseDuration } from '../utils.js';
+import { showAlert } from '../modal-manager.js';
+import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
+
+export function extractActivityFormData(formElement) {
+    const formData = new FormData(formElement);
+    const description = formData.get('description')?.toString().trim();
+
+    if (!description) {
+        showAlert('Activity description cannot be empty.', 'sky');
+        return null;
+    }
+
+    const startTime = formData.get('start-time')?.toString();
+    if (!startTime) {
+        showAlert('Start time is required for activities.', 'sky');
+        return null;
+    }
+
+    const durationResult = parseDuration(
+        formData.get('duration-hours')?.toString() || '0',
+        formData.get('duration-minutes')?.toString() || '0'
+    );
+
+    if (!durationResult.valid) {
+        showAlert(durationResult.error, 'sky');
+        return null;
+    }
+
+    if (durationResult.duration <= 0) {
+        showAlert('Duration must be greater than 0.', 'sky');
+        return null;
+    }
+
+    const categoryKey = formData.get('category')?.toString() || null;
+    let category = null;
+    if (categoryKey) {
+        if (!resolveCategoryKey(categoryKey)) {
+            showAlert('Selected category is no longer available.', 'sky');
+            return null;
+        }
+        category = categoryKey;
+    }
+
+    return {
+        description,
+        category,
+        startTime,
+        duration: durationResult.duration
+    };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-form-utils.test.js --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/activities/form-utils.js
+git commit -m "feat: add activity form-utils with extractActivityFormData"
+```
+
+### Task 8: Guard task form-utils against activity type
+
+**Files:**
+- Modify: `public/js/tasks/form-utils.js`
+
+- [ ] **Step 1: Add guard in extractTaskFormData for activity task-type**
+
+In `public/js/tasks/form-utils.js`, in the `extractTaskFormData` function, change the final `else` branch. Currently:
+
+```js
+    } else {
+        showAlert('Invalid task type selected.', 'indigo');
+        return null;
+    }
+```
+
+Replace with:
+
+```js
+    } else if (taskType === 'activity') {
+        // Activity form data is handled by activities/form-utils.js
+        return null;
+    } else {
+        showAlert('Invalid task type selected.', 'indigo');
+        return null;
+    }
+```
+
+- [ ] **Step 2: Run existing form-utils tests to check for regressions**
+
+Run: `npx jest __tests__/form-utils.test.js --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/tasks/form-utils.js
+git commit -m "fix: guard task form-utils against activity task-type"
+```
+
+---
+
+## Chunk 4: Activity Handlers
+
+### Task 9: Activity handlers — failing tests
+
+**Files:**
+- Create: `__tests__/activity-handlers.test.js`
+
+- [ ] **Step 1: Write failing tests for handleAddActivity, handleDeleteActivity, handleEditActivity**
+
+```js
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/storage.js', () => ({
+    putActivity: jest.fn(() => Promise.resolve()),
+    loadActivities: jest.fn(() => Promise.resolve([])),
+    deleteActivity: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('../public/js/activities/manager.js', () => ({
+    addActivity: jest.fn(() =>
+        Promise.resolve({ success: true, activity: { id: 'activity-1', description: 'Test' } })
+    ),
+    removeActivity: jest.fn(() =>
+        Promise.resolve({ success: true, activity: { id: 'activity-1' } })
+    ),
+    editActivity: jest.fn(() =>
+        Promise.resolve({
+            success: true,
+            activity: { id: 'activity-1', description: 'Updated' }
+        })
+    ),
+    getActivityById: jest.fn(() => ({
+        id: 'activity-1',
+        description: 'Test',
+        source: 'manual'
+    }))
+}));
+
+jest.mock('../public/js/app-coordinator.js', () => ({
+    onActivityCreated: jest.fn(),
+    onActivityEdited: jest.fn(),
+    onActivityDeleted: jest.fn()
+}));
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn(),
+    askConfirmation: jest.fn(() => Promise.resolve(true))
+}));
+
+jest.mock('../public/js/toast-manager.js', () => ({
+    showToast: jest.fn()
+}));
+
+jest.mock('../public/js/dom-renderer.js', () => ({
+    refreshUI: jest.fn(),
+    initializeTaskTypeToggle: jest.fn()
+}));
+
+jest.mock('../public/js/tasks/form-utils.js', () => ({
+    focusTaskDescriptionInput: jest.fn(),
+    resetTaskFormPreviewState: jest.fn()
+}));
+
+import {
+    handleAddActivity,
+    handleDeleteActivity,
+    handleEditActivity
+} from '../public/js/activities/handlers.js';
+import { addActivity, removeActivity, editActivity } from '../public/js/activities/manager.js';
+import {
+    onActivityCreated,
+    onActivityEdited,
+    onActivityDeleted
+} from '../public/js/app-coordinator.js';
+import { showToast } from '../public/js/toast-manager.js';
+import { showAlert } from '../public/js/modal-manager.js';
+
+describe('activity handlers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('handleAddActivity', () => {
+        test('adds activity and calls onActivityCreated on success', async () => {
+            const activityData = {
+                description: 'Deep work',
+                category: 'work/deep',
+                startTime: '09:00',
+                duration: 60
+            };
+
+            await handleAddActivity(activityData);
+
+            expect(addActivity).toHaveBeenCalled();
+            expect(onActivityCreated).toHaveBeenCalled();
+            expect(showToast).toHaveBeenCalledWith(
+                expect.stringMatching(/logged/i),
+                expect.objectContaining({ theme: 'sky' })
+            );
+        });
+
+        test('shows alert on failure', async () => {
+            addActivity.mockResolvedValueOnce({
+                success: false,
+                reason: 'Description is required.'
+            });
+
+            await handleAddActivity({ description: '', startTime: '09:00', duration: 60 });
+
+            expect(onActivityCreated).not.toHaveBeenCalled();
+            expect(showAlert).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleDeleteActivity', () => {
+        test('removes activity and calls onActivityDeleted', async () => {
+            await handleDeleteActivity('activity-1');
+
+            expect(removeActivity).toHaveBeenCalledWith('activity-1');
+            expect(onActivityDeleted).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleEditActivity', () => {
+        test('edits activity and calls onActivityEdited', async () => {
+            await handleEditActivity('activity-1', { description: 'Updated' });
+
+            expect(editActivity).toHaveBeenCalledWith('activity-1', { description: 'Updated' });
+            expect(onActivityEdited).toHaveBeenCalled();
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-handlers.test.js --no-coverage 2>&1 | tail -5`
+Expected: FAIL — cannot find module `../public/js/activities/handlers.js`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/activity-handlers.test.js
+git commit -m "test: add failing tests for activity handlers"
+```
+
+### Task 10: Activity handlers — implementation
+
+**Files:**
+- Create: `public/js/activities/handlers.js`
+
+- [ ] **Step 1: Implement activity handlers**
+
+```js
+import { addActivity, removeActivity, editActivity, getActivityById } from './manager.js';
+import {
+    onActivityCreated,
+    onActivityEdited,
+    onActivityDeleted
+} from '../app-coordinator.js';
+import { showAlert } from '../modal-manager.js';
+import { showToast } from '../toast-manager.js';
+import { timeToDateTime, calculateEndDateTime, logger } from '../utils.js';
+
+export async function handleAddActivity(activityData) {
+    const startDateTime = timeToDateTime(activityData.startTime);
+    const endDateTime = calculateEndDateTime(startDateTime, activityData.duration);
+
+    const result = await addActivity({
+        description: activityData.description,
+        category: activityData.category || null,
+        startDateTime,
+        endDateTime,
+        duration: activityData.duration,
+        source: 'manual',
+        sourceTaskId: null
+    });
+
+    if (result.success) {
+        onActivityCreated({ activity: result.activity });
+        showToast('Activity logged.', { theme: 'sky' });
+    } else {
+        showAlert(result.reason, 'sky');
+    }
+}
+
+export async function handleDeleteActivity(activityId) {
+    const activity = getActivityById(activityId);
+    if (!activity) {
+        logger.warn('handleDeleteActivity: activity not found', activityId);
+        return;
+    }
+
+    const result = await removeActivity(activityId);
+    if (result.success) {
+        onActivityDeleted({ activity: result.activity });
+        showToast('Activity removed.', { theme: 'sky' });
+    } else {
+        showAlert(result.reason, 'sky');
+    }
+}
+
+export async function handleEditActivity(activityId, updates) {
+    const result = await editActivity(activityId, updates);
+    if (result.success) {
+        onActivityEdited({ activity: result.activity });
+    } else {
+        showAlert(result.reason, 'sky');
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-handlers.test.js --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/activities/handlers.js
+git commit -m "feat: add activity handlers for add, delete, edit"
+```
+
+---
+
+## Chunk 5: Activity Renderer
+
+### Task 11: Activity renderer — failing tests
+
+**Files:**
+- Create: `__tests__/activity-renderer.test.js`
+
+- [ ] **Step 1: Write failing tests for renderActivities**
+
+```js
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    renderCategoryBadge: jest.fn((key) =>
+        key ? `<span class="category-badge">${key}</span>` : ''
+    )
+}));
+
+import { renderActivities } from '../public/js/activities/renderer.js';
+
+describe('activity renderer', () => {
+    let container;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = '<div id="activity-list"></div>';
+        container = document.getElementById('activity-list');
+    });
+
+    test('renders empty state when no activities', () => {
+        renderActivities([], container);
+
+        expect(container.innerHTML).toContain('No activities');
+    });
+
+    test('renders activity with description and time range', () => {
+        const activities = [
+            {
+                id: 'activity-1',
+                description: 'Deep work',
+                category: 'work/deep',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            }
+        ];
+
+        renderActivities(activities, container);
+
+        expect(container.innerHTML).toContain('Deep work');
+        expect(container.innerHTML).toContain('1h');
+        expect(container.querySelectorAll('[data-activity-id]')).toHaveLength(1);
+    });
+
+    test('renders edit and delete buttons for manual activities', () => {
+        const activities = [
+            {
+                id: 'activity-1',
+                description: 'Manual',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            }
+        ];
+
+        renderActivities(activities, container);
+
+        expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
+        expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
+    });
+
+    test('renders source task link for auto-logged activities instead of edit/delete', () => {
+        const activities = [
+            {
+                id: 'activity-2',
+                description: 'Auto standup',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:30:00.000Z',
+                duration: 30,
+                source: 'auto',
+                sourceTaskId: 'sched-123'
+            }
+        ];
+
+        renderActivities(activities, container);
+
+        expect(container.querySelector('.btn-edit-activity')).toBeNull();
+        expect(container.querySelector('.btn-delete-activity')).toBeNull();
+        const sourceLink = container.querySelector('.activity-source-link');
+        expect(sourceLink).not.toBeNull();
+        expect(sourceLink.dataset.sourceTaskId).toBe('sched-123');
+    });
+
+    test('renders category badge when category is present', () => {
+        const activities = [
+            {
+                id: 'activity-3',
+                description: 'Categorized',
+                category: 'work/deep',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            }
+        ];
+
+        renderActivities(activities, container);
+
+        expect(container.innerHTML).toContain('category-badge');
+    });
+
+    test('omits category badge when category is null', () => {
+        const activities = [
+            {
+                id: 'activity-4',
+                description: 'No category',
+                category: null,
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T10:00:00.000Z',
+                duration: 60,
+                source: 'manual',
+                sourceTaskId: null
+            }
+        ];
+
+        renderActivities(activities, container);
+
+        expect(container.innerHTML).not.toContain('category-badge');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-renderer.test.js --no-coverage 2>&1 | tail -5`
+Expected: FAIL — cannot find module `../public/js/activities/renderer.js`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/activity-renderer.test.js
+git commit -m "test: add failing tests for activity renderer"
+```
+
+### Task 12: Activity renderer — implementation
+
+**Files:**
+- Create: `public/js/activities/renderer.js`
+
+- [ ] **Step 1: Implement renderActivities**
+
+```js
+import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
+import { calculateHoursAndMinutes, extractTimeFromDateTime, convertTo12HourTime } from '../utils.js';
+
+function formatTimeRange(startDateTime, endDateTime) {
+    const startTime = extractTimeFromDateTime(new Date(startDateTime));
+    const endTime = extractTimeFromDateTime(new Date(endDateTime));
+    return `${convertTo12HourTime(startTime)} – ${convertTo12HourTime(endTime)}`;
+}
+
+function renderActivityItem(activity) {
+    const timeRange = formatTimeRange(activity.startDateTime, activity.endDateTime);
+    const durationText = calculateHoursAndMinutes(activity.duration);
+    const badge = renderCategoryBadge(activity.category);
+    const isAuto = activity.source === 'auto';
+
+    const actionsHtml = isAuto
+        ? `<span class="activity-source-link text-xs text-sky-400/60 italic cursor-default" data-source-task-id="${activity.sourceTaskId}" title="Auto-logged from task">
+               <i class="fa-solid fa-link mr-0.5"></i>auto
+           </span>`
+        : `<div class="flex items-center gap-2">
+               <button class="btn-edit-activity text-sky-400/60 hover:text-sky-400 transition-colors text-xs" title="Edit activity">
+                   <i class="fa-solid fa-pen"></i>
+               </button>
+               <button class="btn-delete-activity text-rose-400/60 hover:text-rose-400 transition-colors text-xs" title="Delete activity">
+                   <i class="fa-solid fa-trash-can"></i>
+               </button>
+           </div>`;
+
+    return `<div class="activity-item flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/50 hover:border-sky-700/30 transition-colors" data-activity-id="${activity.id}">
+        <div class="flex-grow min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-sm text-slate-200 truncate">${escapeHtml(activity.description)}</span>
+                ${badge}
+            </div>
+            <div class="text-xs text-slate-400 mt-0.5">
+                ${timeRange} · ${durationText}
+            </div>
+        </div>
+        <div class="shrink-0">
+            ${actionsHtml}
+        </div>
+    </div>`;
+}
+
+export function renderActivities(activities, container) {
+    if (!container) return;
+
+    if (!activities || activities.length === 0) {
+        container.innerHTML = `
+            <div class="text-center py-6 text-slate-500 text-sm">
+                <i class="fa-regular fa-clock mr-1"></i>
+                No activities tracked today. Log one or complete a scheduled task.
+            </div>`;
+        return;
+    }
+
+    container.innerHTML = activities.map(renderActivityItem).join('');
+}
+
+function escapeHtml(value) {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-renderer.test.js --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/activities/renderer.js
+git commit -m "feat: add activity renderer with chronological list and empty state"
+```
+
+---
+
+## Chunk 6: HTML + Three-Way Form Toggle + Test Utils
+
+### Task 13: Update index.html with activity radio and activity list container
+
+**Files:**
+- Modify: `public/index.html`
+
+- [ ] **Step 1: Add Activity radio option to the form**
+
+In `public/index.html`, inside the `<div class="flex flex-col sm:flex-row sm:space-x-4 mb-2">` that holds the Scheduled and Unscheduled radio buttons, add a third option after the Unscheduled radio div. Add it inside a hidden wrapper so it only shows when Activities are enabled:
+
+```html
+                        <div
+                            id="activity-radio-container"
+                            class="hidden"
+                        >
+                            <div
+                                class="flex items-center p-1.5 rounded hover:bg-slate-700/50 transition-colors"
+                            >
+                                <input
+                                    id="activity"
+                                    type="radio"
+                                    name="task-type"
+                                    value="activity"
+                                    class="mr-2 h-4 w-4 text-sky-400 focus:ring-sky-400"
+                                />
+                                <label
+                                    for="activity"
+                                    class="text-slate-300 flex items-center text-sm"
+                                >
+                                    <i class="fa-regular fa-clock mr-1 text-sky-400/75"></i
+                                    >Activity
+                                </label>
+                            </div>
+                        </div>
+```
+
+- [ ] **Step 2: Add activity list container below unscheduled tasks**
+
+In `public/index.html`, after the `<!-- Unscheduled Tasks Section -->` closing `</div>`, add the activity section. Place it before the `<!-- Info Panel -->`:
+
+```html
+                <!-- Activity Log Section (hidden until Activities enabled) -->
+                <div id="activities-container" class="hidden text-left mb-4 sm:mb-6 px-2 sm:px-0">
+                    <div class="flex justify-between items-center mb-2 sm:mb-3">
+                        <h3
+                            class="text-lg sm:text-xl font-normal text-sky-400 pl-2 flex items-center"
+                        >
+                            <i class="fa-regular fa-clock mr-2"></i>Today's Activities
+                        </h3>
+                    </div>
+                    <div id="activity-list" class="space-y-1.5">
+                        <!-- activities will be generated here by JavaScript -->
+                    </div>
+                </div>
+```
+
+- [ ] **Step 3: Verify the page loads without errors**
+
+Open the app in a browser (or run `firebase serve` if available) and confirm the page loads without JS errors in the console. The new radio and activity section should be hidden.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/index.html
+git commit -m "feat: add activity radio option and activity list container to HTML"
+```
+
+### Task 14: Update test-utils.js setupDOM
+
+**Files:**
+- Modify: `__tests__/test-utils.js`
+
+- [ ] **Step 1: Add activity radio and activity list container to setupDOM**
+
+In `__tests__/test-utils.js`, inside the `setupDOM()` function's `document.body.innerHTML` template, add the activity radio after the unscheduled radio in the task-type-toggle section:
+
+```html
+          <input type="radio" id="activity" name="task-type" value="activity" />
+          <label for="activity">Activity</label>
+```
+
+And add the activity list container after the unscheduled task list:
+
+```html
+      <div id="activities-container" class="hidden">
+        <div id="activity-list"></div>
+      </div>
+```
+
+- [ ] **Step 2: Run full test suite to verify no regressions**
+
+Run: `npx jest --no-coverage 2>&1 | tail -10`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/test-utils.js
+git commit -m "test: add activity radio and list container to test DOM setup"
+```
+
+### Task 15: Three-way form toggle in dom-renderer.js
+
+**Files:**
+- Modify: `public/js/dom-renderer.js`
+
+- [ ] **Step 1: Extend initializeTaskTypeToggle to handle three modes**
+
+In `public/js/dom-renderer.js`, replace the `initializeTaskTypeToggle` function. The new version handles scheduled, unscheduled, and activity radio buttons:
+
+```js
+export function initializeTaskTypeToggle() {
+    const scheduledRadio = document.getElementById('scheduled');
+    const unscheduledRadio = document.getElementById('unscheduled');
+    const activityRadio = document.getElementById('activity');
+    const timeInputs = document.getElementById('time-inputs');
+    const priorityInput = document.getElementById('priority-input');
+    const addTaskButton = document.querySelector('#task-form button[type="submit"]');
+    const descriptionInput = document.querySelector('input[name="description"]');
+    const startTimeInput = document.querySelector('input[name="start-time"]');
+
+    if (
+        scheduledRadio instanceof HTMLInputElement &&
+        unscheduledRadio instanceof HTMLInputElement &&
+        timeInputs instanceof HTMLElement &&
+        priorityInput instanceof HTMLElement &&
+        addTaskButton instanceof HTMLElement &&
+        descriptionInput instanceof HTMLElement
+    ) {
+        const toggleVisibility = () => {
+            const isActivity = activityRadio instanceof HTMLInputElement && activityRadio.checked;
+
+            if (scheduledRadio.checked) {
+                timeInputs.classList.remove('hidden');
+                priorityInput.classList.add('hidden');
+                if (startTimeInput) startTimeInput.setAttribute('required', '');
+                addTaskButton.className =
+                    'shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+                descriptionInput.className =
+                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all';
+                descriptionInput.placeholder = 'Describe your task...';
+                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
+            } else if (isActivity) {
+                timeInputs.classList.remove('hidden');
+                priorityInput.classList.add('hidden');
+                if (startTimeInput) startTimeInput.setAttribute('required', '');
+                addTaskButton.className =
+                    'shrink-0 bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+                descriptionInput.className =
+                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all';
+                descriptionInput.placeholder = 'What did you work on?';
+                addTaskButton.innerHTML = '<i class="fa-regular fa-clock mr-2"></i>Log Activity';
+            } else {
+                timeInputs.classList.add('hidden');
+                priorityInput.classList.remove('hidden');
+                if (startTimeInput) startTimeInput.removeAttribute('required');
+                addTaskButton.className =
+                    'shrink-0 bg-gradient-to-r from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+                descriptionInput.className =
+                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-indigo-400 focus:outline-none transition-all';
+                descriptionInput.placeholder = 'Describe your task...';
+                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
+            }
+        };
+
+        scheduledRadio.addEventListener('change', toggleVisibility);
+        unscheduledRadio.addEventListener('change', toggleVisibility);
+        if (activityRadio instanceof HTMLInputElement) {
+            activityRadio.addEventListener('change', toggleVisibility);
+        }
+        toggleVisibility();
+
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) {
+                toggleVisibility();
+            }
+        });
+
+        window.addEventListener('focus', () => {
+            toggleVisibility();
+        });
+    } else {
+        logger.error('DOM elements for task type toggle not found or not of expected types.');
+    }
+}
+```
+
+- [ ] **Step 2: Run existing tests to check for regressions**
+
+Run: `npx jest --no-coverage 2>&1 | tail -10`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/dom-renderer.js
+git commit -m "feat: extend form toggle to support three-way scheduled/unscheduled/activity mode"
+```
+
+---
+
+## Chunk 7: Boot Wiring + Integration
+
+### Task 16: Wire activities into app.js boot sequence
+
+**Files:**
+- Modify: `public/js/app.js`
+
+- [ ] **Step 1: Add activity imports to app.js**
+
+Add these imports to the top of `public/js/app.js`:
+
+```js
+import { loadActivitiesState, getTodaysActivities } from './activities/manager.js';
+import { renderActivities } from './activities/renderer.js';
+import { extractActivityFormData } from './activities/form-utils.js';
+import { handleAddActivity, handleDeleteActivity, handleEditActivity } from './activities/handlers.js';
+```
+
+- [ ] **Step 2: Load activities during boot**
+
+In the `initAndBootApp` function, after `await loadTaxonomy();`, add:
+
+```js
+    // Load activities state
+    if (isActivitiesEnabled()) {
+        await loadActivitiesState();
+    }
+```
+
+- [ ] **Step 3: Show/hide activity UI containers based on feature flag**
+
+In the `initAndBootApp` function, after the existing `if (isActivitiesEnabled())` block that reveals the category dropdown, add code to reveal the activity containers:
+
+```js
+    if (isActivitiesEnabled()) {
+        const activityRadioContainer = document.getElementById('activity-radio-container');
+        if (activityRadioContainer) {
+            activityRadioContainer.classList.remove('hidden');
+        }
+
+        const activitiesContainer = document.getElementById('activities-container');
+        if (activitiesContainer) {
+            activitiesContainer.classList.remove('hidden');
+        }
+    }
+```
+
+- [ ] **Step 4: Route form submission to activity handler when activity mode is selected**
+
+Modify the `onTaskFormSubmit` callback inside `initAndBootApp`. Replace the existing implementation with:
+
+```js
+        onTaskFormSubmit: async (formElement) => {
+            const selectedType = formElement.querySelector('input[name="task-type"]:checked')?.value;
+
+            if (selectedType === 'activity') {
+                const activityData = extractActivityFormData(formElement);
+                if (!activityData) return;
+                await handleAddActivity(activityData);
+                formElement.reset();
+                const activityRadio = formElement.querySelector('input[name="task-type"][value="activity"]');
+                if (activityRadio) activityRadio.checked = true;
+                initializeTaskTypeToggle();
+                focusTaskDescriptionInput();
+                return;
+            }
+
+            const taskData = extractTaskFormData(formElement);
+            if (!taskData) {
+                focusTaskDescriptionInput();
+                return;
+            }
+            const overlapEl = document.getElementById('overlap-warning');
+            const reschedulePreApproved = !!(overlapEl && overlapEl.textContent.trim());
+            await handleAddTaskProcess(formElement, taskData, { reschedulePreApproved });
+        },
+```
+
+- [ ] **Step 5: Add activity rendering to refreshTaskDisplays**
+
+In the `initAndBootApp` function, modify the `refreshTaskDisplays` closure to also render activities. After the existing `refreshCurrentGapHighlight();` line, add:
+
+```js
+        if (isActivitiesEnabled()) {
+            const activityListEl = document.getElementById('activity-list');
+            if (activityListEl) {
+                renderActivities(getTodaysActivities(), activityListEl);
+            }
+        }
+```
+
+- [ ] **Step 6: Add activity list event delegation for edit and delete buttons**
+
+In the `initAndBootApp` function, after the existing event listener setup (after `initializeClearTasksHandlers()`), add:
+
+```js
+    // Activity list event delegation
+    if (isActivitiesEnabled()) {
+        const activityList = document.getElementById('activity-list');
+        if (activityList) {
+            activityList.addEventListener('click', (event) => {
+                const target = event.target;
+                const activityItem = target.closest('[data-activity-id]');
+                if (!activityItem) return;
+                const activityId = activityItem.dataset.activityId;
+
+                if (target.closest('.btn-delete-activity')) {
+                    handleDeleteActivity(activityId);
+                } else if (target.closest('.btn-edit-activity')) {
+                    // For v1, edit via a prompt-style inline flow.
+                    // The activity description is extracted from the DOM, presented
+                    // in an editable input, and handleEditActivity is called on save.
+                    // A richer inline edit form can replace this in a future phase.
+                    const descEl = activityItem.querySelector('.text-sm.text-slate-200');
+                    const currentDesc = descEl ? descEl.textContent.trim() : '';
+                    const newDesc = window.prompt('Edit activity description:', currentDesc);
+                    if (newDesc !== null && newDesc.trim() !== '' && newDesc.trim() !== currentDesc) {
+                        handleEditActivity(activityId, { description: newDesc.trim() });
+                    }
+                }
+            }, { signal });
+        }
+    }
+```
+
+- [ ] **Step 7: Update refreshFromStorage to reload activities**
+
+In the `refreshFromStorage` function, add activity reloading after `await loadTasksIntoState();`:
+
+```js
+    if (isActivitiesEnabled()) {
+        await loadActivitiesState();
+    }
+```
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `npx jest --no-coverage 2>&1 | tail -10`
+Expected: All tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add public/js/app.js
+git commit -m "feat: wire activity boot sequence, form routing, rendering, and event delegation"
+```
+
+### Task 17: Manual smoke test
+
+- [ ] **Step 1: Start the app locally and enable Activities in settings**
+
+Open the app, go to Settings (gear icon), and toggle "Enable Activities" on. Reload when prompted.
+
+- [ ] **Step 2: Verify the Activity radio option appears in the form**
+
+The three-way toggle should show Scheduled, Unscheduled, and Activity. Switching to Activity should turn the button sky blue and change placeholder to "What did you work on?"
+
+- [ ] **Step 3: Log a manual activity**
+
+Select Activity mode, enter a description, pick a category, set a start time and duration, submit. Verify:
+- Toast shows "Activity logged."
+- Activity appears in the "Today's Activities" list below
+- Category badge renders if category was selected
+
+- [ ] **Step 4: Edit a manual activity**
+
+Click the pencil icon on the manual activity. A browser prompt should appear with the current description. Change it and confirm. Verify the activity list re-renders with the updated description.
+
+- [ ] **Step 5: Complete a scheduled task and verify auto-logging**
+
+Add a scheduled task, complete it (checkbox). Verify:
+- Confetti still triggers
+- A new activity appears in the activity list with a link icon and "auto" label
+- The auto activity shows the correct description, time range, and category
+- The auto activity has NO edit or delete buttons
+
+- [ ] **Step 6: Delete a manual activity**
+
+Click the trash icon on a manual activity. Verify it disappears.
+
+- [ ] **Step 7: Disable Activities and verify clean state**
+
+Toggle Activities off in settings, reload. Verify:
+- Activity radio is hidden
+- Activity list section is hidden
+- Completing a scheduled task does NOT create an activity
+
+- [ ] **Step 8: Run the full test suite with coverage**
+
+Run: `npx jest 2>&1 | tail -20`
+Expected: All tests PASS, coverage thresholds met (90/90/90/79)
+
+- [ ] **Step 9: Commit any fixes from smoke testing**
+
+```bash
+git add -A
+git commit -m "fix: address issues found during Phase 4 smoke testing"
+```
+
+(Skip this step if no fixes were needed.)

--- a/docs/plans/2026-04-07-fortudo-activities-phase4.md
+++ b/docs/plans/2026-04-07-fortudo-activities-phase4.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add activity logging to Fortudo: an activity manager with CRUD and auto-logging from scheduled task completion, a third "Activity" form mode, an activity renderer showing today's log, and coordinator wiring for activity events.
+**Goal:** Add activity logging to Fortudo: an activity manager with CRUD and auto-logging from scheduled task completion, a third "Activity" form mode, an activity renderer showing today's log, inline full-field activity editing, and coordinator wiring for activity events.
 
-**Architecture:** Activities are PouchDB documents (`docType: 'activity'`) using the existing `putActivity`/`loadActivities`/`deleteActivity` storage primitives shipped in Phase 2. The activity manager owns in-memory state and CRUD. Auto-logging fires as fire-and-forget async work inside the synchronous `onTaskCompleted` coordinator event. A three-way form toggle (scheduled/unscheduled/activity) routes submission to either `tasks/add-handler.js` or `activities/handlers.js`. The activity list renders below the unscheduled task list, gated by `isActivitiesEnabled()`. The entire activity UI container is hidden when Activities are disabled in settings.
+**Architecture:** Activities are PouchDB documents (`docType: 'activity'`) using the existing `putActivity`/`loadActivities`/`deleteActivity` storage primitives shipped in Phase 2. The activity manager owns in-memory state and CRUD. Auto-logging fires as fire-and-forget async work inside the synchronous `onTaskCompleted` coordinator event. A three-way form toggle (scheduled/unscheduled/activity) routes submission to either `tasks/add-handler.js` or `activities/handlers.js`. The activity list renders below the unscheduled task list, gated by `isActivitiesEnabled()`. Inline activity edit state is kept in the UI layer and rendered as row replacement rather than persisted into activity docs. The entire activity UI container is hidden when Activities are disabled in settings.
 
 **Tech Stack:** Vanilla JS ES modules, PouchDB (memory adapter in tests), Jest 30, Tailwind CSS
 
@@ -12,25 +12,23 @@
 
 ## File Structure
 
-| Action | File | Responsibility |
-|--------|------|----------------|
-| Create | `public/js/activities/manager.js` | Activity state management, CRUD, `createActivityFromTask` |
-| Create | `public/js/activities/form-utils.js` | Activity form data extraction and validation |
-| Create | `public/js/activities/handlers.js` | Activity add/edit/delete handler functions |
-| Create | `public/js/activities/renderer.js` | Renders chronological activity list for today |
-| Create | `__tests__/activity-manager.test.js` | Tests for activity manager CRUD + auto-logging |
-| Create | `__tests__/activity-form-utils.test.js` | Tests for activity form extraction |
-| Create | `__tests__/activity-handlers.test.js` | Tests for activity handlers |
-| Create | `__tests__/activity-renderer.test.js` | Tests for activity list rendering |
-| Modify | `public/js/app-coordinator.js` | Add `onActivityCreated`, `onActivityEdited`, `onActivityDeleted` + auto-logging in `onTaskCompleted` |
-| Modify | `__tests__/app-coordinator.test.js` | Test new activity events + auto-logging |
-| Modify | `public/js/utils.js` | Add `'activity'` branch to `getThemeForTaskType` and `getThemeForTask` |
-| Modify | `public/js/toast-manager.js` | Add `sky` theme to `THEME_CLASSES` |
-| Modify | `public/index.html` | Add Activity radio option, activity list container |
-| Modify | `public/js/dom-renderer.js` | Three-way form toggle, activity list event delegation |
-| Modify | `public/js/tasks/form-utils.js` | Guard `extractTaskFormData` against `'activity'` task-type |
-| Modify | `public/js/app.js` | Boot wiring: load activities, activity form routing, activity event listeners, show/hide activity UI |
-| Modify | `__tests__/test-utils.js` | Add activity radio + activity list container to `setupDOM` |
+| Action | File                                    | Responsibility                                                                                       |
+| ------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Create | `public/js/activities/manager.js`       | Activity state management, CRUD, `createActivityFromTask`                                            |
+| Create | `public/js/activities/form-utils.js`    | Activity form data extraction and validation                                                         |
+| Create | `public/js/activities/handlers.js`      | Activity add/edit/delete handler functions                                                           |
+| Create | `public/js/activities/renderer.js`      | Renders chronological activity list for today                                                        |
+| Create | `__tests__/activity-manager.test.js`    | Tests for activity manager CRUD + auto-logging                                                       |
+| Create | `__tests__/activity-form-utils.test.js` | Tests for activity form extraction                                                                   |
+| Create | `__tests__/activity-handlers.test.js`   | Tests for activity handlers                                                                          |
+| Create | `__tests__/activity-renderer.test.js`   | Tests for activity list rendering                                                                    |
+| Modify | `public/js/app-coordinator.js`          | Add `onActivityCreated`, `onActivityEdited`, `onActivityDeleted` + auto-logging in `onTaskCompleted` |
+| Modify | `__tests__/app-coordinator.test.js`     | Test new activity events + auto-logging                                                              |
+| Modify | `public/index.html`                     | Add Activity radio option, activity list container                                                   |
+| Modify | `public/js/dom-renderer.js`             | Three-way form toggle, activity list event delegation                                                |
+| Modify | `public/js/tasks/form-utils.js`         | Guard `extractTaskFormData` against `'activity'` task-type                                           |
+| Modify | `public/js/app.js`                      | Boot wiring: load activities, activity form routing, activity event listeners, show/hide activity UI |
+| Modify | `__tests__/test-utils.js`               | Add activity radio + activity list container to `setupDOM`                                           |
 
 ---
 
@@ -39,6 +37,7 @@
 ### Task 1: Activity manager — failing tests for core CRUD
 
 **Files:**
+
 - Create: `__tests__/activity-manager.test.js`
 
 - [ ] **Step 1: Write failing tests for addActivity, getActivityState, getActivityById, getTodaysActivities**
@@ -49,230 +48,236 @@
  */
 
 jest.mock('../public/js/storage.js', () => ({
-    putActivity: jest.fn(() => Promise.resolve()),
-    loadActivities: jest.fn(() => Promise.resolve([])),
-    deleteActivity: jest.fn(() => Promise.resolve())
+  putActivity: jest.fn(() => Promise.resolve()),
+  loadActivities: jest.fn(() => Promise.resolve([])),
+  deleteActivity: jest.fn(() => Promise.resolve())
 }));
 
 import {
-    addActivity,
-    getActivityState,
-    getActivityById,
-    getTodaysActivities,
-    loadActivitiesState,
-    removeActivity,
-    editActivity,
-    resetActivityState
+  addActivity,
+  getActivityState,
+  getActivityById,
+  getTodaysActivities,
+  loadActivitiesState,
+  removeActivity,
+  editActivity,
+  resetActivityState
 } from '../public/js/activities/manager.js';
-import { putActivity, loadActivities, deleteActivity } from '../public/js/storage.js';
+import {
+  putActivity,
+  loadActivities,
+  deleteActivity
+} from '../public/js/storage.js';
 
 describe('activity manager', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        resetActivityState();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetActivityState();
+  });
+
+  describe('addActivity', () => {
+    test('creates activity with generated id and stores it', async () => {
+      const data = {
+        description: 'Deep work session',
+        category: 'work/deep',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      };
+
+      const result = await addActivity(data);
+
+      expect(result.success).toBe(true);
+      expect(result.activity.id).toMatch(/^activity-/);
+      expect(result.activity.description).toBe('Deep work session');
+      expect(result.activity.docType).toBe('activity');
+      expect(putActivity).toHaveBeenCalledWith(result.activity);
+      expect(getActivityState()).toContain(result.activity);
     });
 
-    describe('addActivity', () => {
-        test('creates activity with generated id and stores it', async () => {
-            const data = {
-                description: 'Deep work session',
-                category: 'work/deep',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            };
+    test('rejects activity with empty description', async () => {
+      const data = {
+        description: '',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      };
 
-            const result = await addActivity(data);
+      const result = await addActivity(data);
 
-            expect(result.success).toBe(true);
-            expect(result.activity.id).toMatch(/^activity-/);
-            expect(result.activity.description).toBe('Deep work session');
-            expect(result.activity.docType).toBe('activity');
-            expect(putActivity).toHaveBeenCalledWith(result.activity);
-            expect(getActivityState()).toContain(result.activity);
-        });
-
-        test('rejects activity with empty description', async () => {
-            const data = {
-                description: '',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            };
-
-            const result = await addActivity(data);
-
-            expect(result.success).toBe(false);
-            expect(result.reason).toMatch(/description/i);
-            expect(putActivity).not.toHaveBeenCalled();
-        });
-
-        test('rejects activity with zero duration', async () => {
-            const data = {
-                description: 'Test',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T09:00:00.000Z',
-                duration: 0,
-                source: 'manual',
-                sourceTaskId: null
-            };
-
-            const result = await addActivity(data);
-
-            expect(result.success).toBe(false);
-            expect(result.reason).toMatch(/duration/i);
-        });
+      expect(result.success).toBe(false);
+      expect(result.reason).toMatch(/description/i);
+      expect(putActivity).not.toHaveBeenCalled();
     });
 
-    describe('getActivityById', () => {
-        test('returns activity when found', async () => {
-            const { activity } = await addActivity({
-                description: 'Test',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
+    test('rejects activity with zero duration', async () => {
+      const data = {
+        description: 'Test',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T09:00:00.000Z',
+        duration: 0,
+        source: 'manual',
+        sourceTaskId: null
+      };
 
-            expect(getActivityById(activity.id)).toBe(activity);
-        });
+      const result = await addActivity(data);
 
-        test('returns null when not found', () => {
-            expect(getActivityById('activity-nonexistent')).toBeNull();
-        });
+      expect(result.success).toBe(false);
+      expect(result.reason).toMatch(/duration/i);
+    });
+  });
+
+  describe('getActivityById', () => {
+    test('returns activity when found', async () => {
+      const { activity } = await addActivity({
+        description: 'Test',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      });
+
+      expect(getActivityById(activity.id)).toBe(activity);
     });
 
-    describe('getTodaysActivities', () => {
-        test('returns only activities from today sorted by start time', async () => {
-            const today = new Date();
-            const todayISO = today.toISOString().slice(0, 10);
-            const yesterdayDate = new Date(today);
-            yesterdayDate.setDate(yesterdayDate.getDate() - 1);
-            const yesterdayISO = yesterdayDate.toISOString().slice(0, 10);
+    test('returns null when not found', () => {
+      expect(getActivityById('activity-nonexistent')).toBeNull();
+    });
+  });
 
-            await addActivity({
-                description: 'Yesterday',
-                startDateTime: `${yesterdayISO}T09:00:00.000Z`,
-                endDateTime: `${yesterdayISO}T10:00:00.000Z`,
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
+  describe('getTodaysActivities', () => {
+    test('returns only activities from today sorted by start time', async () => {
+      const today = new Date();
+      const todayISO = today.toISOString().slice(0, 10);
+      const yesterdayDate = new Date(today);
+      yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+      const yesterdayISO = yesterdayDate.toISOString().slice(0, 10);
 
-            await addActivity({
-                description: 'Today later',
-                startDateTime: `${todayISO}T14:00:00.000Z`,
-                endDateTime: `${todayISO}T15:00:00.000Z`,
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
+      await addActivity({
+        description: 'Yesterday',
+        startDateTime: `${yesterdayISO}T09:00:00.000Z`,
+        endDateTime: `${yesterdayISO}T10:00:00.000Z`,
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      });
 
-            await addActivity({
-                description: 'Today earlier',
-                startDateTime: `${todayISO}T09:00:00.000Z`,
-                endDateTime: `${todayISO}T10:00:00.000Z`,
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
+      await addActivity({
+        description: 'Today later',
+        startDateTime: `${todayISO}T14:00:00.000Z`,
+        endDateTime: `${todayISO}T15:00:00.000Z`,
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      });
 
-            const todays = getTodaysActivities();
-            expect(todays).toHaveLength(2);
-            expect(todays[0].description).toBe('Today earlier');
-            expect(todays[1].description).toBe('Today later');
-        });
+      await addActivity({
+        description: 'Today earlier',
+        startDateTime: `${todayISO}T09:00:00.000Z`,
+        endDateTime: `${todayISO}T10:00:00.000Z`,
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      });
+
+      const todays = getTodaysActivities();
+      expect(todays).toHaveLength(2);
+      expect(todays[0].description).toBe('Today earlier');
+      expect(todays[1].description).toBe('Today later');
+    });
+  });
+
+  describe('removeActivity', () => {
+    test('removes activity from state and storage', async () => {
+      const { activity } = await addActivity({
+        description: 'To remove',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      });
+
+      const result = await removeActivity(activity.id);
+
+      expect(result.success).toBe(true);
+      expect(deleteActivity).toHaveBeenCalledWith(activity.id);
+      expect(getActivityById(activity.id)).toBeNull();
     });
 
-    describe('removeActivity', () => {
-        test('removes activity from state and storage', async () => {
-            const { activity } = await addActivity({
-                description: 'To remove',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
+    test('returns failure for nonexistent activity', async () => {
+      const result = await removeActivity('activity-fake');
+      expect(result.success).toBe(false);
+    });
+  });
 
-            const result = await removeActivity(activity.id);
+  describe('editActivity', () => {
+    test('updates editable fields and persists', async () => {
+      const { activity } = await addActivity({
+        description: 'Original',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      });
 
-            expect(result.success).toBe(true);
-            expect(deleteActivity).toHaveBeenCalledWith(activity.id);
-            expect(getActivityById(activity.id)).toBeNull();
-        });
+      const result = await editActivity(activity.id, {
+        description: 'Updated',
+        duration: 90
+      });
 
-        test('returns failure for nonexistent activity', async () => {
-            const result = await removeActivity('activity-fake');
-            expect(result.success).toBe(false);
-        });
+      expect(result.success).toBe(true);
+      expect(result.activity.description).toBe('Updated');
+      expect(result.activity.duration).toBe(90);
+      expect(putActivity).toHaveBeenCalled();
     });
 
-    describe('editActivity', () => {
-        test('updates editable fields and persists', async () => {
-            const { activity } = await addActivity({
-                description: 'Original',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            });
+    test('rejects edit of auto-logged activity', async () => {
+      const { activity } = await addActivity({
+        description: 'Auto',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'auto',
+        sourceTaskId: 'sched-123'
+      });
 
-            const result = await editActivity(activity.id, {
-                description: 'Updated',
-                duration: 90
-            });
+      const result = await editActivity(activity.id, {
+        description: 'Changed'
+      });
 
-            expect(result.success).toBe(true);
-            expect(result.activity.description).toBe('Updated');
-            expect(result.activity.duration).toBe(90);
-            expect(putActivity).toHaveBeenCalled();
-        });
-
-        test('rejects edit of auto-logged activity', async () => {
-            const { activity } = await addActivity({
-                description: 'Auto',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'auto',
-                sourceTaskId: 'sched-123'
-            });
-
-            const result = await editActivity(activity.id, { description: 'Changed' });
-
-            expect(result.success).toBe(false);
-            expect(result.reason).toMatch(/auto/i);
-        });
+      expect(result.success).toBe(false);
+      expect(result.reason).toMatch(/auto/i);
     });
+  });
 
-    describe('loadActivitiesState', () => {
-        test('populates state from storage', async () => {
-            loadActivities.mockResolvedValueOnce([
-                {
-                    id: 'activity-1',
-                    docType: 'activity',
-                    description: 'Stored',
-                    startDateTime: '2026-04-07T09:00:00.000Z',
-                    endDateTime: '2026-04-07T10:00:00.000Z',
-                    duration: 60,
-                    source: 'manual',
-                    sourceTaskId: null
-                }
-            ]);
+  describe('loadActivitiesState', () => {
+    test('populates state from storage', async () => {
+      loadActivities.mockResolvedValueOnce([
+        {
+          id: 'activity-1',
+          docType: 'activity',
+          description: 'Stored',
+          startDateTime: '2026-04-07T09:00:00.000Z',
+          endDateTime: '2026-04-07T10:00:00.000Z',
+          duration: 60,
+          source: 'manual',
+          sourceTaskId: null
+        }
+      ]);
 
-            await loadActivitiesState();
+      await loadActivitiesState();
 
-            expect(getActivityState()).toHaveLength(1);
-            expect(getActivityState()[0].description).toBe('Stored');
-        });
+      expect(getActivityState()).toHaveLength(1);
+      expect(getActivityState()[0].description).toBe('Stored');
     });
+  });
 });
 ```
 
@@ -291,6 +296,7 @@ git commit -m "test: add failing tests for activity manager CRUD"
 ### Task 2: Activity manager — implementation
 
 **Files:**
+
 - Create: `public/js/activities/manager.js`
 
 - [ ] **Step 1: Implement the activity manager**
@@ -303,104 +309,119 @@ import { logger } from '../utils.js';
 let activities = [];
 
 export function resetActivityState() {
-    activities = [];
+  activities = [];
 }
 
 export function getActivityState() {
-    return activities;
+  return activities;
 }
 
 export function getActivityById(id) {
-    return activities.find((a) => a.id === id) || null;
+  return activities.find((a) => a.id === id) || null;
 }
 
 export function getTodaysActivities(now = new Date()) {
-    const todayStr = now.toISOString().slice(0, 10);
-    return activities
-        .filter((a) => a.startDateTime && a.startDateTime.slice(0, 10) === todayStr)
-        .sort((a, b) => new Date(a.startDateTime) - new Date(b.startDateTime));
+  const todayStr = now.toISOString().slice(0, 10);
+  return activities
+    .filter((a) => a.startDateTime && a.startDateTime.slice(0, 10) === todayStr)
+    .sort((a, b) => new Date(a.startDateTime) - new Date(b.startDateTime));
 }
 
 export async function loadActivitiesState() {
-    activities = await loadActivities();
+  activities = await loadActivities();
 }
 
 export async function addActivity(data) {
-    if (!data.description || data.description.trim() === '') {
-        return { success: false, reason: 'Activity description is required.' };
-    }
+  if (!data.description || data.description.trim() === '') {
+    return { success: false, reason: 'Activity description is required.' };
+  }
 
-    if (!data.duration || data.duration <= 0) {
-        return { success: false, reason: 'Activity duration must be greater than 0.' };
-    }
-
-    if (!data.startDateTime || !data.endDateTime) {
-        return { success: false, reason: 'Activity start and end times are required.' };
-    }
-
-    const activity = {
-        id: `activity-${Date.now()}`,
-        docType: 'activity',
-        description: data.description.trim(),
-        category: data.category || null,
-        startDateTime: data.startDateTime,
-        endDateTime: data.endDateTime,
-        duration: data.duration,
-        source: data.source || 'manual',
-        sourceTaskId: data.sourceTaskId || null
+  if (!data.duration || data.duration <= 0) {
+    return {
+      success: false,
+      reason: 'Activity duration must be greater than 0.'
     };
+  }
 
-    await putActivity(activity);
-    activities.push(activity);
+  if (!data.startDateTime || !data.endDateTime) {
+    return {
+      success: false,
+      reason: 'Activity start and end times are required.'
+    };
+  }
 
-    return { success: true, activity };
+  const activity = {
+    id: `activity-${Date.now()}`,
+    docType: 'activity',
+    description: data.description.trim(),
+    category: data.category || null,
+    startDateTime: data.startDateTime,
+    endDateTime: data.endDateTime,
+    duration: data.duration,
+    source: data.source || 'manual',
+    sourceTaskId: data.sourceTaskId || null
+  };
+
+  await putActivity(activity);
+  activities.push(activity);
+
+  return { success: true, activity };
 }
 
 export async function removeActivity(id) {
-    const index = activities.findIndex((a) => a.id === id);
-    if (index === -1) {
-        return { success: false, reason: 'Activity not found.' };
-    }
+  const index = activities.findIndex((a) => a.id === id);
+  if (index === -1) {
+    return { success: false, reason: 'Activity not found.' };
+  }
 
-    const activity = activities[index];
-    await deleteActivity(id);
-    activities.splice(index, 1);
+  const activity = activities[index];
+  await deleteActivity(id);
+  activities.splice(index, 1);
 
-    return { success: true, activity };
+  return { success: true, activity };
 }
 
 export async function editActivity(id, updates) {
-    const activity = getActivityById(id);
-    if (!activity) {
-        return { success: false, reason: 'Activity not found.' };
+  const activity = getActivityById(id);
+  if (!activity) {
+    return { success: false, reason: 'Activity not found.' };
+  }
+
+  if (activity.source === 'auto') {
+    return {
+      success: false,
+      reason: 'Auto-logged activities cannot be edited.'
+    };
+  }
+
+  const editableFields = [
+    'description',
+    'category',
+    'startDateTime',
+    'endDateTime',
+    'duration'
+  ];
+  for (const field of editableFields) {
+    if (Object.prototype.hasOwnProperty.call(updates, field)) {
+      activity[field] = updates[field];
     }
+  }
 
-    if (activity.source === 'auto') {
-        return { success: false, reason: 'Auto-logged activities cannot be edited.' };
-    }
+  await putActivity(activity);
 
-    const editableFields = ['description', 'category', 'startDateTime', 'endDateTime', 'duration'];
-    for (const field of editableFields) {
-        if (Object.prototype.hasOwnProperty.call(updates, field)) {
-            activity[field] = updates[field];
-        }
-    }
-
-    await putActivity(activity);
-
-    return { success: true, activity };
+  return { success: true, activity };
 }
 
 export function createActivityFromTask(task) {
-    return {
-        description: task.description,
-        category: task.category || null,
-        startDateTime: task.startDateTime,
-        endDateTime: task.endDateTime,
-        duration: task.duration,
-        source: 'auto',
-        sourceTaskId: task.id
-    };
+  return {
+    description: task.description,
+    category: task.category || null,
+    startDateTime: task.startDateTime,
+    endDateTime: task.endDateTime,
+    duration: task.duration,
+    source: 'auto',
+    sourceTaskId: task.id
+  };
 }
 ```
 
@@ -419,6 +440,7 @@ git commit -m "feat: add activity manager with CRUD and createActivityFromTask"
 ### Task 3: Coordinator activity events + auto-logging — failing tests
 
 **Files:**
+
 - Modify: `__tests__/app-coordinator.test.js`
 
 - [ ] **Step 1: Add failing tests for activity events and auto-logging**
@@ -428,90 +450,93 @@ Add these tests to the existing `describe('app-coordinator', ...)` block:
 ```js
 // Add to the existing mock block at the top:
 jest.mock('../public/js/activities/manager.js', () => ({
-    addActivity: jest.fn(() => Promise.resolve({ success: true, activity: {} })),
-    createActivityFromTask: jest.fn((task) => ({
-        description: task.description,
-        startDateTime: task.startDateTime,
-        endDateTime: task.endDateTime,
-        duration: task.duration,
-        category: task.category || null,
-        source: 'auto',
-        sourceTaskId: task.id
-    })),
-    getTodaysActivities: jest.fn(() => [])
+  addActivity: jest.fn(() => Promise.resolve({ success: true, activity: {} })),
+  createActivityFromTask: jest.fn((task) => ({
+    description: task.description,
+    startDateTime: task.startDateTime,
+    endDateTime: task.endDateTime,
+    duration: task.duration,
+    category: task.category || null,
+    source: 'auto',
+    sourceTaskId: task.id
+  })),
+  getTodaysActivities: jest.fn(() => [])
 }));
 
 jest.mock('../public/js/settings-manager.js', () => ({
-    isActivitiesEnabled: jest.fn(() => false)
+  isActivitiesEnabled: jest.fn(() => false)
 }));
 
 // Add imports:
-import { addActivity, createActivityFromTask } from '../public/js/activities/manager.js';
+import {
+  addActivity,
+  createActivityFromTask
+} from '../public/js/activities/manager.js';
 import { isActivitiesEnabled } from '../public/js/settings-manager.js';
 
 // Add these test cases inside describe('app-coordinator'):
 
 test('onActivityCreated refreshes UI', () => {
-    appCoordinator.onActivityCreated({
-        activity: { id: 'activity-1', description: 'Test' }
-    });
-    expect(refreshUI).toHaveBeenCalledTimes(1);
+  appCoordinator.onActivityCreated({
+    activity: { id: 'activity-1', description: 'Test' }
+  });
+  expect(refreshUI).toHaveBeenCalledTimes(1);
 });
 
 test('onActivityEdited refreshes UI', () => {
-    appCoordinator.onActivityEdited({
-        activity: { id: 'activity-1', description: 'Test' }
-    });
-    expect(refreshUI).toHaveBeenCalledTimes(1);
+  appCoordinator.onActivityEdited({
+    activity: { id: 'activity-1', description: 'Test' }
+  });
+  expect(refreshUI).toHaveBeenCalledTimes(1);
 });
 
 test('onActivityDeleted refreshes UI', () => {
-    appCoordinator.onActivityDeleted({
-        activity: { id: 'activity-1', description: 'Test' }
-    });
-    expect(refreshUI).toHaveBeenCalledTimes(1);
+  appCoordinator.onActivityDeleted({
+    activity: { id: 'activity-1', description: 'Test' }
+  });
+  expect(refreshUI).toHaveBeenCalledTimes(1);
 });
 
 test('onActivityCreated does nothing when activity is null', () => {
-    appCoordinator.onActivityCreated({ activity: null });
-    expect(refreshUI).not.toHaveBeenCalled();
+  appCoordinator.onActivityCreated({ activity: null });
+  expect(refreshUI).not.toHaveBeenCalled();
 });
 
 test('onTaskCompleted auto-logs when activities are enabled and task is scheduled', () => {
-    isActivitiesEnabled.mockReturnValue(true);
-    const task = {
-        id: 'sched-123',
-        type: 'scheduled',
-        description: 'Standup',
-        startDateTime: '2026-04-07T09:00:00.000Z',
-        endDateTime: '2026-04-07T09:30:00.000Z',
-        duration: 30,
-        category: 'work/meetings'
-    };
+  isActivitiesEnabled.mockReturnValue(true);
+  const task = {
+    id: 'sched-123',
+    type: 'scheduled',
+    description: 'Standup',
+    startDateTime: '2026-04-07T09:00:00.000Z',
+    endDateTime: '2026-04-07T09:30:00.000Z',
+    duration: 30,
+    category: 'work/meetings'
+  };
 
-    appCoordinator.onTaskCompleted({ task });
+  appCoordinator.onTaskCompleted({ task });
 
-    expect(createActivityFromTask).toHaveBeenCalledWith(task);
-    expect(addActivity).toHaveBeenCalled();
+  expect(createActivityFromTask).toHaveBeenCalledWith(task);
+  expect(addActivity).toHaveBeenCalled();
 });
 
 test('onTaskCompleted does not auto-log when activities are disabled', () => {
-    isActivitiesEnabled.mockReturnValue(false);
-    const task = { id: 'sched-456', type: 'scheduled' };
+  isActivitiesEnabled.mockReturnValue(false);
+  const task = { id: 'sched-456', type: 'scheduled' };
 
-    appCoordinator.onTaskCompleted({ task });
+  appCoordinator.onTaskCompleted({ task });
 
-    expect(createActivityFromTask).not.toHaveBeenCalled();
-    expect(addActivity).not.toHaveBeenCalled();
+  expect(createActivityFromTask).not.toHaveBeenCalled();
+  expect(addActivity).not.toHaveBeenCalled();
 });
 
 test('onTaskCompleted does not auto-log unscheduled tasks even when activities enabled', () => {
-    isActivitiesEnabled.mockReturnValue(true);
-    const task = { id: 'unsched-789', type: 'unscheduled' };
+  isActivitiesEnabled.mockReturnValue(true);
+  const task = { id: 'unsched-789', type: 'unscheduled' };
 
-    appCoordinator.onTaskCompleted({ task });
+  appCoordinator.onTaskCompleted({ task });
 
-    expect(createActivityFromTask).not.toHaveBeenCalled();
+  expect(createActivityFromTask).not.toHaveBeenCalled();
 });
 ```
 
@@ -530,6 +555,7 @@ git commit -m "test: add failing tests for coordinator activity events and auto-
 ### Task 4: Coordinator activity events + auto-logging — implementation
 
 **Files:**
+
 - Modify: `public/js/app-coordinator.js`
 
 - [ ] **Step 1: Add activity events and auto-logging to the coordinator**
@@ -547,24 +573,24 @@ Add new event functions after the existing task events:
 // --- Activity Events ---
 
 export function onActivityCreated({ activity }) {
-    if (!activity) {
-        return;
-    }
-    refreshUI();
+  if (!activity) {
+    return;
+  }
+  refreshUI();
 }
 
 export function onActivityEdited({ activity }) {
-    if (!activity) {
-        return;
-    }
-    refreshUI();
+  if (!activity) {
+    return;
+  }
+  refreshUI();
 }
 
 export function onActivityDeleted({ activity }) {
-    if (!activity) {
-        return;
-    }
-    refreshUI();
+  if (!activity) {
+    return;
+  }
+  refreshUI();
 }
 ```
 
@@ -572,21 +598,21 @@ Modify the existing `onTaskCompleted` to add auto-logging. Replace the entire fu
 
 ```js
 export function onTaskCompleted({ task }) {
-    if (!task) {
-        return;
-    }
-    refreshUI();
-    if (task.type === 'scheduled') {
-        triggerConfettiAnimation(task.id);
+  if (!task) {
+    return;
+  }
+  refreshUI();
+  if (task.type === 'scheduled') {
+    triggerConfettiAnimation(task.id);
 
-        // Auto-log activity (fire-and-forget)
-        if (isActivitiesEnabled()) {
-            const activityData = createActivityFromTask(task);
-            addActivity(activityData).catch((err) => {
-                logger.warn('Auto-logging activity failed:', err);
-            });
-        }
+    // Auto-log activity (fire-and-forget)
+    if (isActivitiesEnabled()) {
+      const activityData = createActivityFromTask(task);
+      addActivity(activityData).catch((err) => {
+        logger.warn('Auto-logging activity failed:', err);
+      });
     }
+  }
 }
 ```
 
@@ -620,6 +646,7 @@ git commit -m "feat: add coordinator activity events and auto-logging on task co
 ### Task 5: Add sky theme to toast-manager and activity theme mapping
 
 **Files:**
+
 - Modify: `public/js/toast-manager.js`
 - Modify: `public/js/utils.js`
 
@@ -629,12 +656,12 @@ In `public/js/toast-manager.js`, add `sky` to the `THEME_CLASSES` object:
 
 ```js
 const THEME_CLASSES = {
-    teal: 'bg-teal-900/90 border-teal-700 text-teal-200',
-    indigo: 'bg-indigo-900/90 border-indigo-700 text-indigo-200',
-    sky: 'bg-sky-900/90 border-sky-700 text-sky-200',
-    amber: 'bg-amber-900/90 border-amber-700 text-amber-200',
-    rose: 'bg-rose-900/90 border-rose-700 text-rose-200',
-    default: 'bg-slate-800/90 border-slate-600 text-slate-200'
+  teal: 'bg-teal-900/90 border-teal-700 text-teal-200',
+  indigo: 'bg-indigo-900/90 border-indigo-700 text-indigo-200',
+  sky: 'bg-sky-900/90 border-sky-700 text-sky-200',
+  amber: 'bg-amber-900/90 border-amber-700 text-amber-200',
+  rose: 'bg-rose-900/90 border-rose-700 text-rose-200',
+  default: 'bg-slate-800/90 border-slate-600 text-slate-200'
 };
 ```
 
@@ -644,13 +671,13 @@ In `public/js/utils.js`, update both functions:
 
 ```js
 export function getThemeForTask(task) {
-    if (task?.type === 'activity' || task?.docType === 'activity') return 'sky';
-    return task?.type === 'scheduled' ? 'teal' : 'indigo';
+  if (task?.type === 'activity' || task?.docType === 'activity') return 'sky';
+  return task?.type === 'scheduled' ? 'teal' : 'indigo';
 }
 
 export function getThemeForTaskType(taskType) {
-    if (taskType === 'activity') return 'sky';
-    return taskType === 'scheduled' ? 'teal' : 'indigo';
+  if (taskType === 'activity') return 'sky';
+  return taskType === 'scheduled' ? 'teal' : 'indigo';
 }
 ```
 
@@ -673,6 +700,7 @@ git commit -m "feat: add sky theme for activities and update theme helpers"
 ### Task 6: Activity form-utils — failing tests
 
 **Files:**
+
 - Create: `__tests__/activity-form-utils.test.js`
 
 - [ ] **Step 1: Write failing tests for extractActivityFormData**
@@ -683,22 +711,24 @@ git commit -m "feat: add sky theme for activities and update theme helpers"
  */
 
 jest.mock('../public/js/modal-manager.js', () => ({
-    showAlert: jest.fn()
+  showAlert: jest.fn()
 }));
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
-    resolveCategoryKey: jest.fn((key) => (key ? { kind: 'category', record: { key } } : null))
+  resolveCategoryKey: jest.fn((key) =>
+    key ? { kind: 'category', record: { key } } : null
+  )
 }));
 
 import { extractActivityFormData } from '../public/js/activities/form-utils.js';
 import { showAlert } from '../public/js/modal-manager.js';
 
 describe('extractActivityFormData', () => {
-    let formElement;
+  let formElement;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        document.body.innerHTML = `
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = `
             <form id="task-form">
                 <input type="text" name="description" value="Deep work" />
                 <input type="radio" name="task-type" value="activity" checked />
@@ -711,64 +741,64 @@ describe('extractActivityFormData', () => {
                 <input type="number" name="duration-minutes" value="30" />
             </form>
         `;
-        formElement = document.getElementById('task-form');
-    });
+    formElement = document.getElementById('task-form');
+  });
 
-    test('extracts valid activity form data', () => {
-        const result = extractActivityFormData(formElement);
+  test('extracts valid activity form data', () => {
+    const result = extractActivityFormData(formElement);
 
-        expect(result).not.toBeNull();
-        expect(result.description).toBe('Deep work');
-        expect(result.category).toBe('work/deep');
-        expect(result.startTime).toBe('09:00');
-        expect(result.duration).toBe(90);
-    });
+    expect(result).not.toBeNull();
+    expect(result.description).toBe('Deep work');
+    expect(result.category).toBe('work/deep');
+    expect(result.startTime).toBe('09:00');
+    expect(result.duration).toBe(90);
+  });
 
-    test('returns null and alerts for empty description', () => {
-        formElement.querySelector('input[name="description"]').value = '';
+  test('returns null and alerts for empty description', () => {
+    formElement.querySelector('input[name="description"]').value = '';
 
-        const result = extractActivityFormData(formElement);
+    const result = extractActivityFormData(formElement);
 
-        expect(result).toBeNull();
-        expect(showAlert).toHaveBeenCalledWith(
-            expect.stringMatching(/description/i),
-            'sky'
-        );
-    });
+    expect(result).toBeNull();
+    expect(showAlert).toHaveBeenCalledWith(
+      expect.stringMatching(/description/i),
+      'sky'
+    );
+  });
 
-    test('returns null and alerts for missing start time', () => {
-        formElement.querySelector('input[name="start-time"]').value = '';
+  test('returns null and alerts for missing start time', () => {
+    formElement.querySelector('input[name="start-time"]').value = '';
 
-        const result = extractActivityFormData(formElement);
+    const result = extractActivityFormData(formElement);
 
-        expect(result).toBeNull();
-        expect(showAlert).toHaveBeenCalledWith(
-            expect.stringMatching(/start time/i),
-            'sky'
-        );
-    });
+    expect(result).toBeNull();
+    expect(showAlert).toHaveBeenCalledWith(
+      expect.stringMatching(/start time/i),
+      'sky'
+    );
+  });
 
-    test('returns null and alerts for zero duration', () => {
-        formElement.querySelector('input[name="duration-hours"]').value = '0';
-        formElement.querySelector('input[name="duration-minutes"]').value = '0';
+  test('returns null and alerts for zero duration', () => {
+    formElement.querySelector('input[name="duration-hours"]').value = '0';
+    formElement.querySelector('input[name="duration-minutes"]').value = '0';
 
-        const result = extractActivityFormData(formElement);
+    const result = extractActivityFormData(formElement);
 
-        expect(result).toBeNull();
-        expect(showAlert).toHaveBeenCalledWith(
-            expect.stringMatching(/duration/i),
-            'sky'
-        );
-    });
+    expect(result).toBeNull();
+    expect(showAlert).toHaveBeenCalledWith(
+      expect.stringMatching(/duration/i),
+      'sky'
+    );
+  });
 
-    test('returns null category when none selected', () => {
-        formElement.querySelector('#category-select').value = '';
+  test('returns null category when none selected', () => {
+    formElement.querySelector('#category-select').value = '';
 
-        const result = extractActivityFormData(formElement);
+    const result = extractActivityFormData(formElement);
 
-        expect(result).not.toBeNull();
-        expect(result.category).toBeNull();
-    });
+    expect(result).not.toBeNull();
+    expect(result.category).toBeNull();
+  });
 });
 ```
 
@@ -787,6 +817,7 @@ git commit -m "test: add failing tests for activity form-utils"
 ### Task 7: Activity form-utils — implementation
 
 **Files:**
+
 - Create: `public/js/activities/form-utils.js`
 
 - [ ] **Step 1: Implement extractActivityFormData**
@@ -797,51 +828,51 @@ import { showAlert } from '../modal-manager.js';
 import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
 
 export function extractActivityFormData(formElement) {
-    const formData = new FormData(formElement);
-    const description = formData.get('description')?.toString().trim();
+  const formData = new FormData(formElement);
+  const description = formData.get('description')?.toString().trim();
 
-    if (!description) {
-        showAlert('Activity description cannot be empty.', 'sky');
-        return null;
+  if (!description) {
+    showAlert('Activity description cannot be empty.', 'sky');
+    return null;
+  }
+
+  const startTime = formData.get('start-time')?.toString();
+  if (!startTime) {
+    showAlert('Start time is required for activities.', 'sky');
+    return null;
+  }
+
+  const durationResult = parseDuration(
+    formData.get('duration-hours')?.toString() || '0',
+    formData.get('duration-minutes')?.toString() || '0'
+  );
+
+  if (!durationResult.valid) {
+    showAlert(durationResult.error, 'sky');
+    return null;
+  }
+
+  if (durationResult.duration <= 0) {
+    showAlert('Duration must be greater than 0.', 'sky');
+    return null;
+  }
+
+  const categoryKey = formData.get('category')?.toString() || null;
+  let category = null;
+  if (categoryKey) {
+    if (!resolveCategoryKey(categoryKey)) {
+      showAlert('Selected category is no longer available.', 'sky');
+      return null;
     }
+    category = categoryKey;
+  }
 
-    const startTime = formData.get('start-time')?.toString();
-    if (!startTime) {
-        showAlert('Start time is required for activities.', 'sky');
-        return null;
-    }
-
-    const durationResult = parseDuration(
-        formData.get('duration-hours')?.toString() || '0',
-        formData.get('duration-minutes')?.toString() || '0'
-    );
-
-    if (!durationResult.valid) {
-        showAlert(durationResult.error, 'sky');
-        return null;
-    }
-
-    if (durationResult.duration <= 0) {
-        showAlert('Duration must be greater than 0.', 'sky');
-        return null;
-    }
-
-    const categoryKey = formData.get('category')?.toString() || null;
-    let category = null;
-    if (categoryKey) {
-        if (!resolveCategoryKey(categoryKey)) {
-            showAlert('Selected category is no longer available.', 'sky');
-            return null;
-        }
-        category = categoryKey;
-    }
-
-    return {
-        description,
-        category,
-        startTime,
-        duration: durationResult.duration
-    };
+  return {
+    description,
+    category,
+    startTime,
+    duration: durationResult.duration
+  };
 }
 ```
 
@@ -860,6 +891,7 @@ git commit -m "feat: add activity form-utils with extractActivityFormData"
 ### Task 8: Guard task form-utils against activity type
 
 **Files:**
+
 - Modify: `public/js/tasks/form-utils.js`
 
 - [ ] **Step 1: Add guard in extractTaskFormData for activity task-type**
@@ -904,6 +936,7 @@ git commit -m "fix: guard task form-utils against activity task-type"
 ### Task 9: Activity handlers — failing tests
 
 **Files:**
+
 - Create: `__tests__/activity-handlers.test.js`
 
 - [ ] **Step 1: Write failing tests for handleAddActivity, handleDeleteActivity, handleEditActivity**
@@ -914,124 +947,137 @@ git commit -m "fix: guard task form-utils against activity task-type"
  */
 
 jest.mock('../public/js/storage.js', () => ({
-    putActivity: jest.fn(() => Promise.resolve()),
-    loadActivities: jest.fn(() => Promise.resolve([])),
-    deleteActivity: jest.fn(() => Promise.resolve())
+  putActivity: jest.fn(() => Promise.resolve()),
+  loadActivities: jest.fn(() => Promise.resolve([])),
+  deleteActivity: jest.fn(() => Promise.resolve())
 }));
 
 jest.mock('../public/js/activities/manager.js', () => ({
-    addActivity: jest.fn(() =>
-        Promise.resolve({ success: true, activity: { id: 'activity-1', description: 'Test' } })
-    ),
-    removeActivity: jest.fn(() =>
-        Promise.resolve({ success: true, activity: { id: 'activity-1' } })
-    ),
-    editActivity: jest.fn(() =>
-        Promise.resolve({
-            success: true,
-            activity: { id: 'activity-1', description: 'Updated' }
-        })
-    ),
-    getActivityById: jest.fn(() => ({
-        id: 'activity-1',
-        description: 'Test',
-        source: 'manual'
-    }))
+  addActivity: jest.fn(() =>
+    Promise.resolve({
+      success: true,
+      activity: { id: 'activity-1', description: 'Test' }
+    })
+  ),
+  removeActivity: jest.fn(() =>
+    Promise.resolve({ success: true, activity: { id: 'activity-1' } })
+  ),
+  editActivity: jest.fn(() =>
+    Promise.resolve({
+      success: true,
+      activity: { id: 'activity-1', description: 'Updated' }
+    })
+  ),
+  getActivityById: jest.fn(() => ({
+    id: 'activity-1',
+    description: 'Test',
+    source: 'manual'
+  }))
 }));
 
 jest.mock('../public/js/app-coordinator.js', () => ({
-    onActivityCreated: jest.fn(),
-    onActivityEdited: jest.fn(),
-    onActivityDeleted: jest.fn()
+  onActivityCreated: jest.fn(),
+  onActivityEdited: jest.fn(),
+  onActivityDeleted: jest.fn()
 }));
 
 jest.mock('../public/js/modal-manager.js', () => ({
-    showAlert: jest.fn(),
-    askConfirmation: jest.fn(() => Promise.resolve(true))
+  showAlert: jest.fn(),
+  askConfirmation: jest.fn(() => Promise.resolve(true))
 }));
 
 jest.mock('../public/js/toast-manager.js', () => ({
-    showToast: jest.fn()
+  showToast: jest.fn()
 }));
 
 jest.mock('../public/js/dom-renderer.js', () => ({
-    refreshUI: jest.fn(),
-    initializeTaskTypeToggle: jest.fn()
+  refreshUI: jest.fn(),
+  initializeTaskTypeToggle: jest.fn()
 }));
 
 jest.mock('../public/js/tasks/form-utils.js', () => ({
-    focusTaskDescriptionInput: jest.fn(),
-    resetTaskFormPreviewState: jest.fn()
+  focusTaskDescriptionInput: jest.fn(),
+  resetTaskFormPreviewState: jest.fn()
 }));
 
 import {
-    handleAddActivity,
-    handleDeleteActivity,
-    handleEditActivity
+  handleAddActivity,
+  handleDeleteActivity,
+  handleEditActivity
 } from '../public/js/activities/handlers.js';
-import { addActivity, removeActivity, editActivity } from '../public/js/activities/manager.js';
 import {
-    onActivityCreated,
-    onActivityEdited,
-    onActivityDeleted
+  addActivity,
+  removeActivity,
+  editActivity
+} from '../public/js/activities/manager.js';
+import {
+  onActivityCreated,
+  onActivityEdited,
+  onActivityDeleted
 } from '../public/js/app-coordinator.js';
 import { showToast } from '../public/js/toast-manager.js';
 import { showAlert } from '../public/js/modal-manager.js';
 
 describe('activity handlers', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleAddActivity', () => {
+    test('adds activity and calls onActivityCreated on success', async () => {
+      const activityData = {
+        description: 'Deep work',
+        category: 'work/deep',
+        startTime: '09:00',
+        duration: 60
+      };
+
+      await handleAddActivity(activityData);
+
+      expect(addActivity).toHaveBeenCalled();
+      expect(onActivityCreated).toHaveBeenCalled();
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringMatching(/logged/i),
+        expect.objectContaining({ theme: 'sky' })
+      );
     });
 
-    describe('handleAddActivity', () => {
-        test('adds activity and calls onActivityCreated on success', async () => {
-            const activityData = {
-                description: 'Deep work',
-                category: 'work/deep',
-                startTime: '09:00',
-                duration: 60
-            };
+    test('shows alert on failure', async () => {
+      addActivity.mockResolvedValueOnce({
+        success: false,
+        reason: 'Description is required.'
+      });
 
-            await handleAddActivity(activityData);
+      await handleAddActivity({
+        description: '',
+        startTime: '09:00',
+        duration: 60
+      });
 
-            expect(addActivity).toHaveBeenCalled();
-            expect(onActivityCreated).toHaveBeenCalled();
-            expect(showToast).toHaveBeenCalledWith(
-                expect.stringMatching(/logged/i),
-                expect.objectContaining({ theme: 'sky' })
-            );
-        });
-
-        test('shows alert on failure', async () => {
-            addActivity.mockResolvedValueOnce({
-                success: false,
-                reason: 'Description is required.'
-            });
-
-            await handleAddActivity({ description: '', startTime: '09:00', duration: 60 });
-
-            expect(onActivityCreated).not.toHaveBeenCalled();
-            expect(showAlert).toHaveBeenCalled();
-        });
+      expect(onActivityCreated).not.toHaveBeenCalled();
+      expect(showAlert).toHaveBeenCalled();
     });
+  });
 
-    describe('handleDeleteActivity', () => {
-        test('removes activity and calls onActivityDeleted', async () => {
-            await handleDeleteActivity('activity-1');
+  describe('handleDeleteActivity', () => {
+    test('removes activity and calls onActivityDeleted', async () => {
+      await handleDeleteActivity('activity-1');
 
-            expect(removeActivity).toHaveBeenCalledWith('activity-1');
-            expect(onActivityDeleted).toHaveBeenCalled();
-        });
+      expect(removeActivity).toHaveBeenCalledWith('activity-1');
+      expect(onActivityDeleted).toHaveBeenCalled();
     });
+  });
 
-    describe('handleEditActivity', () => {
-        test('edits activity and calls onActivityEdited', async () => {
-            await handleEditActivity('activity-1', { description: 'Updated' });
+  describe('handleEditActivity', () => {
+    test('edits activity and calls onActivityEdited', async () => {
+      await handleEditActivity('activity-1', { description: 'Updated' });
 
-            expect(editActivity).toHaveBeenCalledWith('activity-1', { description: 'Updated' });
-            expect(onActivityEdited).toHaveBeenCalled();
-        });
+      expect(editActivity).toHaveBeenCalledWith('activity-1', {
+        description: 'Updated'
+      });
+      expect(onActivityEdited).toHaveBeenCalled();
     });
+  });
 });
 ```
 
@@ -1050,66 +1096,75 @@ git commit -m "test: add failing tests for activity handlers"
 ### Task 10: Activity handlers — implementation
 
 **Files:**
+
 - Create: `public/js/activities/handlers.js`
 
 - [ ] **Step 1: Implement activity handlers**
 
 ```js
-import { addActivity, removeActivity, editActivity, getActivityById } from './manager.js';
 import {
-    onActivityCreated,
-    onActivityEdited,
-    onActivityDeleted
+  addActivity,
+  removeActivity,
+  editActivity,
+  getActivityById
+} from './manager.js';
+import {
+  onActivityCreated,
+  onActivityEdited,
+  onActivityDeleted
 } from '../app-coordinator.js';
 import { showAlert } from '../modal-manager.js';
 import { showToast } from '../toast-manager.js';
 import { timeToDateTime, calculateEndDateTime, logger } from '../utils.js';
 
 export async function handleAddActivity(activityData) {
-    const startDateTime = timeToDateTime(activityData.startTime);
-    const endDateTime = calculateEndDateTime(startDateTime, activityData.duration);
+  const startDateTime = timeToDateTime(activityData.startTime);
+  const endDateTime = calculateEndDateTime(
+    startDateTime,
+    activityData.duration
+  );
 
-    const result = await addActivity({
-        description: activityData.description,
-        category: activityData.category || null,
-        startDateTime,
-        endDateTime,
-        duration: activityData.duration,
-        source: 'manual',
-        sourceTaskId: null
-    });
+  const result = await addActivity({
+    description: activityData.description,
+    category: activityData.category || null,
+    startDateTime,
+    endDateTime,
+    duration: activityData.duration,
+    source: 'manual',
+    sourceTaskId: null
+  });
 
-    if (result.success) {
-        onActivityCreated({ activity: result.activity });
-        showToast('Activity logged.', { theme: 'sky' });
-    } else {
-        showAlert(result.reason, 'sky');
-    }
+  if (result.success) {
+    onActivityCreated({ activity: result.activity });
+    showToast('Activity logged.', { theme: 'sky' });
+  } else {
+    showAlert(result.reason, 'sky');
+  }
 }
 
 export async function handleDeleteActivity(activityId) {
-    const activity = getActivityById(activityId);
-    if (!activity) {
-        logger.warn('handleDeleteActivity: activity not found', activityId);
-        return;
-    }
+  const activity = getActivityById(activityId);
+  if (!activity) {
+    logger.warn('handleDeleteActivity: activity not found', activityId);
+    return;
+  }
 
-    const result = await removeActivity(activityId);
-    if (result.success) {
-        onActivityDeleted({ activity: result.activity });
-        showToast('Activity removed.', { theme: 'sky' });
-    } else {
-        showAlert(result.reason, 'sky');
-    }
+  const result = await removeActivity(activityId);
+  if (result.success) {
+    onActivityDeleted({ activity: result.activity });
+    showToast('Activity removed.', { theme: 'sky' });
+  } else {
+    showAlert(result.reason, 'sky');
+  }
 }
 
 export async function handleEditActivity(activityId, updates) {
-    const result = await editActivity(activityId, updates);
-    if (result.success) {
-        onActivityEdited({ activity: result.activity });
-    } else {
-        showAlert(result.reason, 'sky');
-    }
+  const result = await editActivity(activityId, updates);
+  if (result.success) {
+    onActivityEdited({ activity: result.activity });
+  } else {
+    showAlert(result.reason, 'sky');
+  }
 }
 ```
 
@@ -1132,6 +1187,7 @@ git commit -m "feat: add activity handlers for add, delete, edit"
 ### Task 11: Activity renderer — failing tests
 
 **Files:**
+
 - Create: `__tests__/activity-renderer.test.js`
 
 - [ ] **Step 1: Write failing tests for renderActivities**
@@ -1142,127 +1198,127 @@ git commit -m "feat: add activity handlers for add, delete, edit"
  */
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
-    renderCategoryBadge: jest.fn((key) =>
-        key ? `<span class="category-badge">${key}</span>` : ''
-    )
+  renderCategoryBadge: jest.fn((key) =>
+    key ? `<span class="category-badge">${key}</span>` : ''
+  )
 }));
 
 import { renderActivities } from '../public/js/activities/renderer.js';
 
 describe('activity renderer', () => {
-    let container;
+  let container;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        document.body.innerHTML = '<div id="activity-list"></div>';
-        container = document.getElementById('activity-list');
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '<div id="activity-list"></div>';
+    container = document.getElementById('activity-list');
+  });
 
-    test('renders empty state when no activities', () => {
-        renderActivities([], container);
+  test('renders empty state when no activities', () => {
+    renderActivities([], container);
 
-        expect(container.innerHTML).toContain('No activities');
-    });
+    expect(container.innerHTML).toContain('No activities');
+  });
 
-    test('renders activity with description and time range', () => {
-        const activities = [
-            {
-                id: 'activity-1',
-                description: 'Deep work',
-                category: 'work/deep',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            }
-        ];
+  test('renders activity with description and time range', () => {
+    const activities = [
+      {
+        id: 'activity-1',
+        description: 'Deep work',
+        category: 'work/deep',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      }
+    ];
 
-        renderActivities(activities, container);
+    renderActivities(activities, container);
 
-        expect(container.innerHTML).toContain('Deep work');
-        expect(container.innerHTML).toContain('1h');
-        expect(container.querySelectorAll('[data-activity-id]')).toHaveLength(1);
-    });
+    expect(container.innerHTML).toContain('Deep work');
+    expect(container.innerHTML).toContain('1h');
+    expect(container.querySelectorAll('[data-activity-id]')).toHaveLength(1);
+  });
 
-    test('renders edit and delete buttons for manual activities', () => {
-        const activities = [
-            {
-                id: 'activity-1',
-                description: 'Manual',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            }
-        ];
+  test('renders edit and delete buttons for manual activities', () => {
+    const activities = [
+      {
+        id: 'activity-1',
+        description: 'Manual',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      }
+    ];
 
-        renderActivities(activities, container);
+    renderActivities(activities, container);
 
-        expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
-        expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
-    });
+    expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
+    expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
+  });
 
-    test('renders source task link for auto-logged activities instead of edit/delete', () => {
-        const activities = [
-            {
-                id: 'activity-2',
-                description: 'Auto standup',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T09:30:00.000Z',
-                duration: 30,
-                source: 'auto',
-                sourceTaskId: 'sched-123'
-            }
-        ];
+  test('renders source task link plus edit/delete actions for auto-logged activities', () => {
+    const activities = [
+      {
+        id: 'activity-2',
+        description: 'Auto standup',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T09:30:00.000Z',
+        duration: 30,
+        source: 'auto',
+        sourceTaskId: 'sched-123'
+      }
+    ];
 
-        renderActivities(activities, container);
+    renderActivities(activities, container);
 
-        expect(container.querySelector('.btn-edit-activity')).toBeNull();
-        expect(container.querySelector('.btn-delete-activity')).toBeNull();
-        const sourceLink = container.querySelector('.activity-source-link');
-        expect(sourceLink).not.toBeNull();
-        expect(sourceLink.dataset.sourceTaskId).toBe('sched-123');
-    });
+    expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
+    expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
+    const sourceLink = container.querySelector('.activity-source-link');
+    expect(sourceLink).not.toBeNull();
+    expect(sourceLink.dataset.sourceTaskId).toBe('sched-123');
+  });
 
-    test('renders category badge when category is present', () => {
-        const activities = [
-            {
-                id: 'activity-3',
-                description: 'Categorized',
-                category: 'work/deep',
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            }
-        ];
+  test('renders category badge when category is present', () => {
+    const activities = [
+      {
+        id: 'activity-3',
+        description: 'Categorized',
+        category: 'work/deep',
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      }
+    ];
 
-        renderActivities(activities, container);
+    renderActivities(activities, container);
 
-        expect(container.innerHTML).toContain('category-badge');
-    });
+    expect(container.innerHTML).toContain('category-badge');
+  });
 
-    test('omits category badge when category is null', () => {
-        const activities = [
-            {
-                id: 'activity-4',
-                description: 'No category',
-                category: null,
-                startDateTime: '2026-04-07T09:00:00.000Z',
-                endDateTime: '2026-04-07T10:00:00.000Z',
-                duration: 60,
-                source: 'manual',
-                sourceTaskId: null
-            }
-        ];
+  test('omits category badge when category is null', () => {
+    const activities = [
+      {
+        id: 'activity-4',
+        description: 'No category',
+        category: null,
+        startDateTime: '2026-04-07T09:00:00.000Z',
+        endDateTime: '2026-04-07T10:00:00.000Z',
+        duration: 60,
+        source: 'manual',
+        sourceTaskId: null
+      }
+    ];
 
-        renderActivities(activities, container);
+    renderActivities(activities, container);
 
-        expect(container.innerHTML).not.toContain('category-badge');
-    });
+    expect(container.innerHTML).not.toContain('category-badge');
+  });
 });
 ```
 
@@ -1281,31 +1337,39 @@ git commit -m "test: add failing tests for activity renderer"
 ### Task 12: Activity renderer — implementation
 
 **Files:**
+
 - Create: `public/js/activities/renderer.js`
 
 - [ ] **Step 1: Implement renderActivities**
 
 ```js
 import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
-import { calculateHoursAndMinutes, extractTimeFromDateTime, convertTo12HourTime } from '../utils.js';
+import {
+  calculateHoursAndMinutes,
+  extractTimeFromDateTime,
+  convertTo12HourTime
+} from '../utils.js';
 
 function formatTimeRange(startDateTime, endDateTime) {
-    const startTime = extractTimeFromDateTime(new Date(startDateTime));
-    const endTime = extractTimeFromDateTime(new Date(endDateTime));
-    return `${convertTo12HourTime(startTime)} – ${convertTo12HourTime(endTime)}`;
+  const startTime = extractTimeFromDateTime(new Date(startDateTime));
+  const endTime = extractTimeFromDateTime(new Date(endDateTime));
+  return `${convertTo12HourTime(startTime)} – ${convertTo12HourTime(endTime)}`;
 }
 
 function renderActivityItem(activity) {
-    const timeRange = formatTimeRange(activity.startDateTime, activity.endDateTime);
-    const durationText = calculateHoursAndMinutes(activity.duration);
-    const badge = renderCategoryBadge(activity.category);
-    const isAuto = activity.source === 'auto';
+  const timeRange = formatTimeRange(
+    activity.startDateTime,
+    activity.endDateTime
+  );
+  const durationText = calculateHoursAndMinutes(activity.duration);
+  const badge = renderCategoryBadge(activity.category);
+  const isAuto = activity.source === 'auto';
 
-    const actionsHtml = isAuto
-        ? `<span class="activity-source-link text-xs text-sky-400/60 italic cursor-default" data-source-task-id="${activity.sourceTaskId}" title="Auto-logged from task">
+  const actionsHtml = isAuto
+    ? `<span class="activity-source-link text-xs text-sky-400/60 italic cursor-default" data-source-task-id="${activity.sourceTaskId}" title="Auto-logged from task">
                <i class="fa-solid fa-link mr-0.5"></i>auto
            </span>`
-        : `<div class="flex items-center gap-2">
+    : `<div class="flex items-center gap-2">
                <button class="btn-edit-activity text-sky-400/60 hover:text-sky-400 transition-colors text-xs" title="Edit activity">
                    <i class="fa-solid fa-pen"></i>
                </button>
@@ -1314,7 +1378,7 @@ function renderActivityItem(activity) {
                </button>
            </div>`;
 
-    return `<div class="activity-item flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/50 hover:border-sky-700/30 transition-colors" data-activity-id="${activity.id}">
+  return `<div class="activity-item flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/50 hover:border-sky-700/30 transition-colors" data-activity-id="${activity.id}">
         <div class="flex-grow min-w-0">
             <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-sm text-slate-200 truncate">${escapeHtml(activity.description)}</span>
@@ -1331,27 +1395,27 @@ function renderActivityItem(activity) {
 }
 
 export function renderActivities(activities, container) {
-    if (!container) return;
+  if (!container) return;
 
-    if (!activities || activities.length === 0) {
-        container.innerHTML = `
+  if (!activities || activities.length === 0) {
+    container.innerHTML = `
             <div class="text-center py-6 text-slate-500 text-sm">
                 <i class="fa-regular fa-clock mr-1"></i>
                 No activities tracked today. Log one or complete a scheduled task.
             </div>`;
-        return;
-    }
+    return;
+  }
 
-    container.innerHTML = activities.map(renderActivityItem).join('');
+  container.innerHTML = activities.map(renderActivityItem).join('');
 }
 
 function escapeHtml(value) {
-    return value
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&#39;');
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 ```
 
@@ -1374,6 +1438,7 @@ git commit -m "feat: add activity renderer with chronological list and empty sta
 ### Task 13: Update index.html with activity radio and activity list container
 
 **Files:**
+
 - Modify: `public/index.html`
 
 - [ ] **Step 1: Add Activity radio option to the form**
@@ -1381,29 +1446,22 @@ git commit -m "feat: add activity renderer with chronological list and empty sta
 In `public/index.html`, inside the `<div class="flex flex-col sm:flex-row sm:space-x-4 mb-2">` that holds the Scheduled and Unscheduled radio buttons, add a third option after the Unscheduled radio div. Add it inside a hidden wrapper so it only shows when Activities are enabled:
 
 ```html
-                        <div
-                            id="activity-radio-container"
-                            class="hidden"
-                        >
-                            <div
-                                class="flex items-center p-1.5 rounded hover:bg-slate-700/50 transition-colors"
-                            >
-                                <input
-                                    id="activity"
-                                    type="radio"
-                                    name="task-type"
-                                    value="activity"
-                                    class="mr-2 h-4 w-4 text-sky-400 focus:ring-sky-400"
-                                />
-                                <label
-                                    for="activity"
-                                    class="text-slate-300 flex items-center text-sm"
-                                >
-                                    <i class="fa-regular fa-clock mr-1 text-sky-400/75"></i
-                                    >Activity
-                                </label>
-                            </div>
-                        </div>
+<div id="activity-radio-container" class="hidden">
+  <div
+    class="flex items-center p-1.5 rounded hover:bg-slate-700/50 transition-colors"
+  >
+    <input
+      id="activity"
+      type="radio"
+      name="task-type"
+      value="activity"
+      class="mr-2 h-4 w-4 text-sky-400 focus:ring-sky-400"
+    />
+    <label for="activity" class="text-slate-300 flex items-center text-sm">
+      <i class="fa-regular fa-clock mr-1 text-sky-400/75"></i>Activity
+    </label>
+  </div>
+</div>
 ```
 
 - [ ] **Step 2: Add activity list container below unscheduled tasks**
@@ -1411,19 +1469,22 @@ In `public/index.html`, inside the `<div class="flex flex-col sm:flex-row sm:spa
 In `public/index.html`, after the `<!-- Unscheduled Tasks Section -->` closing `</div>`, add the activity section. Place it before the `<!-- Info Panel -->`:
 
 ```html
-                <!-- Activity Log Section (hidden until Activities enabled) -->
-                <div id="activities-container" class="hidden text-left mb-4 sm:mb-6 px-2 sm:px-0">
-                    <div class="flex justify-between items-center mb-2 sm:mb-3">
-                        <h3
-                            class="text-lg sm:text-xl font-normal text-sky-400 pl-2 flex items-center"
-                        >
-                            <i class="fa-regular fa-clock mr-2"></i>Today's Activities
-                        </h3>
-                    </div>
-                    <div id="activity-list" class="space-y-1.5">
-                        <!-- activities will be generated here by JavaScript -->
-                    </div>
-                </div>
+<!-- Activity Log Section (hidden until Activities enabled) -->
+<div
+  id="activities-container"
+  class="hidden text-left mb-4 sm:mb-6 px-2 sm:px-0"
+>
+  <div class="flex justify-between items-center mb-2 sm:mb-3">
+    <h3
+      class="text-lg sm:text-xl font-normal text-sky-400 pl-2 flex items-center"
+    >
+      <i class="fa-regular fa-clock mr-2"></i>Today's Activities
+    </h3>
+  </div>
+  <div id="activity-list" class="space-y-1.5">
+    <!-- activities will be generated here by JavaScript -->
+  </div>
+</div>
 ```
 
 - [ ] **Step 3: Verify the page loads without errors**
@@ -1440,6 +1501,7 @@ git commit -m "feat: add activity radio option and activity list container to HT
 ### Task 14: Update test-utils.js setupDOM
 
 **Files:**
+
 - Modify: `__tests__/test-utils.js`
 
 - [ ] **Step 1: Add activity radio and activity list container to setupDOM**
@@ -1447,16 +1509,16 @@ git commit -m "feat: add activity radio option and activity list container to HT
 In `__tests__/test-utils.js`, inside the `setupDOM()` function's `document.body.innerHTML` template, add the activity radio after the unscheduled radio in the task-type-toggle section:
 
 ```html
-          <input type="radio" id="activity" name="task-type" value="activity" />
-          <label for="activity">Activity</label>
+<input type="radio" id="activity" name="task-type" value="activity" />
+<label for="activity">Activity</label>
 ```
 
 And add the activity list container after the unscheduled task list:
 
 ```html
-      <div id="activities-container" class="hidden">
-        <div id="activity-list"></div>
-      </div>
+<div id="activities-container" class="hidden">
+  <div id="activity-list"></div>
+</div>
 ```
 
 - [ ] **Step 2: Run full test suite to verify no regressions**
@@ -1474,6 +1536,7 @@ git commit -m "test: add activity radio and list container to test DOM setup"
 ### Task 15: Three-way form toggle in dom-renderer.js
 
 **Files:**
+
 - Modify: `public/js/dom-renderer.js`
 
 - [ ] **Step 1: Extend initializeTaskTypeToggle to handle three modes**
@@ -1482,78 +1545,86 @@ In `public/js/dom-renderer.js`, replace the `initializeTaskTypeToggle` function.
 
 ```js
 export function initializeTaskTypeToggle() {
-    const scheduledRadio = document.getElementById('scheduled');
-    const unscheduledRadio = document.getElementById('unscheduled');
-    const activityRadio = document.getElementById('activity');
-    const timeInputs = document.getElementById('time-inputs');
-    const priorityInput = document.getElementById('priority-input');
-    const addTaskButton = document.querySelector('#task-form button[type="submit"]');
-    const descriptionInput = document.querySelector('input[name="description"]');
-    const startTimeInput = document.querySelector('input[name="start-time"]');
+  const scheduledRadio = document.getElementById('scheduled');
+  const unscheduledRadio = document.getElementById('unscheduled');
+  const activityRadio = document.getElementById('activity');
+  const timeInputs = document.getElementById('time-inputs');
+  const priorityInput = document.getElementById('priority-input');
+  const addTaskButton = document.querySelector(
+    '#task-form button[type="submit"]'
+  );
+  const descriptionInput = document.querySelector('input[name="description"]');
+  const startTimeInput = document.querySelector('input[name="start-time"]');
 
-    if (
-        scheduledRadio instanceof HTMLInputElement &&
-        unscheduledRadio instanceof HTMLInputElement &&
-        timeInputs instanceof HTMLElement &&
-        priorityInput instanceof HTMLElement &&
-        addTaskButton instanceof HTMLElement &&
-        descriptionInput instanceof HTMLElement
-    ) {
-        const toggleVisibility = () => {
-            const isActivity = activityRadio instanceof HTMLInputElement && activityRadio.checked;
+  if (
+    scheduledRadio instanceof HTMLInputElement &&
+    unscheduledRadio instanceof HTMLInputElement &&
+    timeInputs instanceof HTMLElement &&
+    priorityInput instanceof HTMLElement &&
+    addTaskButton instanceof HTMLElement &&
+    descriptionInput instanceof HTMLElement
+  ) {
+    const toggleVisibility = () => {
+      const isActivity =
+        activityRadio instanceof HTMLInputElement && activityRadio.checked;
 
-            if (scheduledRadio.checked) {
-                timeInputs.classList.remove('hidden');
-                priorityInput.classList.add('hidden');
-                if (startTimeInput) startTimeInput.setAttribute('required', '');
-                addTaskButton.className =
-                    'shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
-                descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all';
-                descriptionInput.placeholder = 'Describe your task...';
-                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
-            } else if (isActivity) {
-                timeInputs.classList.remove('hidden');
-                priorityInput.classList.add('hidden');
-                if (startTimeInput) startTimeInput.setAttribute('required', '');
-                addTaskButton.className =
-                    'shrink-0 bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
-                descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all';
-                descriptionInput.placeholder = 'What did you work on?';
-                addTaskButton.innerHTML = '<i class="fa-regular fa-clock mr-2"></i>Log Activity';
-            } else {
-                timeInputs.classList.add('hidden');
-                priorityInput.classList.remove('hidden');
-                if (startTimeInput) startTimeInput.removeAttribute('required');
-                addTaskButton.className =
-                    'shrink-0 bg-gradient-to-r from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
-                descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-indigo-400 focus:outline-none transition-all';
-                descriptionInput.placeholder = 'Describe your task...';
-                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
-            }
-        };
+      if (scheduledRadio.checked) {
+        timeInputs.classList.remove('hidden');
+        priorityInput.classList.add('hidden');
+        if (startTimeInput) startTimeInput.setAttribute('required', '');
+        addTaskButton.className =
+          'shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+        descriptionInput.className =
+          'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all';
+        descriptionInput.placeholder = 'Describe your task...';
+        addTaskButton.innerHTML =
+          '<i class="fa-regular fa-plus mr-2"></i>Add Task';
+      } else if (isActivity) {
+        timeInputs.classList.remove('hidden');
+        priorityInput.classList.add('hidden');
+        if (startTimeInput) startTimeInput.setAttribute('required', '');
+        addTaskButton.className =
+          'shrink-0 bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+        descriptionInput.className =
+          'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all';
+        descriptionInput.placeholder = 'What did you work on?';
+        addTaskButton.innerHTML =
+          '<i class="fa-regular fa-clock mr-2"></i>Log Activity';
+      } else {
+        timeInputs.classList.add('hidden');
+        priorityInput.classList.remove('hidden');
+        if (startTimeInput) startTimeInput.removeAttribute('required');
+        addTaskButton.className =
+          'shrink-0 bg-gradient-to-r from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+        descriptionInput.className =
+          'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-indigo-400 focus:outline-none transition-all';
+        descriptionInput.placeholder = 'Describe your task...';
+        addTaskButton.innerHTML =
+          '<i class="fa-regular fa-plus mr-2"></i>Add Task';
+      }
+    };
 
-        scheduledRadio.addEventListener('change', toggleVisibility);
-        unscheduledRadio.addEventListener('change', toggleVisibility);
-        if (activityRadio instanceof HTMLInputElement) {
-            activityRadio.addEventListener('change', toggleVisibility);
-        }
-        toggleVisibility();
-
-        document.addEventListener('visibilitychange', () => {
-            if (!document.hidden) {
-                toggleVisibility();
-            }
-        });
-
-        window.addEventListener('focus', () => {
-            toggleVisibility();
-        });
-    } else {
-        logger.error('DOM elements for task type toggle not found or not of expected types.');
+    scheduledRadio.addEventListener('change', toggleVisibility);
+    unscheduledRadio.addEventListener('change', toggleVisibility);
+    if (activityRadio instanceof HTMLInputElement) {
+      activityRadio.addEventListener('change', toggleVisibility);
     }
+    toggleVisibility();
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) {
+        toggleVisibility();
+      }
+    });
+
+    window.addEventListener('focus', () => {
+      toggleVisibility();
+    });
+  } else {
+    logger.error(
+      'DOM elements for task type toggle not found or not of expected types.'
+    );
+  }
 }
 ```
 
@@ -1576,6 +1647,7 @@ git commit -m "feat: extend form toggle to support three-way scheduled/unschedul
 ### Task 16: Wire activities into app.js boot sequence
 
 **Files:**
+
 - Modify: `public/js/app.js`
 
 - [ ] **Step 1: Add activity imports to app.js**
@@ -1583,10 +1655,17 @@ git commit -m "feat: extend form toggle to support three-way scheduled/unschedul
 Add these imports to the top of `public/js/app.js`:
 
 ```js
-import { loadActivitiesState, getTodaysActivities } from './activities/manager.js';
+import {
+  loadActivitiesState,
+  getTodaysActivities
+} from './activities/manager.js';
 import { renderActivities } from './activities/renderer.js';
 import { extractActivityFormData } from './activities/form-utils.js';
-import { handleAddActivity, handleDeleteActivity, handleEditActivity } from './activities/handlers.js';
+import {
+  handleAddActivity,
+  handleDeleteActivity,
+  handleEditActivity
+} from './activities/handlers.js';
 ```
 
 - [ ] **Step 2: Load activities during boot**
@@ -1594,10 +1673,10 @@ import { handleAddActivity, handleDeleteActivity, handleEditActivity } from './a
 In the `initAndBootApp` function, after `await loadTaxonomy();`, add:
 
 ```js
-    // Load activities state
-    if (isActivitiesEnabled()) {
-        await loadActivitiesState();
-    }
+// Load activities state
+if (isActivitiesEnabled()) {
+  await loadActivitiesState();
+}
 ```
 
 - [ ] **Step 3: Show/hide activity UI containers based on feature flag**
@@ -1605,17 +1684,19 @@ In the `initAndBootApp` function, after `await loadTaxonomy();`, add:
 In the `initAndBootApp` function, after the existing `if (isActivitiesEnabled())` block that reveals the category dropdown, add code to reveal the activity containers:
 
 ```js
-    if (isActivitiesEnabled()) {
-        const activityRadioContainer = document.getElementById('activity-radio-container');
-        if (activityRadioContainer) {
-            activityRadioContainer.classList.remove('hidden');
-        }
+if (isActivitiesEnabled()) {
+  const activityRadioContainer = document.getElementById(
+    'activity-radio-container'
+  );
+  if (activityRadioContainer) {
+    activityRadioContainer.classList.remove('hidden');
+  }
 
-        const activitiesContainer = document.getElementById('activities-container');
-        if (activitiesContainer) {
-            activitiesContainer.classList.remove('hidden');
-        }
-    }
+  const activitiesContainer = document.getElementById('activities-container');
+  if (activitiesContainer) {
+    activitiesContainer.classList.remove('hidden');
+  }
+}
 ```
 
 - [ ] **Step 4: Route form submission to activity handler when activity mode is selected**
@@ -1654,12 +1735,12 @@ Modify the `onTaskFormSubmit` callback inside `initAndBootApp`. Replace the exis
 In the `initAndBootApp` function, modify the `refreshTaskDisplays` closure to also render activities. After the existing `refreshCurrentGapHighlight();` line, add:
 
 ```js
-        if (isActivitiesEnabled()) {
-            const activityListEl = document.getElementById('activity-list');
-            if (activityListEl) {
-                renderActivities(getTodaysActivities(), activityListEl);
-            }
-        }
+if (isActivitiesEnabled()) {
+  const activityListEl = document.getElementById('activity-list');
+  if (activityListEl) {
+    renderActivities(getTodaysActivities(), activityListEl);
+  }
+}
 ```
 
 - [ ] **Step 6: Add activity list event delegation for edit and delete buttons**
@@ -1667,33 +1748,31 @@ In the `initAndBootApp` function, modify the `refreshTaskDisplays` closure to al
 In the `initAndBootApp` function, after the existing event listener setup (after `initializeClearTasksHandlers()`), add:
 
 ```js
-    // Activity list event delegation
-    if (isActivitiesEnabled()) {
-        const activityList = document.getElementById('activity-list');
-        if (activityList) {
-            activityList.addEventListener('click', (event) => {
-                const target = event.target;
-                const activityItem = target.closest('[data-activity-id]');
-                if (!activityItem) return;
-                const activityId = activityItem.dataset.activityId;
+// Activity list event delegation
+if (isActivitiesEnabled()) {
+  const activityList = document.getElementById('activity-list');
+  if (activityList) {
+    activityList.addEventListener(
+      'click',
+      (event) => {
+        const target = event.target;
+        const activityItem = target.closest('[data-activity-id]');
+        if (!activityItem) return;
+        const activityId = activityItem.dataset.activityId;
 
-                if (target.closest('.btn-delete-activity')) {
-                    handleDeleteActivity(activityId);
-                } else if (target.closest('.btn-edit-activity')) {
-                    // For v1, edit via a prompt-style inline flow.
-                    // The activity description is extracted from the DOM, presented
-                    // in an editable input, and handleEditActivity is called on save.
-                    // A richer inline edit form can replace this in a future phase.
-                    const descEl = activityItem.querySelector('.text-sm.text-slate-200');
-                    const currentDesc = descEl ? descEl.textContent.trim() : '';
-                    const newDesc = window.prompt('Edit activity description:', currentDesc);
-                    if (newDesc !== null && newDesc.trim() !== '' && newDesc.trim() !== currentDesc) {
-                        handleEditActivity(activityId, { description: newDesc.trim() });
-                    }
-                }
-            }, { signal });
+        if (target.closest('.btn-delete-activity')) {
+          handleDeleteActivity(activityId);
+        } else if (target.closest('.btn-edit-activity')) {
+          // Shipped implementation uses task-style inline row replacement
+          // with full-field editing (description, category, start time, duration)
+          // rather than a prompt/modal description-only flow.
+          enterInlineActivityEdit(activityId);
         }
-    }
+      },
+      { signal }
+    );
+  }
+}
 ```
 
 - [ ] **Step 7: Update refreshFromStorage to reload activities**
@@ -1701,9 +1780,9 @@ In the `initAndBootApp` function, after the existing event listener setup (after
 In the `refreshFromStorage` function, add activity reloading after `await loadTasksIntoState();`:
 
 ```js
-    if (isActivitiesEnabled()) {
-        await loadActivitiesState();
-    }
+if (isActivitiesEnabled()) {
+  await loadActivitiesState();
+}
 ```
 
 - [ ] **Step 8: Run full test suite**
@@ -1731,6 +1810,7 @@ The three-way toggle should show Scheduled, Unscheduled, and Activity. Switching
 - [ ] **Step 3: Log a manual activity**
 
 Select Activity mode, enter a description, pick a category, set a start time and duration, submit. Verify:
+
 - Toast shows "Activity logged."
 - Activity appears in the "Today's Activities" list below
 - Category badge renders if category was selected
@@ -1742,6 +1822,7 @@ Click the pencil icon on the manual activity. A browser prompt should appear wit
 - [ ] **Step 5: Complete a scheduled task and verify auto-logging**
 
 Add a scheduled task, complete it (checkbox). Verify:
+
 - Confetti still triggers
 - A new activity appears in the activity list with a link icon and "auto" label
 - The auto activity shows the correct description, time range, and category
@@ -1754,6 +1835,7 @@ Click the trash icon on a manual activity. Verify it disappears.
 - [ ] **Step 7: Disable Activities and verify clean state**
 
 Toggle Activities off in settings, reload. Verify:
+
 - Activity radio is hidden
 - Activity list section is hidden
 - Completing a scheduled task does NOT create an activity

--- a/public/index.html
+++ b/public/index.html
@@ -705,5 +705,57 @@
                 </div>
             </div>
         </div>
+
+        <div
+            id="activity-edit-modal"
+            class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-50"
+        >
+            <div class="bg-slate-800 border border-slate-700 p-6 rounded-lg max-w-md w-full">
+                <div class="flex justify-between items-center mb-4">
+                    <h3 id="activity-edit-title" class="text-xl font-normal text-sky-400">
+                        Edit Activity
+                    </h3>
+                    <button
+                        id="close-activity-edit-modal"
+                        class="text-slate-400 hover:text-slate-200 p-1"
+                    >
+                        <i class="fa-solid fa-xmark text-xl"></i>
+                    </button>
+                </div>
+                <form id="activity-edit-form" class="space-y-4">
+                    <div>
+                        <label
+                            for="activity-edit-description"
+                            class="block text-sm text-slate-300 mb-2"
+                        >
+                            Description
+                        </label>
+                        <input
+                            id="activity-edit-description"
+                            name="activity-description"
+                            type="text"
+                            class="bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all"
+                            required
+                        />
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <button
+                            id="cancel-activity-edit-modal"
+                            type="button"
+                            class="bg-slate-700 hover:bg-slate-600 px-5 py-2 rounded-lg text-slate-200 transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            id="save-activity-edit-modal"
+                            type="submit"
+                            class="bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-5 py-2 rounded-lg text-white font-normal transition-colors"
+                        >
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -146,6 +146,21 @@
                                 >Unscheduled
                             </label>
                         </div>
+                        <div
+                            id="activity-toggle-option"
+                            class="hidden flex items-center p-1.5 rounded hover:bg-slate-700/50 transition-colors"
+                        >
+                            <input
+                                id="activity"
+                                type="radio"
+                                name="task-type"
+                                value="activity"
+                                class="mr-2 h-4 w-4 text-sky-400 focus:ring-sky-400"
+                            />
+                            <label for="activity" class="text-slate-300 flex items-center text-sm">
+                                <i class="fa-regular fa-clock mr-1 text-sky-400/75"></i>Activity
+                            </label>
+                        </div>
                     </div>
 
                     <div class="mb-2 sm:mb-3">
@@ -373,6 +388,20 @@
                     </div>
                     <div id="unscheduled-task-list" class="grid grid-cols-1 gap-2">
                         <!-- tasks will be generated here by JavaScript -->
+                    </div>
+                </div>
+
+                <div
+                    id="activities-container"
+                    class="hidden text-left mb-4 sm:mb-6 px-2 sm:px-0"
+                >
+                    <div class="flex justify-between items-center mb-2 sm:mb-3">
+                        <h3 class="text-lg sm:text-xl font-normal text-sky-400 pl-2 flex items-center">
+                            <i class="fa-regular fa-clock mr-2"></i>Today's Activities
+                        </h3>
+                    </div>
+                    <div id="activity-list" class="grid grid-cols-1 gap-2">
+                        <!-- activities will be generated here by JavaScript -->
                     </div>
                 </div>
 

--- a/public/js/activities/form-utils.js
+++ b/public/js/activities/form-utils.js
@@ -7,7 +7,7 @@ import {
 import { showAlert } from '../modal-manager.js';
 import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
 
-export function extractActivityFormData(formElement) {
+function extractActivityFields(formElement, options = {}) {
     const formData = new FormData(formElement);
     const description = formData.get('description')?.toString().trim();
     const startTime = formData.get('start-time')?.toString();
@@ -37,8 +37,8 @@ export function extractActivityFormData(formElement) {
         return null;
     }
 
-    const date = extractDateFromDateTime(new Date());
-    const startDateTime = timeToDateTime(startTime, date);
+    const baseDate = options.baseDate || extractDateFromDateTime(new Date());
+    const startDateTime = timeToDateTime(startTime, baseDate);
     const endDateTime = calculateEndDateTime(startDateTime, durationResult.duration);
 
     return {
@@ -46,8 +46,25 @@ export function extractActivityFormData(formElement) {
         category: categoryKey || null,
         startDateTime,
         endDateTime,
-        duration: durationResult.duration,
+        duration: durationResult.duration
+    };
+}
+
+export function extractActivityFormData(formElement) {
+    const fields = extractActivityFields(formElement);
+    if (!fields) {
+        return null;
+    }
+
+    return {
+        ...fields,
         source: 'manual',
         sourceTaskId: null
     };
+}
+
+export function extractActivityEditFormData(formElement) {
+    return extractActivityFields(formElement, {
+        baseDate: formElement?.dataset?.activityDate || extractDateFromDateTime(new Date())
+    });
 }

--- a/public/js/activities/form-utils.js
+++ b/public/js/activities/form-utils.js
@@ -1,0 +1,53 @@
+import {
+    calculateEndDateTime,
+    extractDateFromDateTime,
+    parseDuration,
+    timeToDateTime
+} from '../utils.js';
+import { showAlert } from '../modal-manager.js';
+import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
+
+export function extractActivityFormData(formElement) {
+    const formData = new FormData(formElement);
+    const description = formData.get('description')?.toString().trim();
+    const startTime = formData.get('start-time')?.toString();
+    const durationResult = parseDuration(
+        formData.get('duration-hours')?.toString() || '0',
+        formData.get('duration-minutes')?.toString() || '0'
+    );
+    const categoryKey = formData.get('category')?.toString() || '';
+
+    if (!description) {
+        showAlert('Activity description cannot be empty.', 'sky');
+        return null;
+    }
+
+    if (!startTime) {
+        showAlert('Start time is required for activities.', 'sky');
+        return null;
+    }
+
+    if (!durationResult.valid) {
+        showAlert(durationResult.error, 'sky');
+        return null;
+    }
+
+    if (categoryKey && !resolveCategoryKey(categoryKey)) {
+        showAlert('Selected category is no longer available.', 'sky');
+        return null;
+    }
+
+    const date = extractDateFromDateTime(new Date());
+    const startDateTime = timeToDateTime(startTime, date);
+    const endDateTime = calculateEndDateTime(startDateTime, durationResult.duration);
+
+    return {
+        description,
+        category: categoryKey || null,
+        startDateTime,
+        endDateTime,
+        duration: durationResult.duration,
+        source: 'manual',
+        sourceTaskId: null
+    };
+}

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -2,6 +2,7 @@ import { showAlert } from '../modal-manager.js';
 import { showToast } from '../toast-manager.js';
 import { extractActivityFormData } from './form-utils.js';
 import { addActivity, editActivity, removeActivity } from './manager.js';
+import { consumeActivitySmokeFailure } from './smoke-hooks.js';
 import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
 
 function resolveActivityPayload(activityDataOrForm) {
@@ -18,6 +19,9 @@ export async function handleAddActivity(activityDataOrForm) {
 
     let result;
     try {
+        if (consumeActivitySmokeFailure('manual-add')) {
+            throw new Error('Smoke forced manual activity add failure.');
+        }
         result = await addActivity(activityData);
     } catch {
         showAlert('Could not log activity.', 'sky');

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -1,14 +1,18 @@
 import { showAlert } from '../modal-manager.js';
 import { showToast } from '../toast-manager.js';
-import { extractActivityFormData } from './form-utils.js';
+import { extractActivityFormData, extractActivityEditFormData } from './form-utils.js';
 import { addActivity, editActivity, removeActivity } from './manager.js';
 import { consumeActivitySmokeFailure } from './smoke-hooks.js';
 import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
 
 function resolveActivityPayload(activityDataOrForm) {
-    return activityDataOrForm instanceof HTMLFormElement
-        ? extractActivityFormData(activityDataOrForm)
-        : activityDataOrForm;
+    if (!(activityDataOrForm instanceof HTMLFormElement)) {
+        return activityDataOrForm;
+    }
+
+    return activityDataOrForm.dataset.activityEdit === 'true'
+        ? extractActivityEditFormData(activityDataOrForm)
+        : extractActivityFormData(activityDataOrForm);
 }
 
 export async function handleAddActivity(activityDataOrForm) {

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -16,14 +16,25 @@ export async function handleAddActivity(activityDataOrForm) {
         return;
     }
 
-    const result = await addActivity(activityData);
+    let result;
+    try {
+        result = await addActivity(activityData);
+    } catch {
+        showAlert('Could not log activity.', 'sky');
+        return { success: false, reason: 'Could not log activity.' };
+    }
+
     if (!result.success) {
         showAlert(result.reason || 'Could not log activity.', 'sky');
-        return;
+        return {
+            success: false,
+            reason: result.reason || 'Could not log activity.'
+        };
     }
 
     onActivityCreated({ activity: result.activity });
     showToast('Activity logged.', { theme: 'sky' });
+    return result;
 }
 
 export async function handleEditActivity(activityId, updatesOrForm) {
@@ -32,14 +43,25 @@ export async function handleEditActivity(activityId, updatesOrForm) {
         return;
     }
 
-    const result = await editActivity(activityId, updates);
+    let result;
+    try {
+        result = await editActivity(activityId, updates);
+    } catch {
+        showAlert('Could not update activity.', 'sky');
+        return { success: false, reason: 'Could not update activity.' };
+    }
+
     if (!result.success) {
         showAlert(result.reason || 'Could not update activity.', 'sky');
-        return;
+        return {
+            success: false,
+            reason: result.reason || 'Could not update activity.'
+        };
     }
 
     onActivityEdited({ activity: result.activity });
     showToast('Activity updated.', { theme: 'sky' });
+    return result;
 }
 
 export async function handleSaveActivityEdit(activityId, formElement) {
@@ -47,14 +69,25 @@ export async function handleSaveActivityEdit(activityId, formElement) {
 }
 
 export async function handleDeleteActivity(activityId) {
-    const result = await removeActivity(activityId);
+    let result;
+    try {
+        result = await removeActivity(activityId);
+    } catch {
+        showAlert('Could not delete activity.', 'sky');
+        return { success: false, reason: 'Could not delete activity.' };
+    }
+
     if (!result.success) {
         showAlert(result.reason || 'Could not delete activity.', 'sky');
-        return;
+        return {
+            success: false,
+            reason: result.reason || 'Could not delete activity.'
+        };
     }
 
     onActivityDeleted({ activity: result.activity });
     showToast('Activity deleted.', { theme: 'sky' });
+    return result;
 }
 
 export function createActivityCallbacks() {

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -1,0 +1,67 @@
+import { showAlert } from '../modal-manager.js';
+import { showToast } from '../toast-manager.js';
+import { extractActivityFormData } from './form-utils.js';
+import { addActivity, editActivity, removeActivity } from './manager.js';
+import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
+
+function resolveActivityPayload(activityDataOrForm) {
+    return activityDataOrForm instanceof HTMLFormElement
+        ? extractActivityFormData(activityDataOrForm)
+        : activityDataOrForm;
+}
+
+export async function handleAddActivity(activityDataOrForm) {
+    const activityData = resolveActivityPayload(activityDataOrForm);
+    if (!activityData) {
+        return;
+    }
+
+    const result = await addActivity(activityData);
+    if (!result.success) {
+        showAlert(result.reason || 'Could not log activity.', 'sky');
+        return;
+    }
+
+    onActivityCreated({ activity: result.activity });
+    showToast('Activity logged.', { theme: 'sky' });
+}
+
+export async function handleEditActivity(activityId, updatesOrForm) {
+    const updates = resolveActivityPayload(updatesOrForm);
+    if (!updates) {
+        return;
+    }
+
+    const result = await editActivity(activityId, updates);
+    if (!result.success) {
+        showAlert(result.reason || 'Could not update activity.', 'sky');
+        return;
+    }
+
+    onActivityEdited({ activity: result.activity });
+    showToast('Activity updated.', { theme: 'sky' });
+}
+
+export async function handleSaveActivityEdit(activityId, formElement) {
+    return handleEditActivity(activityId, formElement);
+}
+
+export async function handleDeleteActivity(activityId) {
+    const result = await removeActivity(activityId);
+    if (!result.success) {
+        showAlert(result.reason || 'Could not delete activity.', 'sky');
+        return;
+    }
+
+    onActivityDeleted({ activity: result.activity });
+    showToast('Activity deleted.', { theme: 'sky' });
+}
+
+export function createActivityCallbacks() {
+    return {
+        onAddActivity: handleAddActivity,
+        onEditActivity: handleEditActivity,
+        onDeleteActivity: handleDeleteActivity,
+        onSaveActivityEdit: handleSaveActivityEdit
+    };
+}

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -1,0 +1,178 @@
+import {
+    putActivity,
+    loadActivities as loadActivitiesFromStorage,
+    deleteActivity as deleteActivityFromStorage
+} from '../storage.js';
+import { extractDateFromDateTime } from '../utils.js';
+
+/** @type {Array<Object>} */
+let activities = [];
+
+function cloneActivity(activity) {
+    return activity ? { ...activity } : activity;
+}
+
+function sortByStartDateTime(list) {
+    list.sort((left, right) => new Date(left.startDateTime) - new Date(right.startDateTime));
+}
+
+function normalizeActivity(activity) {
+    return {
+        docType: 'activity',
+        category: null,
+        source: 'manual',
+        sourceTaskId: null,
+        ...activity
+    };
+}
+
+function generateActivityId() {
+    return `activity-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function replaceState(nextActivities = []) {
+    activities = nextActivities.map((activity) => normalizeActivity(cloneActivity(activity)));
+    sortByStartDateTime(activities);
+    return getActivityState();
+}
+
+export function resetActivityState() {
+    activities = [];
+}
+
+export function updateActivityState(nextActivities = []) {
+    return replaceState(nextActivities);
+}
+
+export function getActivityState() {
+    return activities.map(cloneActivity);
+}
+
+export function getActivityById(activityId) {
+    return activities.find((activity) => activity.id === activityId) || null;
+}
+
+export function getTodaysActivities(now = new Date()) {
+    const today = extractDateFromDateTime(now instanceof Date ? now : new Date(now));
+
+    return activities
+        .filter(
+            (activity) =>
+                activity.startDateTime &&
+                extractDateFromDateTime(new Date(activity.startDateTime)) === today
+        )
+        .slice()
+        .sort((left, right) => new Date(left.startDateTime) - new Date(right.startDateTime))
+        .map(cloneActivity);
+}
+
+export async function loadActivitiesState(loadActivities = loadActivitiesFromStorage) {
+    if (typeof loadActivities !== 'function') {
+        replaceState([]);
+        return getActivityState();
+    }
+
+    const loadedActivities = await loadActivities();
+    replaceState(Array.isArray(loadedActivities) ? loadedActivities : []);
+    return getActivityState();
+}
+
+export async function loadActivityState(loadActivities = loadActivitiesFromStorage) {
+    return loadActivitiesState(loadActivities);
+}
+
+export async function addActivity(activityData) {
+    const description = activityData?.description?.trim();
+
+    if (!description) {
+        return { success: false, reason: 'Activity description is required.' };
+    }
+
+    if (!activityData?.startDateTime || !activityData?.endDateTime) {
+        return { success: false, reason: 'Activity start and end times are required.' };
+    }
+
+    if (!activityData?.duration || activityData.duration <= 0) {
+        return { success: false, reason: 'Activity duration must be greater than 0.' };
+    }
+
+    const activity = normalizeActivity({
+        ...activityData,
+        id: activityData.id || generateActivityId(),
+        description
+    });
+
+    await putActivity(activity);
+    activities.push(activity);
+    sortByStartDateTime(activities);
+
+    return { success: true, activity: cloneActivity(activity) };
+}
+
+export async function editActivity(activityId, updates = {}) {
+    const existing = getActivityById(activityId);
+
+    if (!existing) {
+        return { success: false, reason: 'Activity not found.' };
+    }
+
+    if (existing.source === 'auto') {
+        return { success: false, reason: 'Auto-logged activities cannot be edited.' };
+    }
+
+    const nextActivity = normalizeActivity({
+        ...existing,
+        ...updates,
+        id: activityId,
+        description: updates.description ? updates.description.trim() : existing.description
+    });
+
+    if (!nextActivity.description) {
+        return { success: false, reason: 'Activity description is required.' };
+    }
+
+    if (!nextActivity.duration || nextActivity.duration <= 0) {
+        return { success: false, reason: 'Activity duration must be greater than 0.' };
+    }
+
+    await putActivity(nextActivity);
+    activities = activities.map((activity) =>
+        activity.id === activityId ? nextActivity : activity
+    );
+    sortByStartDateTime(activities);
+
+    return { success: true, activity: cloneActivity(nextActivity) };
+}
+
+export async function updateActivity(activityId, updates = {}) {
+    return editActivity(activityId, updates);
+}
+
+export async function removeActivity(activityId) {
+    const existing = getActivityById(activityId);
+
+    if (!existing) {
+        return { success: false, reason: 'Activity not found.' };
+    }
+
+    await deleteActivityFromStorage(activityId);
+    activities = activities.filter((activity) => activity.id !== activityId);
+
+    return { success: true, activity: cloneActivity(existing) };
+}
+
+export async function deleteActivity(activityId) {
+    return removeActivity(activityId);
+}
+
+export function createActivityFromTask(task) {
+    return {
+        description: task.description,
+        category: task.category || null,
+        startDateTime: task.startDateTime,
+        endDateTime: task.endDateTime,
+        duration: task.duration,
+        source: 'auto',
+        sourceTaskId: task.id || null
+    };
+}

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -77,10 +77,6 @@ export async function loadActivitiesState(loadActivities = loadActivitiesFromSto
     return getActivityState();
 }
 
-export async function loadActivityState(loadActivities = loadActivitiesFromStorage) {
-    return loadActivitiesState(loadActivities);
-}
-
 export async function addActivity(activityData) {
     const description = activityData?.description?.trim();
 
@@ -144,10 +140,6 @@ export async function editActivity(activityId, updates = {}) {
     return { success: true, activity: cloneActivity(nextActivity) };
 }
 
-export async function updateActivity(activityId, updates = {}) {
-    return editActivity(activityId, updates);
-}
-
 export async function removeActivity(activityId) {
     const existing = getActivityById(activityId);
 
@@ -159,10 +151,6 @@ export async function removeActivity(activityId) {
     activities = activities.filter((activity) => activity.id !== activityId);
 
     return { success: true, activity: cloneActivity(existing) };
-}
-
-export async function deleteActivity(activityId) {
-    return removeActivity(activityId);
 }
 
 export function createActivityFromTask(task) {

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -112,10 +112,6 @@ export async function editActivity(activityId, updates = {}) {
         return { success: false, reason: 'Activity not found.' };
     }
 
-    if (existing.source === 'auto') {
-        return { success: false, reason: 'Auto-logged activities cannot be edited.' };
-    }
-
     const nextActivity = normalizeActivity({
         ...existing,
         ...updates,

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -1,8 +1,12 @@
-import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
+import {
+    renderCategoryBadge,
+    getSelectableCategoryOptions
+} from '../taxonomy/taxonomy-selectors.js';
 import {
     calculateHoursAndMinutes,
     extractTimeFromDateTime,
-    convertTo12HourTime
+    convertTo12HourTime,
+    extractDateFromDateTime
 } from '../utils.js';
 
 function escapeHtml(value) {
@@ -20,18 +24,92 @@ function formatTimeRange(startDateTime, endDateTime) {
     return `${convertTo12HourTime(startTime)} - ${convertTo12HourTime(endTime)}`;
 }
 
+function renderCategoryOptions(selectedCategory) {
+    const options = getSelectableCategoryOptions();
+    const baseOption = '<option value="">No category</option>';
+    const renderedOptions = options
+        .map((option) => {
+            const indent = option.indentLevel > 0 ? '&nbsp;&nbsp;' : '';
+            const selected = option.value === selectedCategory ? ' selected' : '';
+            return `<option value="${escapeHtml(option.value)}"${selected}>${indent}${escapeHtml(option.label)}</option>`;
+        })
+        .join('');
+
+    return `${baseOption}${renderedOptions}`;
+}
+
+function renderInlineEditActivityItem(activity) {
+    const durationHours = Math.floor(activity.duration / 60);
+    const durationMinutes = activity.duration % 60;
+    const displayStartTime = extractTimeFromDateTime(new Date(activity.startDateTime));
+    const activityDate = extractDateFromDateTime(new Date(activity.startDateTime));
+    const isAuto = activity.source === 'auto';
+    const provenanceHtml = isAuto
+        ? `<div class="flex items-center gap-2 text-xs text-sky-400/70">
+               <span class="activity-source-link italic cursor-default" data-source-task-id="${escapeHtml(activity.sourceTaskId || '')}" title="Auto-logged from task">
+                   <i class="fa-solid fa-link mr-0.5"></i>auto
+               </span>
+               <span class="text-slate-500">Edited copy of a completed task</span>
+           </div>`
+        : '';
+
+    return `<form class="activity-inline-edit-form activity-item px-3 py-3 rounded-lg bg-slate-800/70 border border-sky-700/40 shadow-md space-y-3" data-activity-id="${escapeHtml(activity.id)}" data-activity-date="${escapeHtml(activityDate)}" data-activity-edit="true" autocomplete="off">
+        ${provenanceHtml}
+        <div class="flex flex-col sm:flex-row gap-3">
+            <div class="relative sm:flex-[1.8]">
+                <i class="fa-regular fa-pen-to-square absolute left-3 top-1/2 -translate-y-1/2 text-sky-400"></i>
+                <input type="text" name="description" value="${escapeHtml(activity.description)}" placeholder="What did you work on?"
+                    class="bg-slate-700 pl-10 pr-4 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100" required>
+            </div>
+            <div class="sm:flex-1 sm:min-w-[13rem]">
+                <select name="category" class="bg-slate-700 px-3 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
+                    ${renderCategoryOptions(activity.category)}
+                </select>
+            </div>
+        </div>
+        <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+            <div class="relative sm:w-40">
+                <i class="fa-regular fa-clock absolute left-3 top-1/2 -translate-y-1/2 text-sky-400"></i>
+                <input type="time" name="start-time" value="${escapeHtml(displayStartTime)}"
+                    class="bg-slate-700 pl-10 pr-3 py-2 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100" required>
+            </div>
+            <div class="flex items-center gap-2 sm:w-44">
+                <div class="relative flex-1">
+                    <i class="fa-regular fa-hourglass absolute left-3 top-1/2 -translate-y-1/2 text-sky-400"></i>
+                    <input type="number" name="duration-hours" value="${durationHours}" min="0" placeholder="HH"
+                        class="bg-slate-700 pl-10 pr-2 py-2 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
+                </div>
+                <span class="text-slate-400 text-lg">:</span>
+                <div class="relative flex-1">
+                    <input type="number" name="duration-minutes" value="${durationMinutes.toString().padStart(2, '0')}" min="0" max="59" placeholder="MM"
+                        class="bg-slate-700 px-3 py-2 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
+                </div>
+            </div>
+            <div class="flex items-center gap-2 sm:ml-auto">
+                <button type="button" class="btn-cancel-activity-edit px-4 py-2 rounded-lg font-medium transition-all duration-300 shadow flex items-center bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100">
+                    <i class="fa-solid fa-xmark mr-2"></i>Cancel
+                </button>
+                <button type="button" class="btn-save-activity-edit px-4 py-2 rounded-lg font-medium transition-all duration-300 shadow flex items-center bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 text-white">
+                    <i class="fa-solid fa-check mr-2"></i>Save
+                </button>
+            </div>
+        </div>
+    </form>`;
+}
+
 function renderActivityItem(activity) {
     const timeRange = formatTimeRange(activity.startDateTime, activity.endDateTime);
     const durationText = calculateHoursAndMinutes(activity.duration);
     const badge = renderCategoryBadge(activity.category);
     const isAuto = activity.source === 'auto';
-
-    const actionsHtml = isAuto
+    const provenanceHtml = isAuto
         ? `<span class="activity-source-link text-xs text-sky-400/60 italic cursor-default" data-source-task-id="${escapeHtml(activity.sourceTaskId || '')}" title="Auto-logged from task">
                <i class="fa-solid fa-link mr-0.5"></i>auto
            </span>`
-        : `<div class="flex items-center gap-2">
-               <button class="btn-edit-activity text-sky-400/60 hover:text-sky-400 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Edit activity">
+        : '';
+    const actionsHtml = `<div class="flex items-center gap-2">
+               ${provenanceHtml}
+               <button class="btn-edit-activity text-slate-400 hover:text-slate-200 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Edit activity">
                    <i class="fa-solid fa-pen"></i>
                </button>
                <button class="btn-delete-activity text-rose-400/60 hover:text-rose-400 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Delete activity">
@@ -55,7 +133,7 @@ function renderActivityItem(activity) {
     </div>`;
 }
 
-export function renderActivities(activities, container) {
+export function renderActivities(activities, container, options = {}) {
     const targetContainer = container || document.getElementById('activity-list');
 
     if (!targetContainer) {
@@ -71,5 +149,12 @@ export function renderActivities(activities, container) {
         return;
     }
 
-    targetContainer.innerHTML = activities.map((activity) => renderActivityItem(activity)).join('');
+    const editingActivityId = options.editingActivityId || null;
+    targetContainer.innerHTML = activities
+        .map((activity) =>
+            activity.id === editingActivityId
+                ? renderInlineEditActivityItem(activity)
+                : renderActivityItem(activity)
+        )
+        .join('');
 }

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -1,0 +1,75 @@
+import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
+import {
+    calculateHoursAndMinutes,
+    extractTimeFromDateTime,
+    convertTo12HourTime
+} from '../utils.js';
+
+function escapeHtml(value) {
+    return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+function formatTimeRange(startDateTime, endDateTime) {
+    const startTime = extractTimeFromDateTime(new Date(startDateTime));
+    const endTime = extractTimeFromDateTime(new Date(endDateTime));
+    return `${convertTo12HourTime(startTime)} - ${convertTo12HourTime(endTime)}`;
+}
+
+function renderActivityItem(activity) {
+    const timeRange = formatTimeRange(activity.startDateTime, activity.endDateTime);
+    const durationText = calculateHoursAndMinutes(activity.duration);
+    const badge = renderCategoryBadge(activity.category);
+    const isAuto = activity.source === 'auto';
+
+    const actionsHtml = isAuto
+        ? `<span class="activity-source-link text-xs text-sky-400/60 italic cursor-default" data-source-task-id="${escapeHtml(activity.sourceTaskId || '')}" title="Auto-logged from task">
+               <i class="fa-solid fa-link mr-0.5"></i>auto
+           </span>`
+        : `<div class="flex items-center gap-2">
+               <button class="btn-edit-activity text-sky-400/60 hover:text-sky-400 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Edit activity">
+                   <i class="fa-solid fa-pen"></i>
+               </button>
+               <button class="btn-delete-activity text-rose-400/60 hover:text-rose-400 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Delete activity">
+                   <i class="fa-solid fa-trash-can"></i>
+               </button>
+           </div>`;
+
+    return `<div class="activity-item flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/50 hover:border-sky-700/30 transition-colors" data-activity-id="${escapeHtml(activity.id)}">
+        <div class="flex-grow min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-sm text-slate-200 truncate">${escapeHtml(activity.description)}</span>
+                ${badge}
+            </div>
+            <div class="text-xs text-slate-400 mt-0.5">
+                ${escapeHtml(timeRange)} · ${escapeHtml(durationText)}
+            </div>
+        </div>
+        <div class="shrink-0">
+            ${actionsHtml}
+        </div>
+    </div>`;
+}
+
+export function renderActivities(activities, container) {
+    const targetContainer = container || document.getElementById('activity-list');
+
+    if (!targetContainer) {
+        return;
+    }
+
+    if (!activities || activities.length === 0) {
+        targetContainer.innerHTML = `
+            <div class="text-center py-6 text-slate-500 text-sm">
+                <i class="fa-regular fa-clock mr-1"></i>
+                No activities tracked today. Log one or complete a scheduled task.
+            </div>`;
+        return;
+    }
+
+    targetContainer.innerHTML = activities.map((activity) => renderActivityItem(activity)).join('');
+}

--- a/public/js/activities/smoke-hooks.js
+++ b/public/js/activities/smoke-hooks.js
@@ -1,0 +1,73 @@
+const ACTIVITY_SMOKE_FAILURES_KEY = 'fortudo-smoke-activity-failures';
+const SUPPORTED_FAILURE_KINDS = new Set(['manual-add', 'auto-log']);
+
+function isSmokeHost(hostname = window.location.hostname) {
+    const host = String(hostname || '');
+    return (
+        host === 'localhost' ||
+        host === '127.0.0.1' ||
+        (host.startsWith('fortudo--') &&
+            (host.endsWith('.web.app') || host.endsWith('.firebaseapp.com')))
+    );
+}
+
+function readSmokeFailures(storage = window.localStorage) {
+    try {
+        const rawValue = storage?.getItem(ACTIVITY_SMOKE_FAILURES_KEY);
+        if (!rawValue) {
+            return {};
+        }
+
+        const parsed = JSON.parse(rawValue);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function writeSmokeFailures(failures, storage = window.localStorage) {
+    const entries = Object.entries(failures).filter(
+        ([kind, count]) => SUPPORTED_FAILURE_KINDS.has(kind) && Number(count) > 0
+    );
+
+    if (entries.length === 0) {
+        storage?.removeItem(ACTIVITY_SMOKE_FAILURES_KEY);
+        return;
+    }
+
+    storage?.setItem(ACTIVITY_SMOKE_FAILURES_KEY, JSON.stringify(Object.fromEntries(entries)));
+}
+
+export function consumeActivitySmokeFailure(
+    kind,
+    { storage = window.localStorage, hostname = window.location.hostname } = {}
+) {
+    if (!SUPPORTED_FAILURE_KINDS.has(kind) || !isSmokeHost(hostname)) {
+        return false;
+    }
+
+    const failures = readSmokeFailures(storage);
+    const count = Number(failures[kind] || 0);
+    if (count <= 0) {
+        return false;
+    }
+
+    failures[kind] = count - 1;
+    writeSmokeFailures(failures, storage);
+    return true;
+}
+
+export function queueActivitySmokeFailure(
+    kind,
+    count = 1,
+    { storage = window.localStorage, hostname = window.location.hostname } = {}
+) {
+    if (!SUPPORTED_FAILURE_KINDS.has(kind) || !isSmokeHost(hostname) || count <= 0) {
+        return false;
+    }
+
+    const failures = readSmokeFailures(storage);
+    failures[kind] = Number(failures[kind] || 0) + count;
+    writeSmokeFailures(failures, storage);
+    return true;
+}

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -4,6 +4,13 @@ import { renderActivities } from './renderer.js';
 import { handleAddActivity, handleEditActivity, handleDeleteActivity } from './handlers.js';
 import { showActivityEditModal } from '../modal-manager.js';
 
+function clearDeleteConfirmState(deps) {
+    const wasConfirming = deps.resetAllConfirmingDeleteFlags();
+    if (wasConfirming) {
+        deps.refreshUI();
+    }
+}
+
 export function syncActivitiesUI(enabled) {
     const activityToggleOption = document.getElementById('activity-toggle-option');
     const activitiesContainer = document.getElementById('activities-container');
@@ -52,7 +59,11 @@ export async function handleActivityAwareFormSubmit(formElement, deps) {
         return;
     }
 
-    await handleAddActivity(activityData);
+    const result = await handleAddActivity(activityData);
+    if (!result?.success) {
+        return;
+    }
+
     formElement.reset();
     deps.resetTaskFormPreviewState({
         hintElement: document.getElementById('end-time-hint'),
@@ -84,9 +95,10 @@ export function handleActivityListClick(target, deps) {
         const activityItem = editActivityButton.closest('[data-activity-id]');
         const activityId =
             editActivityButton.dataset.activityId || activityItem?.getAttribute('data-activity-id');
+        const currentDescription =
+            activityItem?.querySelector('.text-sm.text-slate-200')?.textContent?.trim() || '';
+        clearDeleteConfirmState(deps);
         if (activityId) {
-            const currentDescription =
-                activityItem?.querySelector('.text-sm.text-slate-200')?.textContent?.trim() || '';
             void showActivityEditModal(currentDescription).then((nextDescription) => {
                 if (
                     typeof nextDescription === 'string' &&
@@ -108,6 +120,7 @@ export function handleActivityListClick(target, deps) {
         const activityId =
             deleteActivityButton.dataset.activityId ||
             activityItem?.getAttribute('data-activity-id');
+        clearDeleteConfirmState(deps);
         if (activityId) {
             void handleDeleteActivity(activityId);
         }
@@ -118,10 +131,7 @@ export function handleActivityListClick(target, deps) {
     const deleteButton = target.closest('.btn-delete, .btn-delete-unscheduled');
 
     if (!taskElement && !deleteButton) {
-        const wasConfirming = deps.resetAllConfirmingDeleteFlags();
-        if (wasConfirming) {
-            deps.refreshUI();
-        }
+        clearDeleteConfirmState(deps);
     }
 
     return false;

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -1,8 +1,13 @@
 import { extractActivityFormData } from './form-utils.js';
 import { getTodaysActivities } from './manager.js';
 import { renderActivities } from './renderer.js';
-import { handleAddActivity, handleEditActivity, handleDeleteActivity } from './handlers.js';
-import { showActivityEditModal } from '../modal-manager.js';
+import { handleAddActivity, handleDeleteActivity, handleSaveActivityEdit } from './handlers.js';
+
+let editingActivityId = null;
+
+export function resetActivityInlineEditState() {
+    editingActivityId = null;
+}
 
 function clearDeleteConfirmState(deps) {
     const wasConfirming = deps.resetAllConfirmingDeleteFlags();
@@ -24,6 +29,7 @@ export function syncActivitiesUI(enabled) {
     }
 
     if (!enabled) {
+        editingActivityId = null;
         const activityRadio = document.getElementById('activity');
         const scheduledRadio = document.getElementById('scheduled');
         if (activityRadio instanceof HTMLInputElement) {
@@ -42,7 +48,8 @@ export function renderTodayActivities(enabled) {
 
     renderActivities(
         getTodaysActivities(),
-        /** @type {HTMLElement|null} */ (document.getElementById('activity-list'))
+        /** @type {HTMLElement|null} */ (document.getElementById('activity-list')),
+        { editingActivityId }
     );
 }
 
@@ -95,20 +102,33 @@ export function handleActivityListClick(target, deps) {
         const activityItem = editActivityButton.closest('.activity-item[data-activity-id]');
         const activityId =
             editActivityButton.dataset.activityId || activityItem?.getAttribute('data-activity-id');
-        const currentDescription =
-            activityItem?.querySelector('.text-sm.text-slate-200')?.textContent?.trim() || '';
         clearDeleteConfirmState(deps);
         if (activityId) {
-            void showActivityEditModal(currentDescription).then((nextDescription) => {
-                if (
-                    typeof nextDescription === 'string' &&
-                    nextDescription.trim() !== '' &&
-                    nextDescription.trim() !== currentDescription
-                ) {
-                    void handleEditActivity(activityId, {
-                        description: nextDescription.trim()
-                    });
+            editingActivityId = activityId;
+            deps.refreshUI();
+        }
+        return true;
+    }
+
+    const cancelActivityEditButton = target.closest('.btn-cancel-activity-edit');
+    if (cancelActivityEditButton instanceof HTMLElement) {
+        editingActivityId = null;
+        deps.refreshUI();
+        return true;
+    }
+
+    const saveActivityEditButton = target.closest('.btn-save-activity-edit');
+    if (saveActivityEditButton instanceof HTMLElement) {
+        const editForm = saveActivityEditButton.closest(
+            'form.activity-inline-edit-form[data-activity-id]'
+        );
+        const activityId = editForm?.getAttribute('data-activity-id');
+        if (activityId && editForm instanceof HTMLFormElement) {
+            void handleSaveActivityEdit(activityId, editForm).then((result) => {
+                if (result?.success) {
+                    editingActivityId = null;
                 }
+                deps.refreshUI();
             });
         }
         return true;
@@ -122,6 +142,9 @@ export function handleActivityListClick(target, deps) {
             activityItem?.getAttribute('data-activity-id');
         clearDeleteConfirmState(deps);
         if (activityId) {
+            if (editingActivityId === activityId) {
+                editingActivityId = null;
+            }
             void handleDeleteActivity(activityId);
         }
         return true;

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -92,7 +92,7 @@ export function handleActivityListClick(target, deps) {
 
     const editActivityButton = target.closest('.btn-edit-activity');
     if (editActivityButton instanceof HTMLElement) {
-        const activityItem = editActivityButton.closest('[data-activity-id]');
+        const activityItem = editActivityButton.closest('.activity-item[data-activity-id]');
         const activityId =
             editActivityButton.dataset.activityId || activityItem?.getAttribute('data-activity-id');
         const currentDescription =
@@ -116,7 +116,7 @@ export function handleActivityListClick(target, deps) {
 
     const deleteActivityButton = target.closest('.btn-delete-activity');
     if (deleteActivityButton instanceof HTMLElement) {
-        const activityItem = deleteActivityButton.closest('[data-activity-id]');
+        const activityItem = deleteActivityButton.closest('.activity-item[data-activity-id]');
         const activityId =
             deleteActivityButton.dataset.activityId ||
             activityItem?.getAttribute('data-activity-id');

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -1,0 +1,126 @@
+import { extractActivityFormData } from './form-utils.js';
+import { getTodaysActivities } from './manager.js';
+import { renderActivities } from './renderer.js';
+import { handleAddActivity, handleEditActivity, handleDeleteActivity } from './handlers.js';
+
+export function syncActivitiesUI(enabled) {
+    const activityToggleOption = document.getElementById('activity-toggle-option');
+    const activitiesContainer = document.getElementById('activities-container');
+
+    if (activityToggleOption) {
+        activityToggleOption.classList.toggle('hidden', !enabled);
+    }
+
+    if (activitiesContainer) {
+        activitiesContainer.classList.toggle('hidden', !enabled);
+    }
+
+    if (!enabled) {
+        const activityRadio = document.getElementById('activity');
+        const scheduledRadio = document.getElementById('scheduled');
+        if (activityRadio instanceof HTMLInputElement) {
+            activityRadio.checked = false;
+        }
+        if (scheduledRadio instanceof HTMLInputElement) {
+            scheduledRadio.checked = true;
+        }
+    }
+}
+
+export function renderTodayActivities(enabled) {
+    if (!enabled) {
+        return;
+    }
+
+    renderActivities(
+        getTodaysActivities(),
+        /** @type {HTMLElement|null} */ (document.getElementById('activity-list'))
+    );
+}
+
+export async function handleActivityAwareFormSubmit(formElement, deps) {
+    const selectedTaskType = new FormData(formElement).get('task-type')?.toString();
+    if (!deps.activitiesEnabled || selectedTaskType !== 'activity') {
+        await deps.handleTaskSubmit(formElement);
+        return;
+    }
+
+    const activityData = extractActivityFormData(formElement);
+    if (!activityData) {
+        deps.focusTaskDescriptionInput();
+        return;
+    }
+
+    await handleAddActivity(activityData);
+    formElement.reset();
+    deps.resetTaskFormPreviewState({
+        hintElement: document.getElementById('end-time-hint'),
+        warningElement: document.getElementById('overlap-warning'),
+        buttonElement: document.getElementById('add-task-btn')
+    });
+
+    const categorySelect = document.getElementById('category-select');
+    if (categorySelect) {
+        categorySelect.dispatchEvent(new Event('change'));
+    }
+
+    const activityRadio = formElement.querySelector('input[name="task-type"][value="activity"]');
+    if (activityRadio instanceof HTMLInputElement) {
+        activityRadio.checked = true;
+    }
+
+    deps.initializeTaskTypeToggle();
+    deps.focusTaskDescriptionInput();
+}
+
+export function handleActivityListClick(target, deps) {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    const editActivityButton = target.closest('.btn-edit-activity');
+    if (editActivityButton instanceof HTMLElement) {
+        const activityItem = editActivityButton.closest('[data-activity-id]');
+        const activityId =
+            editActivityButton.dataset.activityId || activityItem?.getAttribute('data-activity-id');
+        if (activityId) {
+            const currentDescription =
+                activityItem?.querySelector('.text-sm.text-slate-200')?.textContent?.trim() || '';
+            const nextDescription = window.prompt('Edit activity description:', currentDescription);
+            if (
+                nextDescription !== null &&
+                nextDescription.trim() !== '' &&
+                nextDescription.trim() !== currentDescription
+            ) {
+                void handleEditActivity(activityId, {
+                    description: nextDescription.trim()
+                });
+            }
+        }
+        return true;
+    }
+
+    const deleteActivityButton = target.closest('.btn-delete-activity');
+    if (deleteActivityButton instanceof HTMLElement) {
+        const activityItem = deleteActivityButton.closest('[data-activity-id]');
+        const activityId =
+            deleteActivityButton.dataset.activityId ||
+            activityItem?.getAttribute('data-activity-id');
+        if (activityId) {
+            void handleDeleteActivity(activityId);
+        }
+        return true;
+    }
+
+    const taskElement = target.closest('.task-item, .task-card');
+    const deleteButton = target.closest('.btn-delete, .btn-delete-unscheduled');
+
+    if (!taskElement && !deleteButton) {
+        const wasConfirming = deps.resetAllConfirmingDeleteFlags();
+        if (wasConfirming) {
+            deps.refreshUI();
+        }
+    }
+
+    return false;
+}

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -2,6 +2,7 @@ import { extractActivityFormData } from './form-utils.js';
 import { getTodaysActivities } from './manager.js';
 import { renderActivities } from './renderer.js';
 import { handleAddActivity, handleEditActivity, handleDeleteActivity } from './handlers.js';
+import { showActivityEditModal } from '../modal-manager.js';
 
 export function syncActivitiesUI(enabled) {
     const activityToggleOption = document.getElementById('activity-toggle-option');
@@ -86,16 +87,17 @@ export function handleActivityListClick(target, deps) {
         if (activityId) {
             const currentDescription =
                 activityItem?.querySelector('.text-sm.text-slate-200')?.textContent?.trim() || '';
-            const nextDescription = window.prompt('Edit activity description:', currentDescription);
-            if (
-                nextDescription !== null &&
-                nextDescription.trim() !== '' &&
-                nextDescription.trim() !== currentDescription
-            ) {
-                void handleEditActivity(activityId, {
-                    description: nextDescription.trim()
-                });
-            }
+            void showActivityEditModal(currentDescription).then((nextDescription) => {
+                if (
+                    typeof nextDescription === 'string' &&
+                    nextDescription.trim() !== '' &&
+                    nextDescription.trim() !== currentDescription
+                ) {
+                    void handleEditActivity(activityId, {
+                        description: nextDescription.trim()
+                    });
+                }
+            });
         }
         return true;
     }

--- a/public/js/app-coordinator.js
+++ b/public/js/app-coordinator.js
@@ -2,6 +2,7 @@ import { refreshUI } from './dom-renderer.js';
 import { addActivity, createActivityFromTask } from './activities/manager.js';
 import { isActivitiesEnabled } from './settings-manager.js';
 import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
+import { showToast } from './toast-manager.js';
 import { logger } from './utils.js';
 
 function refreshWhenPresent(value) {
@@ -62,9 +63,18 @@ export function onTaskCompleted({ task }) {
     if (isActivitiesEnabled()) {
         const activity = createActivityFromTask(task);
         if (activity) {
-            void addActivity(activity).catch((error) => {
-                logger.error('Failed to auto-log completed task as activity:', error);
-            });
+            void addActivity(activity)
+                .then((result) => {
+                    if (result?.success && result.activity) {
+                        onActivityCreated({ activity: result.activity });
+                    }
+                })
+                .catch((error) => {
+                    logger.error('Failed to auto-log completed task as activity:', error);
+                    showToast('Task completed, but activity auto-log failed.', {
+                        theme: 'amber'
+                    });
+                });
         }
     }
 }

--- a/public/js/app-coordinator.js
+++ b/public/js/app-coordinator.js
@@ -4,6 +4,19 @@ import { isActivitiesEnabled } from './settings-manager.js';
 import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
 import { logger } from './utils.js';
 
+function refreshWhenPresent(value) {
+    if (!value) {
+        return false;
+    }
+
+    refreshUI();
+    return true;
+}
+
+function refreshForClearEvent() {
+    refreshUI();
+}
+
 /**
  * Semantic post-mutation coordinator boundary for task state changes.
  * Handlers should report successful mutations through specific event types:
@@ -21,38 +34,25 @@ import { logger } from './utils.js';
  * - onAllTasksCleared()
  */
 export function onTaskCreated({ task }) {
-    if (!task) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(task);
 }
 
 export function onTaskEdited({ task }) {
-    if (!task) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(task);
 }
 
 export function onTaskScheduled({ task }) {
-    if (!task) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(task);
 }
 
 export function onTaskUnscheduled({ task }) {
-    if (!task) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(task);
 }
 
 export function onTaskCompleted({ task }) {
-    if (!task) {
+    if (!refreshWhenPresent(task)) {
         return;
     }
-    refreshUI();
     if (task.type !== 'scheduled') {
         return;
     }
@@ -70,41 +70,29 @@ export function onTaskCompleted({ task }) {
 }
 
 export function onTaskDeleted({ task }) {
-    if (!task) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(task);
 }
 
 export function onActivityCreated({ activity }) {
-    if (!activity) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(activity);
 }
 
 export function onActivityEdited({ activity }) {
-    if (!activity) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(activity);
 }
 
 export function onActivityDeleted({ activity }) {
-    if (!activity) {
-        return;
-    }
-    refreshUI();
+    refreshWhenPresent(activity);
 }
 
 export function onScheduledTasksCleared() {
-    refreshUI();
+    refreshForClearEvent();
 }
 
 export function onCompletedTasksCleared() {
-    refreshUI();
+    refreshForClearEvent();
 }
 
 export function onAllTasksCleared() {
-    refreshUI();
+    refreshForClearEvent();
 }

--- a/public/js/app-coordinator.js
+++ b/public/js/app-coordinator.js
@@ -1,5 +1,6 @@
 import { refreshUI } from './dom-renderer.js';
 import { addActivity, createActivityFromTask } from './activities/manager.js';
+import { consumeActivitySmokeFailure } from './activities/smoke-hooks.js';
 import { isActivitiesEnabled } from './settings-manager.js';
 import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
 import { showToast } from './toast-manager.js';
@@ -63,7 +64,11 @@ export function onTaskCompleted({ task }) {
     if (isActivitiesEnabled()) {
         const activity = createActivityFromTask(task);
         if (activity) {
-            void addActivity(activity)
+            const autoLogPromise = consumeActivitySmokeFailure('auto-log')
+                ? Promise.reject(new Error('Smoke forced activity auto-log failure.'))
+                : addActivity(activity);
+
+            void autoLogPromise
                 .then((result) => {
                     if (result?.success && result.activity) {
                         onActivityCreated({ activity: result.activity });

--- a/public/js/app-coordinator.js
+++ b/public/js/app-coordinator.js
@@ -1,4 +1,6 @@
 import { refreshUI } from './dom-renderer.js';
+import { addActivity, createActivityFromTask } from './activities/manager.js';
+import { isActivitiesEnabled } from './settings-manager.js';
 import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
 
 /**
@@ -10,6 +12,9 @@ import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
  * - onTaskUnscheduled({ task })
  * - onTaskCompleted({ task })
  * - onTaskDeleted({ task })
+ * - onActivityCreated({ activity })
+ * - onActivityEdited({ activity })
+ * - onActivityDeleted({ activity })
  * - onScheduledTasksCleared()
  * - onCompletedTasksCleared()
  * - onAllTasksCleared()
@@ -47,13 +52,43 @@ export function onTaskCompleted({ task }) {
         return;
     }
     refreshUI();
-    if (task.type === 'scheduled') {
-        triggerConfettiAnimation(task.id);
+    if (task.type !== 'scheduled') {
+        return;
+    }
+
+    triggerConfettiAnimation(task.id);
+
+    if (isActivitiesEnabled()) {
+        const activity = createActivityFromTask(task);
+        if (activity) {
+            void addActivity(activity);
+        }
     }
 }
 
 export function onTaskDeleted({ task }) {
     if (!task) {
+        return;
+    }
+    refreshUI();
+}
+
+export function onActivityCreated({ activity }) {
+    if (!activity) {
+        return;
+    }
+    refreshUI();
+}
+
+export function onActivityEdited({ activity }) {
+    if (!activity) {
+        return;
+    }
+    refreshUI();
+}
+
+export function onActivityDeleted({ activity }) {
+    if (!activity) {
         return;
     }
     refreshUI();

--- a/public/js/app-coordinator.js
+++ b/public/js/app-coordinator.js
@@ -2,6 +2,7 @@ import { refreshUI } from './dom-renderer.js';
 import { addActivity, createActivityFromTask } from './activities/manager.js';
 import { isActivitiesEnabled } from './settings-manager.js';
 import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
+import { logger } from './utils.js';
 
 /**
  * Semantic post-mutation coordinator boundary for task state changes.
@@ -61,7 +62,9 @@ export function onTaskCompleted({ task }) {
     if (isActivitiesEnabled()) {
         const activity = createActivityFromTask(task);
         if (activity) {
-            void addActivity(activity);
+            void addActivity(activity).catch((error) => {
+                logger.error('Failed to auto-log completed task as activity:', error);
+            });
         }
     }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,7 +16,6 @@ import {
     setupEndTimeHint,
     setupOverlapWarning
 } from './tasks/form-utils.js';
-import { extractActivityFormData } from './activities/form-utils.js';
 import { refreshActiveTaskColor, refreshCurrentGapHighlight } from './tasks/scheduled-renderer.js';
 import {
     renderTasks,
@@ -29,13 +28,13 @@ import {
     startRealTimeClock,
     initializeUnscheduledTaskListEventListeners
 } from './dom-renderer.js';
-import { renderActivities } from './activities/renderer.js';
-import { getTodaysActivities, loadActivitiesState } from './activities/manager.js';
+import { loadActivitiesState } from './activities/manager.js';
 import {
-    handleAddActivity,
-    handleEditActivity,
-    handleDeleteActivity
-} from './activities/handlers.js';
+    syncActivitiesUI,
+    renderTodayActivities,
+    handleActivityAwareFormSubmit,
+    handleActivityListClick
+} from './activities/ui-handlers.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';
@@ -66,30 +65,6 @@ let refreshTaskDisplays = () => {};
 function refreshTaxonomyUI() {
     refreshTaskCategoryDropdownUI();
     refreshTaskDisplays();
-}
-
-function syncActivitiesUI(enabled) {
-    const activityToggleOption = document.getElementById('activity-toggle-option');
-    const activitiesContainer = document.getElementById('activities-container');
-
-    if (activityToggleOption) {
-        activityToggleOption.classList.toggle('hidden', !enabled);
-    }
-
-    if (activitiesContainer) {
-        activitiesContainer.classList.toggle('hidden', !enabled);
-    }
-
-    if (!enabled) {
-        const activityRadio = document.getElementById('activity');
-        const scheduledRadio = document.getElementById('scheduled');
-        if (activityRadio instanceof HTMLInputElement) {
-            activityRadio.checked = false;
-        }
-        if (scheduledRadio instanceof HTMLInputElement) {
-            scheduledRadio.checked = true;
-        }
-    }
 }
 
 /**
@@ -183,114 +158,37 @@ async function initAndBootApp(roomCode) {
             scheduledTaskEventCallbacks
         );
         renderUnscheduledTasks(getSortedUnscheduledTasks(), unscheduledTaskEventCallbacks);
-        if (isActivitiesEnabled()) {
-            renderActivities(
-                getTodaysActivities(),
-                /** @type {HTMLElement|null} */ (document.getElementById('activity-list'))
-            );
-        }
+        renderTodayActivities(isActivitiesEnabled());
         refreshActiveTaskColor(allTasks);
         refreshCurrentGapHighlight();
     };
 
     const appCallbacks = {
         onTaskFormSubmit: async (formElement) => {
-            const selectedTaskType = new FormData(formElement).get('task-type')?.toString();
-            if (isActivitiesEnabled() && selectedTaskType === 'activity') {
-                const activityData = extractActivityFormData(formElement);
-                if (!activityData) {
-                    focusTaskDescriptionInput();
-                    return;
+            await handleActivityAwareFormSubmit(formElement, {
+                activitiesEnabled: isActivitiesEnabled(),
+                resetTaskFormPreviewState,
+                initializeTaskTypeToggle,
+                focusTaskDescriptionInput,
+                handleTaskSubmit: async (taskFormElement) => {
+                    const taskData = extractTaskFormData(taskFormElement);
+                    if (!taskData) {
+                        focusTaskDescriptionInput();
+                        return;
+                    }
+                    const overlapEl = document.getElementById('overlap-warning');
+                    const reschedulePreApproved = !!(overlapEl && overlapEl.textContent.trim());
+                    await handleAddTaskProcess(taskFormElement, taskData, {
+                        reschedulePreApproved
+                    });
                 }
-
-                await handleAddActivity(activityData);
-                formElement.reset();
-                resetTaskFormPreviewState({
-                    hintElement: document.getElementById('end-time-hint'),
-                    warningElement: document.getElementById('overlap-warning'),
-                    buttonElement: document.getElementById('add-task-btn')
-                });
-
-                const categorySelect = document.getElementById('category-select');
-                if (categorySelect) {
-                    categorySelect.dispatchEvent(new Event('change'));
-                }
-
-                const activityRadio = formElement.querySelector(
-                    'input[name="task-type"][value="activity"]'
-                );
-                if (activityRadio instanceof HTMLInputElement) {
-                    activityRadio.checked = true;
-                }
-                initializeTaskTypeToggle();
-                focusTaskDescriptionInput();
-                return;
-            }
-
-            const taskData = extractTaskFormData(formElement);
-            if (!taskData) {
-                focusTaskDescriptionInput();
-                return;
-            }
-            const overlapEl = document.getElementById('overlap-warning');
-            const reschedulePreApproved = !!(overlapEl && overlapEl.textContent.trim());
-            await handleAddTaskProcess(formElement, taskData, { reschedulePreApproved });
+            });
         },
         onGlobalClick: (event) => {
-            const target = event.target;
-            if (!(target instanceof HTMLElement)) {
-                return;
-            }
-
-            const editActivityButton = target.closest('.btn-edit-activity');
-            if (editActivityButton instanceof HTMLElement) {
-                const activityItem = editActivityButton.closest('[data-activity-id]');
-                const activityId =
-                    editActivityButton.dataset.activityId ||
-                    activityItem?.getAttribute('data-activity-id');
-                if (activityId) {
-                    const currentDescription =
-                        activityItem
-                            ?.querySelector('.text-sm.text-slate-200')
-                            ?.textContent?.trim() || '';
-                    const nextDescription = window.prompt(
-                        'Edit activity description:',
-                        currentDescription
-                    );
-                    if (
-                        nextDescription !== null &&
-                        nextDescription.trim() !== '' &&
-                        nextDescription.trim() !== currentDescription
-                    ) {
-                        void handleEditActivity(activityId, {
-                            description: nextDescription.trim()
-                        });
-                    }
-                }
-                return;
-            }
-
-            const deleteActivityButton = target.closest('.btn-delete-activity');
-            if (deleteActivityButton instanceof HTMLElement) {
-                const activityItem = deleteActivityButton.closest('[data-activity-id]');
-                const activityId =
-                    deleteActivityButton.dataset.activityId ||
-                    activityItem?.getAttribute('data-activity-id');
-                if (activityId) {
-                    void handleDeleteActivity(activityId);
-                }
-                return;
-            }
-
-            const taskElement = target.closest('.task-item, .task-card');
-            const deleteButton = target.closest('.btn-delete, .btn-delete-unscheduled');
-
-            if (!taskElement && !deleteButton) {
-                const wasConfirming = resetAllConfirmingDeleteFlags();
-                if (wasConfirming) {
-                    refreshUI();
-                }
-            }
+            handleActivityListClick(event.target, {
+                refreshUI,
+                resetAllConfirmingDeleteFlags
+            });
         }
     };
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,12 +9,14 @@ import {
 import { initializeModalEventListeners } from './modal-manager.js';
 import {
     extractTaskFormData,
+    resetTaskFormPreviewState,
     initializeCategoryDropdownListener,
     getTaskFormElement,
     focusTaskDescriptionInput,
     setupEndTimeHint,
     setupOverlapWarning
 } from './tasks/form-utils.js';
+import { extractActivityFormData } from './activities/form-utils.js';
 import { refreshActiveTaskColor, refreshCurrentGapHighlight } from './tasks/scheduled-renderer.js';
 import {
     renderTasks,
@@ -27,6 +29,13 @@ import {
     startRealTimeClock,
     initializeUnscheduledTaskListEventListeners
 } from './dom-renderer.js';
+import { renderActivities } from './activities/renderer.js';
+import { getTodaysActivities, loadActivitiesState } from './activities/manager.js';
+import {
+    handleAddActivity,
+    handleEditActivity,
+    handleDeleteActivity
+} from './activities/handlers.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';
@@ -59,6 +68,30 @@ function refreshTaxonomyUI() {
     refreshTaskDisplays();
 }
 
+function syncActivitiesUI(enabled) {
+    const activityToggleOption = document.getElementById('activity-toggle-option');
+    const activitiesContainer = document.getElementById('activities-container');
+
+    if (activityToggleOption) {
+        activityToggleOption.classList.toggle('hidden', !enabled);
+    }
+
+    if (activitiesContainer) {
+        activitiesContainer.classList.toggle('hidden', !enabled);
+    }
+
+    if (!enabled) {
+        const activityRadio = document.getElementById('activity');
+        const scheduledRadio = document.getElementById('scheduled');
+        if (activityRadio instanceof HTMLInputElement) {
+            activityRadio.checked = false;
+        }
+        if (scheduledRadio instanceof HTMLInputElement) {
+            scheduledRadio.checked = true;
+        }
+    }
+}
+
 /**
  * Use an isolated room code for preview deployments so they never touch prod data.
  * @param {string} roomCode
@@ -82,13 +115,20 @@ async function loadTasksIntoState() {
     updateTaskState(loadedTasks, { persist: false });
 }
 
+async function loadAppState() {
+    await loadTasksIntoState();
+    if (isActivitiesEnabled()) {
+        await loadActivitiesState();
+    }
+}
+
 async function refreshFromStorage() {
     if (refreshFromStoragePromise) {
         return refreshFromStoragePromise;
     }
 
     refreshFromStoragePromise = (async () => {
-        await loadTasksIntoState();
+        await loadAppState();
         refreshUI();
         refreshActiveTaskColor(getTaskState());
         refreshCurrentGapHighlight();
@@ -127,9 +167,10 @@ async function initAndBootApp(roomCode) {
 
     // Load settings before any UI checks that depend on cached flags.
     await loadSettings();
+    syncActivitiesUI(isActivitiesEnabled());
 
     // Load and initialize state
-    await loadTasksIntoState();
+    await loadAppState();
     await loadTaxonomy();
 
     // Create callback objects
@@ -142,12 +183,50 @@ async function initAndBootApp(roomCode) {
             scheduledTaskEventCallbacks
         );
         renderUnscheduledTasks(getSortedUnscheduledTasks(), unscheduledTaskEventCallbacks);
+        if (isActivitiesEnabled()) {
+            renderActivities(
+                getTodaysActivities(),
+                /** @type {HTMLElement|null} */ (document.getElementById('activity-list'))
+            );
+        }
         refreshActiveTaskColor(allTasks);
         refreshCurrentGapHighlight();
     };
 
     const appCallbacks = {
         onTaskFormSubmit: async (formElement) => {
+            const selectedTaskType = new FormData(formElement).get('task-type')?.toString();
+            if (isActivitiesEnabled() && selectedTaskType === 'activity') {
+                const activityData = extractActivityFormData(formElement);
+                if (!activityData) {
+                    focusTaskDescriptionInput();
+                    return;
+                }
+
+                await handleAddActivity(activityData);
+                formElement.reset();
+                resetTaskFormPreviewState({
+                    hintElement: document.getElementById('end-time-hint'),
+                    warningElement: document.getElementById('overlap-warning'),
+                    buttonElement: document.getElementById('add-task-btn')
+                });
+
+                const categorySelect = document.getElementById('category-select');
+                if (categorySelect) {
+                    categorySelect.dispatchEvent(new Event('change'));
+                }
+
+                const activityRadio = formElement.querySelector(
+                    'input[name="task-type"][value="activity"]'
+                );
+                if (activityRadio instanceof HTMLInputElement) {
+                    activityRadio.checked = true;
+                }
+                initializeTaskTypeToggle();
+                focusTaskDescriptionInput();
+                return;
+            }
+
             const taskData = extractTaskFormData(formElement);
             if (!taskData) {
                 focusTaskDescriptionInput();
@@ -159,6 +238,50 @@ async function initAndBootApp(roomCode) {
         },
         onGlobalClick: (event) => {
             const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            const editActivityButton = target.closest('.btn-edit-activity');
+            if (editActivityButton instanceof HTMLElement) {
+                const activityItem = editActivityButton.closest('[data-activity-id]');
+                const activityId =
+                    editActivityButton.dataset.activityId ||
+                    activityItem?.getAttribute('data-activity-id');
+                if (activityId) {
+                    const currentDescription =
+                        activityItem
+                            ?.querySelector('.text-sm.text-slate-200')
+                            ?.textContent?.trim() || '';
+                    const nextDescription = window.prompt(
+                        'Edit activity description:',
+                        currentDescription
+                    );
+                    if (
+                        nextDescription !== null &&
+                        nextDescription.trim() !== '' &&
+                        nextDescription.trim() !== currentDescription
+                    ) {
+                        void handleEditActivity(activityId, {
+                            description: nextDescription.trim()
+                        });
+                    }
+                }
+                return;
+            }
+
+            const deleteActivityButton = target.closest('.btn-delete-activity');
+            if (deleteActivityButton instanceof HTMLElement) {
+                const activityItem = deleteActivityButton.closest('[data-activity-id]');
+                const activityId =
+                    deleteActivityButton.dataset.activityId ||
+                    activityItem?.getAttribute('data-activity-id');
+                if (activityId) {
+                    void handleDeleteActivity(activityId);
+                }
+                return;
+            }
+
             const taskElement = target.closest('.task-item, .task-card');
             const deleteButton = target.closest('.btn-delete, .btn-delete-unscheduled');
 

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -1,6 +1,9 @@
 import { logger, getCurrentTimeRounded } from './utils.js';
 import { getTaskState, getSortedUnscheduledTasks, getSuggestedStartTime } from './tasks/manager.js';
 import { isScheduledTask } from './tasks/validators.js';
+import { getTodaysActivities } from './activities/manager.js';
+import { renderActivities } from './activities/renderer.js';
+import { isActivitiesEnabled } from './settings-manager.js';
 import {
     getTaskFormElement,
     computeEndTimePreview,
@@ -72,11 +75,36 @@ export function startRealTimeClock() {
 export function initializeTaskTypeToggle() {
     const scheduledRadio = document.getElementById('scheduled');
     const unscheduledRadio = document.getElementById('unscheduled');
+    const activityRadio = document.getElementById('activity');
     const timeInputs = document.getElementById('time-inputs');
     const priorityInput = document.getElementById('priority-input');
     const addTaskButton = document.querySelector('#task-form button[type="submit"]');
     const descriptionInput = document.querySelector('input[name="description"]');
     const startTimeInput = document.querySelector('input[name="start-time"]');
+    const durationHoursInput = document.querySelector('input[name="duration-hours"]');
+    const durationMinutesInput = document.querySelector('input[name="duration-minutes"]');
+
+    const setInputTheme = (theme) => {
+        const focusClassMap = {
+            teal: 'focus:border-teal-400',
+            indigo: 'focus:border-indigo-400',
+            sky: 'focus:border-sky-400'
+        };
+        const themeClass = focusClassMap[theme];
+        [descriptionInput, startTimeInput, durationHoursInput, durationMinutesInput].forEach(
+            (element) => {
+                if (!(element instanceof HTMLElement)) {
+                    return;
+                }
+                Object.values(focusClassMap).forEach((className) => {
+                    element.classList.remove(className);
+                });
+                if (themeClass) {
+                    element.classList.add(themeClass);
+                }
+            }
+        );
+    };
 
     if (
         scheduledRadio instanceof HTMLInputElement &&
@@ -90,26 +118,47 @@ export function initializeTaskTypeToggle() {
             if (scheduledRadio.checked) {
                 timeInputs.classList.remove('hidden');
                 priorityInput.classList.add('hidden');
-                // Re-enable required on start-time when showing scheduled inputs
                 if (startTimeInput) startTimeInput.setAttribute('required', '');
                 addTaskButton.className =
                     'shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
                 descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all';
+                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
+                descriptionInput.setAttribute('placeholder', 'Describe your task...');
+                setInputTheme('teal');
+                return;
+            }
+
+            if (activityRadio instanceof HTMLInputElement && activityRadio.checked) {
+                timeInputs.classList.remove('hidden');
+                priorityInput.classList.add('hidden');
+                if (startTimeInput) startTimeInput.setAttribute('required', '');
+                addTaskButton.className =
+                    'shrink-0 bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+                addTaskButton.innerHTML = '<i class="fa-regular fa-clock mr-2"></i>Log Activity';
+                descriptionInput.className =
+                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
+                descriptionInput.setAttribute('placeholder', 'What did you work on?');
+                setInputTheme('sky');
             } else {
                 timeInputs.classList.add('hidden');
                 priorityInput.classList.remove('hidden');
-                // Remove required from start-time when hiding scheduled inputs
                 if (startTimeInput) startTimeInput.removeAttribute('required');
                 addTaskButton.className =
                     'shrink-0 bg-gradient-to-r from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
                 descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:border-indigo-400 focus:outline-none transition-all';
+                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
+                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
+                descriptionInput.setAttribute('placeholder', 'Describe your task...');
+                setInputTheme('indigo');
             }
         };
 
         scheduledRadio.addEventListener('change', toggleVisibility);
         unscheduledRadio.addEventListener('change', toggleVisibility);
+        if (activityRadio instanceof HTMLInputElement) {
+            activityRadio.addEventListener('change', toggleVisibility);
+        }
         toggleVisibility(); // Initial call
 
         // Add page visibility change listener to re-sync form state when user returns to tab
@@ -480,6 +529,9 @@ export function refreshUI() {
     const tasks = getTaskState();
     renderTasks(tasks.filter(isScheduledTask));
     renderUnscheduledTasks(getSortedUnscheduledTasks());
+    if (isActivitiesEnabled()) {
+        renderActivities(getTodaysActivities(), document.getElementById('activity-list'));
+    }
     updateStartTimeField(getSuggestedStartTime(), true);
 }
 

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -27,6 +27,48 @@ let globalScheduledTaskCallbacks = null;
 let globalUnscheduledTaskCallbacks = null;
 let pageEventListenersAbortController = null;
 
+const FORM_INPUT_BASE_CLASSES =
+    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
+const FORM_SUBMIT_BUTTON_BASE_CLASSES =
+    'shrink-0 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
+const INPUT_FOCUS_CLASS_BY_THEME = {
+    teal: 'focus:border-teal-400',
+    indigo: 'focus:border-indigo-400',
+    sky: 'focus:border-sky-400'
+};
+const TASK_FORM_MODE_CONFIG = {
+    scheduled: {
+        showTimeInputs: true,
+        showPriorityInput: false,
+        requireStartTime: true,
+        submitButtonClasses:
+            'bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300',
+        submitButtonHtml: '<i class="fa-regular fa-plus mr-2"></i>Add Task',
+        descriptionPlaceholder: 'Describe your task...',
+        inputTheme: 'teal'
+    },
+    unscheduled: {
+        showTimeInputs: false,
+        showPriorityInput: true,
+        requireStartTime: false,
+        submitButtonClasses:
+            'bg-gradient-to-r from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300',
+        submitButtonHtml: '<i class="fa-regular fa-plus mr-2"></i>Add Task',
+        descriptionPlaceholder: 'Describe your task...',
+        inputTheme: 'indigo'
+    },
+    activity: {
+        showTimeInputs: true,
+        showPriorityInput: false,
+        requireStartTime: true,
+        submitButtonClasses:
+            'bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300',
+        submitButtonHtml: '<i class="fa-regular fa-clock mr-2"></i>Log Activity',
+        descriptionPlaceholder: 'What did you work on?',
+        inputTheme: 'sky'
+    }
+};
+
 // Auto-update state for start time field
 const startTimeAutoUpdate = {
     trackedTime: /** @type {string|null} */ (null),
@@ -85,18 +127,13 @@ export function initializeTaskTypeToggle() {
     const durationMinutesInput = document.querySelector('input[name="duration-minutes"]');
 
     const setInputTheme = (theme) => {
-        const focusClassMap = {
-            teal: 'focus:border-teal-400',
-            indigo: 'focus:border-indigo-400',
-            sky: 'focus:border-sky-400'
-        };
-        const themeClass = focusClassMap[theme];
+        const themeClass = INPUT_FOCUS_CLASS_BY_THEME[theme];
         [descriptionInput, startTimeInput, durationHoursInput, durationMinutesInput].forEach(
             (element) => {
                 if (!(element instanceof HTMLElement)) {
                     return;
                 }
-                Object.values(focusClassMap).forEach((className) => {
+                Object.values(INPUT_FOCUS_CLASS_BY_THEME).forEach((className) => {
                     element.classList.remove(className);
                 });
                 if (themeClass) {
@@ -104,6 +141,30 @@ export function initializeTaskTypeToggle() {
                 }
             }
         );
+    };
+
+    const applyTaskFormMode = (mode) => {
+        const config = TASK_FORM_MODE_CONFIG[mode];
+        if (!config) {
+            return;
+        }
+
+        timeInputs.classList.toggle('hidden', !config.showTimeInputs);
+        priorityInput.classList.toggle('hidden', !config.showPriorityInput);
+
+        if (startTimeInput instanceof HTMLElement) {
+            if (config.requireStartTime) {
+                startTimeInput.setAttribute('required', '');
+            } else {
+                startTimeInput.removeAttribute('required');
+            }
+        }
+
+        addTaskButton.className = `${FORM_SUBMIT_BUTTON_BASE_CLASSES} ${config.submitButtonClasses}`;
+        addTaskButton.innerHTML = config.submitButtonHtml;
+        descriptionInput.className = FORM_INPUT_BASE_CLASSES;
+        descriptionInput.setAttribute('placeholder', config.descriptionPlaceholder);
+        setInputTheme(config.inputTheme);
     };
 
     if (
@@ -116,42 +177,16 @@ export function initializeTaskTypeToggle() {
     ) {
         const toggleVisibility = () => {
             if (scheduledRadio.checked) {
-                timeInputs.classList.remove('hidden');
-                priorityInput.classList.add('hidden');
-                if (startTimeInput) startTimeInput.setAttribute('required', '');
-                addTaskButton.className =
-                    'shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
-                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
-                descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
-                descriptionInput.setAttribute('placeholder', 'Describe your task...');
-                setInputTheme('teal');
+                applyTaskFormMode('scheduled');
                 return;
             }
 
             if (activityRadio instanceof HTMLInputElement && activityRadio.checked) {
-                timeInputs.classList.remove('hidden');
-                priorityInput.classList.add('hidden');
-                if (startTimeInput) startTimeInput.setAttribute('required', '');
-                addTaskButton.className =
-                    'shrink-0 bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
-                addTaskButton.innerHTML = '<i class="fa-regular fa-clock mr-2"></i>Log Activity';
-                descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
-                descriptionInput.setAttribute('placeholder', 'What did you work on?');
-                setInputTheme('sky');
-            } else {
-                timeInputs.classList.add('hidden');
-                priorityInput.classList.remove('hidden');
-                if (startTimeInput) startTimeInput.removeAttribute('required');
-                addTaskButton.className =
-                    'shrink-0 bg-gradient-to-r from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300 px-5 py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center';
-                descriptionInput.className =
-                    'bg-slate-700 p-2.5 rounded-lg w-full border border-slate-600 focus:outline-none transition-all';
-                addTaskButton.innerHTML = '<i class="fa-regular fa-plus mr-2"></i>Add Task';
-                descriptionInput.setAttribute('placeholder', 'Describe your task...');
-                setInputTheme('indigo');
+                applyTaskFormMode('activity');
+                return;
             }
+
+            applyTaskFormMode('unscheduled');
         };
 
         scheduledRadio.addEventListener('change', toggleVisibility);

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -1,9 +1,8 @@
 import { logger, getCurrentTimeRounded } from './utils.js';
 import { getTaskState, getSortedUnscheduledTasks, getSuggestedStartTime } from './tasks/manager.js';
 import { isScheduledTask } from './tasks/validators.js';
-import { getTodaysActivities } from './activities/manager.js';
-import { renderActivities } from './activities/renderer.js';
 import { isActivitiesEnabled } from './settings-manager.js';
+import { renderTodayActivities } from './activities/ui-handlers.js';
 import {
     getTaskFormElement,
     computeEndTimePreview,
@@ -565,7 +564,7 @@ export function refreshUI() {
     renderTasks(tasks.filter(isScheduledTask));
     renderUnscheduledTasks(getSortedUnscheduledTasks());
     if (isActivitiesEnabled()) {
-        renderActivities(getTodaysActivities(), document.getElementById('activity-list'));
+        renderTodayActivities(true);
     }
     updateStartTimeField(getSuggestedStartTime(), true);
 }

--- a/public/js/modal-manager.js
+++ b/public/js/modal-manager.js
@@ -34,17 +34,33 @@ const modalDurationHoursInput = scheduleModalForm
 const modalDurationMinutesInput = scheduleModalForm
     ? scheduleModalForm.querySelector('input[name="modal-duration-minutes"]')
     : null;
+const activityEditModal = document.getElementById('activity-edit-modal');
+const activityEditTitle = document.getElementById('activity-edit-title');
+const closeActivityEditButton = document.getElementById('close-activity-edit-modal');
+const cancelActivityEditButton = document.getElementById('cancel-activity-edit-modal');
+const saveActivityEditButton = document.getElementById('save-activity-edit-modal');
+const activityEditForm = document.getElementById('activity-edit-form');
+const activityEditDescriptionInput = document.getElementById('activity-edit-description');
 
 // --- Helper Functions ---
 function setModalTheme(modal, title, button, theme = 'indigo') {
-    const isIndigo = theme === 'indigo';
+    const titleClasses = {
+        indigo: 'text-indigo-400',
+        teal: 'text-teal-400',
+        sky: 'text-sky-400'
+    };
+    const buttonClasses = {
+        indigo: 'from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300',
+        teal: 'from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300',
+        sky: 'from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300'
+    };
     // Update title color
     if (title) {
-        title.className = `text-xl font-normal ${isIndigo ? 'text-indigo-400' : 'text-teal-400'}`;
+        title.className = `text-xl font-normal ${titleClasses[theme] || titleClasses.indigo}`;
     }
     // Update button gradient
     if (button) {
-        button.className = `bg-gradient-to-r ${isIndigo ? 'from-indigo-500 to-indigo-400 hover:from-indigo-400 hover:to-indigo-300' : 'from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300'} px-5 py-2 rounded-lg text-white font-normal transition-colors`;
+        button.className = `bg-gradient-to-r ${buttonClasses[theme] || buttonClasses.indigo} px-5 py-2 rounded-lg text-white font-normal transition-colors`;
     }
 }
 
@@ -353,6 +369,72 @@ export function showGapTaskPicker(
 if (closeGapTaskPickerButton) closeGapTaskPickerButton.addEventListener('click', hideGapTaskPicker);
 if (cancelGapTaskPickerButton)
     cancelGapTaskPickerButton.addEventListener('click', hideGapTaskPicker);
+
+// --- Activity Edit Modal ---
+export function hideActivityEditModal() {
+    if (activityEditModal) activityEditModal.classList.add('hidden');
+}
+
+export function showActivityEditModal(currentDescription = '') {
+    if (
+        !(activityEditForm instanceof HTMLFormElement) ||
+        !(activityEditDescriptionInput instanceof HTMLInputElement) ||
+        !activityEditModal ||
+        !(saveActivityEditButton instanceof HTMLElement)
+    ) {
+        return Promise.resolve(window.prompt('Edit activity description:', currentDescription));
+    }
+
+    if (activityEditTitle) {
+        activityEditTitle.textContent = 'Edit Activity';
+    }
+    activityEditDescriptionInput.value = currentDescription;
+    setModalTheme(activityEditModal, activityEditTitle, saveActivityEditButton, 'sky');
+    activityEditModal.classList.remove('hidden');
+    activityEditDescriptionInput.focus();
+    activityEditDescriptionInput.select();
+
+    return new Promise((resolve) => {
+        const cleanup = () => {
+            activityEditForm.removeEventListener('submit', handleSubmit);
+            if (closeActivityEditButton) {
+                closeActivityEditButton.removeEventListener('click', handleCancel);
+            }
+            if (cancelActivityEditButton) {
+                cancelActivityEditButton.removeEventListener('click', handleCancel);
+            }
+        };
+
+        const handleCancel = () => {
+            cleanup();
+            hideActivityEditModal();
+            resolve(null);
+        };
+
+        const handleSubmit = (event) => {
+            event.preventDefault();
+
+            const nextDescription = activityEditDescriptionInput.value.trim();
+            if (!nextDescription) {
+                showAlert('Activity description cannot be empty.', 'sky');
+                activityEditDescriptionInput.focus();
+                return;
+            }
+
+            cleanup();
+            hideActivityEditModal();
+            resolve(nextDescription);
+        };
+
+        activityEditForm.addEventListener('submit', handleSubmit);
+        if (closeActivityEditButton) {
+            closeActivityEditButton.addEventListener('click', handleCancel);
+        }
+        if (cancelActivityEditButton) {
+            cancelActivityEditButton.addEventListener('click', handleCancel);
+        }
+    });
+}
 
 // --- Convenience Wrappers ---
 export function showAlert(message, theme = 'indigo') {

--- a/public/js/tasks/form-utils.js
+++ b/public/js/tasks/form-utils.js
@@ -207,7 +207,7 @@ export function extractTaskFormData(formElement) {
         const estDuration = estDurationResult.duration;
         taskData = { ...taskData, priority, estDuration: estDuration > 0 ? estDuration : null };
     } else {
-        showAlert('Invalid task type selected.', 'indigo');
+        showAlert('Invalid task type selected.', getThemeForTaskType(taskType));
         return null;
     }
     return taskData;

--- a/public/js/toast-manager.js
+++ b/public/js/toast-manager.js
@@ -3,6 +3,7 @@ let container = null;
 const THEME_CLASSES = {
     teal: 'bg-teal-900/90 border-teal-700 text-teal-200',
     indigo: 'bg-indigo-900/90 border-indigo-700 text-indigo-200',
+    sky: 'bg-sky-900/90 border-sky-700 text-sky-200',
     amber: 'bg-amber-900/90 border-amber-700 text-amber-200',
     rose: 'bg-rose-900/90 border-rose-700 text-rose-200',
     default: 'bg-slate-800/90 border-slate-600 text-slate-200'

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -319,17 +319,29 @@ export function isTaskCurrentlyActive(task, now = new Date()) {
 /**
  * Get the theme color for a task type
  * @param {Object|null} task - The task object (or null)
- * @returns {'teal'|'indigo'} - Theme color name
+ * @returns {'teal'|'indigo'|'sky'} - Theme color name
  */
 export function getThemeForTask(task) {
-    return task?.type === 'scheduled' ? 'teal' : 'indigo';
+    if (task?.type === 'scheduled') {
+        return 'teal';
+    }
+    if (task?.type === 'activity') {
+        return 'sky';
+    }
+    return 'indigo';
 }
 
 /**
  * Get the theme color from a task type string
- * @param {'scheduled'|'unscheduled'|string} taskType - The task type
- * @returns {'teal'|'indigo'} - Theme color name
+ * @param {'scheduled'|'unscheduled'|'activity'|string} taskType - The task type
+ * @returns {'teal'|'indigo'|'sky'} - Theme color name
  */
 export function getThemeForTaskType(taskType) {
-    return taskType === 'scheduled' ? 'teal' : 'indigo';
+    if (taskType === 'scheduled') {
+        return 'teal';
+    }
+    if (taskType === 'activity') {
+        return 'sky';
+    }
+    return 'indigo';
 }

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -620,6 +620,12 @@ def dismiss_open_modals(page: Any) -> None:
             page.wait_for_timeout(100)
 
 
+def request_manual_sync(page: Any) -> None:
+    indicator = page.locator("#sync-status-indicator")
+    if indicator.count():
+        indicator.click()
+
+
 def enter_room(page: Any, room_code: str) -> None:
     page.locator("#room-entry-screen").wait_for(state="visible", timeout=15000)
     page.locator("#room-code-input").fill(room_code)
@@ -853,6 +859,9 @@ def arm_unscheduled_delete_confirm(
 
 def complete_scheduled_task_via_ui(page: Any, task_id: str) -> None:
     page.locator(f'[data-task-id="{task_id}"] .checkbox').click()
+    confirm_modal = page.locator("#custom-confirm-modal")
+    if confirm_modal.count() and confirm_modal.first.is_visible():
+        page.locator("#ok-custom-confirm-modal").click()
 
 
 def clear_all_tasks_via_ui(
@@ -1138,6 +1147,8 @@ def run_smoke(
             ]:
                 raise ValueError(f"missing edited scheduled task.\n{format_snapshot(alpha_summary)}")
             if couchdb_url:
+                request_manual_sync(page)
+                wait_for_sync_status_normal("taxonomy manual sync")
                 wait_until(
                     lambda: (
                         lambda summary: any(
@@ -1566,7 +1577,7 @@ def run_smoke(
                         )
                     )(read_remote_summary(rooms["taxonomy"])),
                     "taxonomy remote sync",
-                    timeout_s=25.0,
+                    timeout_s=60.0,
                 )
                 wait_for_sync_status_normal("taxonomy")
 

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -734,6 +734,26 @@ def wait_for_input_value(
     )
 
 
+def wait_for_activity_row_text(
+    page: Any,
+    activity_id: str,
+    expected_text: str,
+    *,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.2,
+) -> str:
+    selector = f'div.activity-item[data-activity-id="{activity_id}"]'
+    locator = page.locator(selector)
+    return wait_until(
+        lambda: (
+            text if expected_text in (text := (locator.text_content() or "")) else False
+        ),
+        f"activity row text for {activity_id}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+
+
 def add_scheduled_task(page: Any, description: str, start_time: str, duration_minutes: int) -> None:
     page.locator("#scheduled").check()
     fill_locator_value(
@@ -792,6 +812,29 @@ def ensure_task_doc_present(room_code: str, description: str, docs: list[dict[st
         if doc.get("description") == description:
             return normalize_doc(doc)
     raise ValueError(f"Missing task document for {room_code}: {description}")
+
+
+def wait_for_task_doc(
+    page: Any,
+    room_code: str,
+    description: str,
+    *,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.2,
+) -> dict[str, Any]:
+    return wait_until(
+        lambda: next(
+            (
+                normalized
+                for normalized in map(normalize_doc, read_docs(page, room_code))
+                if normalized.get("description") == description
+            ),
+            False,
+        ),
+        f"task persistence for {description!r}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
 
 
 def open_scheduled_edit_form(
@@ -988,6 +1031,10 @@ def filter_runtime_errors(
         if message.startswith("Failed to load resource: the server responded with a status of "):
             continue
         if has_only_abort_failures and "[sync-manager.js:" in message and "Sync error:" in message:
+            continue
+        if "Failed to auto-log completed task as activity:" in message and (
+            "Smoke forced activity auto-log failure." in message
+        ):
             continue
         filtered_console_errors.append(message)
 
@@ -1677,10 +1724,10 @@ def run_smoke(
                 raise ValueError("failed manual activity unexpectedly persisted")
 
             add_active_scheduled_task(page, "Playwright auto-log success", 20)
-            success_task_doc = ensure_task_doc_present(
+            success_task_doc = wait_for_task_doc(
+                page,
                 rooms["activities"],
                 "Playwright auto-log success",
-                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
             )
             complete_scheduled_task_via_ui(page, success_task_doc["id"])
             wait_until(
@@ -1700,10 +1747,10 @@ def run_smoke(
             )
 
             add_active_scheduled_task(page, "Playwright auto-log failure", 20)
-            failing_task_doc = ensure_task_doc_present(
+            failing_task_doc = wait_for_task_doc(
+                page,
                 rooms["activities"],
                 "Playwright auto-log failure",
-                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
             )
             queue_activity_smoke_failure(page, "auto-log", 1)
             complete_scheduled_task_via_ui(page, failing_task_doc["id"])
@@ -1723,16 +1770,21 @@ def run_smoke(
                 raise ValueError("failed auto-log unexpectedly created an activity")
 
             add_unscheduled_task(page, "Playwright delete confirm task", 15)
-            delete_confirm_task_doc = ensure_task_doc_present(
+            delete_confirm_task_doc = wait_for_task_doc(
+                page,
                 rooms["activities"],
                 "Playwright delete confirm task",
-                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
             )
 
             add_activity(page, "Playwright editable activity", "15:30", 15)
             editable_activity_doc = wait_for_activity_doc(
                 page,
                 rooms["activities"],
+                "Playwright editable activity",
+            )
+            wait_for_activity_row_text(
+                page,
+                editable_activity_doc["id"],
                 "Playwright editable activity",
             )
             arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
@@ -1774,6 +1826,11 @@ def run_smoke(
             deletable_activity_doc = wait_for_activity_doc(
                 page,
                 rooms["activities"],
+                "Playwright delete activity",
+            )
+            wait_for_activity_row_text(
+                page,
+                deletable_activity_doc["id"],
                 "Playwright delete activity",
             )
             arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -497,6 +497,30 @@ def ensure_activity_doc_present(
     raise ValueError(f"Missing activity document for {room_code}: {description}")
 
 
+def wait_for_activity_doc(
+    page: Any,
+    room_code: str,
+    description: str,
+    *,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.2,
+) -> dict[str, Any]:
+    return wait_until(
+        lambda: next(
+            (
+                normalized
+                for normalized in map(normalize_doc, read_docs(page, room_code))
+                if normalized.get("docType") == "activity"
+                and normalized.get("description") == description
+            ),
+            False,
+        ),
+        f"activity persistence for {description!r}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+
+
 def wait_for_activity_failure_alert(
     page: Any,
     room_code: str,
@@ -1686,10 +1710,10 @@ def run_smoke(
             )
 
             add_activity(page, "Playwright editable activity", "15:30", 15)
-            editable_activity_doc = ensure_activity_doc_present(
+            editable_activity_doc = wait_for_activity_doc(
+                page,
                 rooms["activities"],
                 "Playwright editable activity",
-                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
             )
             arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
             page.locator(
@@ -1722,10 +1746,10 @@ def run_smoke(
                 raise ValueError("delete confirm state was not cleared by activity edit")
 
             add_activity(page, "Playwright delete activity", "16:00", 10)
-            deletable_activity_doc = ensure_activity_doc_present(
+            deletable_activity_doc = wait_for_activity_doc(
+                page,
                 rooms["activities"],
                 "Playwright delete activity",
-                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
             )
             arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
             page.locator(

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -14,6 +14,7 @@ from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
 COUCHDB_URL_RE = re.compile(r"COUCHDB_URL\s*=\s*(?:'([^']*)'|null)")
+ACTIVITY_SMOKE_FAILURES_KEY = "fortudo-smoke-activity-failures"
 
 
 def normalize_doc(doc: dict[str, Any]) -> dict[str, Any]:
@@ -197,12 +198,18 @@ def is_preview_host(hostname: str) -> bool:
     )
 
 
+def supports_activity_smoke_failure_host(hostname: str) -> bool:
+    host = str(hostname or "")
+    return host in {"localhost", "127.0.0.1"} or is_preview_host(host)
+
+
 def create_scenario_rooms(prefix: str) -> dict[str, str]:
     return {
         "alpha": f"{prefix}-alpha",
         "legacy": f"{prefix}-legacy",
         "beta": f"{prefix}-beta",
         "taxonomy": f"{prefix}-taxonomy",
+        "activities": f"{prefix}-activities",
     }
 
 
@@ -381,6 +388,38 @@ def set_activities_enabled(page: Any, enabled: bool = True) -> None:
     )
 
 
+def queue_activity_smoke_failure(page: Any, failure_kind: str, count: int = 1) -> None:
+    hostname = get_hostname_from_url(page.url)
+    if not supports_activity_smoke_failure_host(hostname):
+        raise ValueError(
+            "Activity failure injection requires a preview or local host; "
+            f"got {hostname!r}."
+        )
+
+    page.evaluate(
+        """
+        ({ key, failureKind, count }) => {
+            const rawValue = window.localStorage.getItem(key);
+            let failures = {};
+            if (rawValue) {
+                try {
+                    failures = JSON.parse(rawValue) || {};
+                } catch {
+                    failures = {};
+                }
+            }
+            failures[failureKind] = Number(failures[failureKind] || 0) + Number(count || 0);
+            window.localStorage.setItem(key, JSON.stringify(failures));
+        }
+        """,
+        {
+            "key": ACTIVITY_SMOKE_FAILURES_KEY,
+            "failureKind": failure_kind,
+            "count": count,
+        },
+    )
+
+
 def open_settings_modal(page: Any) -> None:
     page.locator("#settings-gear-btn").click()
     page.locator("#settings-modal").wait_for(state="visible", timeout=10000)
@@ -408,6 +447,79 @@ def wait_for_toast_text(
         timeout_s=timeout_s,
         interval_s=interval_s,
     )
+
+
+def add_activity(page: Any, description: str, start_time: str, duration_minutes: int) -> None:
+    page.locator("#activity").check()
+    fill_locator_value(
+        page,
+        page.locator(task_form_input_selector("description")),
+        description,
+        description="activity description",
+    )
+    fill_locator_value(
+        page,
+        page.locator(task_form_input_selector("start-time")),
+        start_time,
+        description="activity start time",
+    )
+    fill_locator_value(
+        page,
+        page.locator(task_form_input_selector("duration-hours")),
+        str(duration_minutes // 60),
+        description="activity duration hours",
+    )
+    fill_locator_value(
+        page,
+        page.locator(task_form_input_selector("duration-minutes")),
+        str(duration_minutes % 60),
+        description="activity duration minutes",
+    )
+    page.locator("#task-form button[type='submit']").click()
+
+
+def ensure_activity_doc_present(
+    room_code: str, description: str, docs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    for doc in docs:
+        normalized = normalize_doc(doc)
+        if normalized.get("docType") == "activity" and normalized.get("description") == description:
+            return normalized
+    raise ValueError(f"Missing activity document for {room_code}: {description}")
+
+
+def wait_for_activity_failure_alert(
+    page: Any,
+    room_code: str,
+    description: str,
+    *,
+    timeout_s: float = 10.0,
+    interval_s: float = 0.2,
+) -> None:
+    outcome = wait_until(
+        lambda: (
+            "alert"
+            if page.locator("#custom-alert-modal").is_visible()
+            else (
+                "persisted"
+                if any(
+                    normalize_doc(doc).get("docType") == "activity"
+                    and normalize_doc(doc).get("description") == description
+                    for doc in read_docs(page, room_code)
+                )
+                else False
+            )
+        ),
+        f"activity failure outcome for {description!r}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+    if outcome == "persisted":
+        raise ValueError(
+            f"Activity failure hook did not fire for {description!r}; the activity was persisted."
+        )
+    if outcome != "alert":
+        raise TimeoutError(f"Timed out waiting for activity failure alert for {description!r}")
 
 
 def add_category_via_settings(page: Any, group_key: str, label: str) -> None:
@@ -709,6 +821,29 @@ def delete_unscheduled_task_via_ui(
             return
 
     raise TimeoutError(f"Timed out waiting for unscheduled task deletion for {task_id}")
+
+
+def arm_unscheduled_delete_confirm(
+    page: Any, task_id: str, *, timeout_s: float = 10.0, interval_s: float = 0.2
+) -> None:
+    button_selector = f'.task-card[data-task-id="{task_id}"] .btn-delete-unscheduled'
+    page.locator(button_selector).click()
+    state = wait_until(
+        lambda: (
+            current_state
+            if (current_state := get_unscheduled_delete_state(page, task_id)) == "confirming"
+            else False
+        ),
+        f"unscheduled delete confirm arm for {task_id}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+    if state != "confirming":
+        raise TimeoutError(f"Timed out arming unscheduled delete confirmation for {task_id}")
+
+
+def complete_scheduled_task_via_ui(page: Any, task_id: str) -> None:
+    page.locator(f'[data-task-id="{task_id}"] .checkbox').click()
 
 
 def clear_all_tasks_via_ui(
@@ -1425,6 +1560,166 @@ def run_smoke(
                     timeout_s=25.0,
                 )
                 wait_for_sync_status_normal("taxonomy")
+
+            demo_step(page, "checking activities room flows", step_pause_ms)
+            switch_room(page, rooms["activities"])
+            clear_room_storage(page, rooms["activities"])
+            set_activities_enabled(page, True)
+            page.reload(wait_until="load")
+            wait_for_main_app(page)
+
+            add_activity(page, "Playwright manual activity", "13:00", 30)
+            wait_until(
+                lambda: any(
+                    doc.get("description") == "Playwright manual activity"
+                    for doc in read_docs(page, rooms["activities"])
+                ),
+                "manual activity persistence",
+            )
+            wait_for_text_in_locator(
+                page,
+                "#activity-list",
+                "Playwright manual activity",
+                description="manual activity render",
+            )
+
+            queue_activity_smoke_failure(page, "manual-add", 1)
+            add_activity(page, "Playwright failed activity", "13:45", 15)
+            wait_for_activity_failure_alert(
+                page,
+                rooms["activities"],
+                "Playwright failed activity",
+            )
+            wait_for_text_in_locator(
+                page,
+                "#custom-alert-message",
+                "Could not log activity.",
+                description="manual activity failure alert",
+            )
+            failed_activity_description = page.locator(
+                task_form_input_selector("description")
+            ).input_value()
+            if failed_activity_description != "Playwright failed activity":
+                raise ValueError(
+                    "manual activity failure cleared the form unexpectedly: "
+                    f"{failed_activity_description!r}"
+                )
+            page.locator("#ok-custom-alert-modal").click()
+            page.locator("#custom-alert-modal").wait_for(state="hidden", timeout=10000)
+            if any(
+                doc.get("description") == "Playwright failed activity"
+                for doc in read_docs(page, rooms["activities"])
+            ):
+                raise ValueError("failed manual activity unexpectedly persisted")
+
+            add_scheduled_task(page, "Playwright auto-log success", "14:15", 20)
+            success_task_doc = ensure_task_doc_present(
+                rooms["activities"],
+                "Playwright auto-log success",
+                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
+            )
+            complete_scheduled_task_via_ui(page, success_task_doc["id"])
+            wait_until(
+                lambda: any(
+                    doc.get("docType") == "activity"
+                    and doc.get("description") == "Playwright auto-log success"
+                    and doc.get("source") == "auto"
+                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+                ),
+                "successful auto-log activity persistence",
+            )
+            wait_for_text_in_locator(
+                page,
+                "#activity-list",
+                "Playwright auto-log success",
+                description="successful auto-log activity render",
+            )
+
+            add_scheduled_task(page, "Playwright auto-log failure", "14:45", 20)
+            failing_task_doc = ensure_task_doc_present(
+                rooms["activities"],
+                "Playwright auto-log failure",
+                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
+            )
+            queue_activity_smoke_failure(page, "auto-log", 1)
+            complete_scheduled_task_via_ui(page, failing_task_doc["id"])
+            wait_for_toast_text(page, "Task completed, but activity auto-log failed.")
+            wait_until(
+                lambda: any(
+                    doc.get("id") == failing_task_doc["id"] and doc.get("status") == "completed"
+                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+                ),
+                "failed auto-log task completion persistence",
+            )
+            if any(
+                doc.get("docType") == "activity"
+                and doc.get("description") == "Playwright auto-log failure"
+                for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+            ):
+                raise ValueError("failed auto-log unexpectedly created an activity")
+
+            add_unscheduled_task(page, "Playwright delete confirm task", 15)
+            delete_confirm_task_doc = ensure_task_doc_present(
+                rooms["activities"],
+                "Playwright delete confirm task",
+                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
+            )
+
+            add_activity(page, "Playwright editable activity", "15:30", 15)
+            editable_activity_doc = ensure_activity_doc_present(
+                rooms["activities"],
+                "Playwright editable activity",
+                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
+            )
+            arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
+            page.locator(
+                f'[data-activity-id="{editable_activity_doc["id"]}"] .btn-edit-activity'
+            ).click()
+            page.locator("#activity-edit-modal").wait_for(state="visible", timeout=10000)
+            current_modal_value = page.locator("#activity-edit-description").input_value()
+            if current_modal_value != "Playwright editable activity":
+                raise ValueError(
+                    "activity edit modal lost the current description after rerender: "
+                    f"{current_modal_value!r}"
+                )
+            fill_locator_value(
+                page,
+                page.locator("#activity-edit-description"),
+                "Playwright editable activity updated",
+                description="activity edit modal description",
+            )
+            page.locator("#activity-edit-form").evaluate("(form) => form.requestSubmit()")
+            page.locator("#activity-edit-modal").wait_for(state="hidden", timeout=10000)
+            wait_until(
+                lambda: any(
+                    doc.get("id") == editable_activity_doc["id"]
+                    and doc.get("description") == "Playwright editable activity updated"
+                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+                ),
+                "activity edit after delete-confirm rerender",
+            )
+            if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
+                raise ValueError("delete confirm state was not cleared by activity edit")
+
+            add_activity(page, "Playwright delete activity", "16:00", 10)
+            deletable_activity_doc = ensure_activity_doc_present(
+                rooms["activities"],
+                "Playwright delete activity",
+                list(map(normalize_doc, read_docs(page, rooms["activities"]))),
+            )
+            arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
+            page.locator(
+                f'[data-activity-id="{deletable_activity_doc["id"]}"] .btn-delete-activity'
+            ).click()
+            wait_until(
+                lambda: not any(
+                    doc.get("id") == deletable_activity_doc["id"]
+                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+                ),
+                "activity delete after delete-confirm rerender",
+            )
+            if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
+                raise ValueError("delete confirm state was not cleared by activity delete")
 
             assert_no_runtime_errors(console_errors, page_errors, request_failures, response_errors)
 

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -478,6 +478,15 @@ def add_activity(page: Any, description: str, start_time: str, duration_minutes:
     page.locator("#task-form button[type='submit']").click()
 
 
+def add_active_scheduled_task(page: Any, description: str, duration_minutes: int) -> None:
+    page.locator("#scheduled").check()
+    start_time = page.locator(task_form_input_selector("start-time")).input_value()
+    if not start_time:
+        raise ValueError("Scheduled task form did not provide a suggested start time.")
+
+    add_scheduled_task(page, description, start_time, duration_minutes)
+
+
 def ensure_activity_doc_present(
     room_code: str, description: str, docs: list[dict[str, Any]]
 ) -> dict[str, Any]:
@@ -1612,7 +1621,7 @@ def run_smoke(
             ):
                 raise ValueError("failed manual activity unexpectedly persisted")
 
-            add_scheduled_task(page, "Playwright auto-log success", "14:15", 20)
+            add_active_scheduled_task(page, "Playwright auto-log success", 20)
             success_task_doc = ensure_task_doc_present(
                 rooms["activities"],
                 "Playwright auto-log success",
@@ -1635,7 +1644,7 @@ def run_smoke(
                 description="successful auto-log activity render",
             )
 
-            add_scheduled_task(page, "Playwright auto-log failure", "14:45", 20)
+            add_active_scheduled_task(page, "Playwright auto-log failure", 20)
             failing_task_doc = ensure_task_doc_present(
                 rooms["activities"],
                 "Playwright auto-log failure",

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -1791,26 +1791,34 @@ def run_smoke(
             page.locator(
                 f'[data-activity-id="{editable_activity_doc["id"]}"] .btn-edit-activity'
             ).click()
-            page.locator("#activity-edit-modal").wait_for(state="visible", timeout=10000)
+            page.locator(
+                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"]'
+            ).wait_for(state="visible", timeout=10000)
             current_modal_value = wait_for_input_value(
                 page,
-                "#activity-edit-description",
+                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] input[name="description"]',
                 "Playwright editable activity",
-                description="activity edit modal description preload",
+                description="activity inline edit description preload",
             )
             if current_modal_value != "Playwright editable activity":
                 raise ValueError(
-                    "activity edit modal lost the current description after rerender: "
+                    "activity inline edit lost the current description after rerender: "
                     f"{current_modal_value!r}"
                 )
             fill_locator_value(
                 page,
-                page.locator("#activity-edit-description"),
+                page.locator(
+                    f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] input[name="description"]'
+                ),
                 "Playwright editable activity updated",
-                description="activity edit modal description",
+                description="activity inline edit description",
             )
-            page.locator("#activity-edit-form").evaluate("(form) => form.requestSubmit()")
-            page.locator("#activity-edit-modal").wait_for(state="hidden", timeout=10000)
+            page.locator(
+                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] .btn-save-activity-edit'
+            ).click()
+            page.locator(
+                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"]'
+            ).wait_for(state="hidden", timeout=10000)
             wait_until(
                 lambda: any(
                     doc.get("id") == editable_activity_doc["id"]

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -714,6 +714,26 @@ def wait_for_text_in_locator(
     )
 
 
+def wait_for_input_value(
+    page: Any,
+    selector: str,
+    expected_value: str,
+    *,
+    description: str,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.2,
+) -> str:
+    locator = page.locator(selector)
+    return wait_until(
+        lambda: (
+            value if (value := locator.input_value()) == expected_value else False
+        ),
+        description,
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+
+
 def add_scheduled_task(page: Any, description: str, start_time: str, duration_minutes: int) -> None:
     page.locator("#scheduled").check()
     fill_locator_value(
@@ -1720,7 +1740,12 @@ def run_smoke(
                 f'[data-activity-id="{editable_activity_doc["id"]}"] .btn-edit-activity'
             ).click()
             page.locator("#activity-edit-modal").wait_for(state="visible", timeout=10000)
-            current_modal_value = page.locator("#activity-edit-description").input_value()
+            current_modal_value = wait_for_input_value(
+                page,
+                "#activity-edit-description",
+                "Playwright editable activity",
+                description="activity edit modal description preload",
+            )
             if current_modal_value != "Playwright editable activity":
                 raise ValueError(
                     "activity edit modal lost the current description after rerender: "

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -31,6 +31,7 @@ from scripts.playwright_preview_smoke import (
     open_scheduled_edit_form,
     parse_cli_args,
     queue_activity_smoke_failure,
+    request_manual_sync,
     supports_activity_smoke_failure_host,
     summarize_docs,
     task_form_input_selector,
@@ -554,6 +555,14 @@ class PreviewWaitHelperTests(unittest.TestCase):
         self.assertEqual(payload["failureKind"], "manual-add")
         self.assertEqual(payload["count"], 2)
 
+    def test_request_manual_sync_clicks_indicator_when_present(self):
+        indicator = FakeLocator()
+        page = FakePage({"#sync-status-indicator": indicator})
+
+        request_manual_sync(page)
+
+        self.assertEqual(indicator.clicks, 1)
+
     def test_add_activity_uses_activity_mode_and_shared_duration_inputs(self):
         activity_radio = FakeLocator()
         description = FakeLocator()
@@ -623,11 +632,34 @@ class PreviewWaitHelperTests(unittest.TestCase):
 
     def test_complete_scheduled_task_via_ui_clicks_task_checkbox(self):
         checkbox = FakeLocator()
-        page = FakePage({'[data-task-id="sched-123"] .checkbox': checkbox})
+        page = FakePage(
+            {
+                '[data-task-id="sched-123"] .checkbox': checkbox,
+                "#custom-confirm-modal": FakeLocator(visible=False),
+                "#ok-custom-confirm-modal": FakeLocator(),
+            }
+        )
 
         complete_scheduled_task_via_ui(page, "sched-123")
 
         self.assertEqual(checkbox.clicks, 1)
+
+    def test_complete_scheduled_task_via_ui_confirms_late_completion_modal(self):
+        checkbox = FakeLocator()
+        confirm_modal = FakeLocator(visible=True)
+        confirm_button = FakeLocator()
+        page = FakePage(
+            {
+                '[data-task-id="sched-123"] .checkbox': checkbox,
+                "#custom-confirm-modal": confirm_modal,
+                "#ok-custom-confirm-modal": confirm_button,
+            }
+        )
+
+        complete_scheduled_task_via_ui(page, "sched-123")
+
+        self.assertEqual(checkbox.clicks, 1)
+        self.assertEqual(confirm_button.clicks, 1)
 
     def test_arm_unscheduled_delete_confirm_waits_for_confirming_state(self):
         page = DeleteStatePage("unsched-123")

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from scripts.playwright_preview_smoke import (
     add_activity,
+    add_active_scheduled_task,
     add_category_via_settings,
     arm_unscheduled_delete_confirm,
     assert_migrated_task_docs,
@@ -579,6 +580,35 @@ class PreviewWaitHelperTests(unittest.TestCase):
         self.assertEqual(start_time.value, "13:00")
         self.assertEqual(duration_hours.value, "1")
         self.assertEqual(duration_minutes.value, "30")
+        self.assertEqual(submit_button.clicks, 1)
+
+    def test_add_active_scheduled_task_uses_current_suggested_start_time(self):
+        scheduled_radio = FakeLocator()
+        description = FakeLocator()
+        start_time = FakeLocator()
+        duration_hours = FakeLocator()
+        duration_minutes = FakeLocator()
+        submit_button = FakeLocator()
+        page = FakePage(
+            {
+                "#scheduled": scheduled_radio,
+                task_form_input_selector("description"): description,
+                task_form_input_selector("start-time"): start_time,
+                task_form_input_selector("duration-hours"): duration_hours,
+                task_form_input_selector("duration-minutes"): duration_minutes,
+                "#task-form button[type='submit']": submit_button,
+            }
+        )
+        scheduled_radio.check = lambda: setattr(scheduled_radio, "value", "checked")
+        start_time.value = "14:10"
+
+        add_active_scheduled_task(page, "Playwright active task", 20)
+
+        self.assertEqual(scheduled_radio.value, "checked")
+        self.assertEqual(description.value, "Playwright active task")
+        self.assertEqual(start_time.value, "14:10")
+        self.assertEqual(duration_hours.value, "0")
+        self.assertEqual(duration_minutes.value, "20")
         self.assertEqual(submit_button.clicks, 1)
 
     def test_ensure_activity_doc_present_requires_activity_doc_type(self):

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -36,6 +36,7 @@ from scripts.playwright_preview_smoke import (
     summarize_docs,
     task_form_input_selector,
     wait_for_activity_doc,
+    wait_for_input_value,
     wait_for_activity_failure_alert,
     wait_for_demo_start,
     wait_for_room_code,
@@ -642,6 +643,34 @@ class PreviewWaitHelperTests(unittest.TestCase):
         result = wait_for_activity_doc(page, "room-a", "Focus block", timeout_s=0.05, interval_s=0)
 
         self.assertEqual(result["id"], "activity-1")
+
+    def test_wait_for_input_value_waits_until_field_matches(self):
+        input_locator = FakeLocator()
+        input_locator.value = ""
+        input_locator.text_values = []
+        page = FakePage({"#activity-edit-description": input_locator})
+
+        original_input_value = input_locator.input_value
+        calls = {"count": 0}
+
+        def delayed_value():
+            calls["count"] += 1
+            if calls["count"] >= 2:
+                input_locator.value = "Playwright editable activity"
+            return original_input_value()
+
+        input_locator.input_value = delayed_value
+
+        result = wait_for_input_value(
+            page,
+            "#activity-edit-description",
+            "Playwright editable activity",
+            description="activity edit modal description preload",
+            timeout_s=0.05,
+            interval_s=0,
+        )
+
+        self.assertEqual(result, "Playwright editable activity")
 
     def test_complete_scheduled_task_via_ui_clicks_task_checkbox(self):
         checkbox = FakeLocator()

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -2,7 +2,9 @@ import unittest
 from unittest.mock import patch
 
 from scripts.playwright_preview_smoke import (
+    add_activity,
     add_category_via_settings,
+    arm_unscheduled_delete_confirm,
     assert_migrated_task_docs,
     assert_non_task_docs_remain,
     build_phase3_taxonomy_config_doc,
@@ -10,11 +12,13 @@ from scripts.playwright_preview_smoke import (
     build_couchdb_request_parts,
     build_remote_db_name,
     clear_all_tasks_via_ui,
+    complete_scheduled_task_via_ui,
     compute_storage_room_code,
     create_run_scoped_prefix,
     create_scenario_rooms,
     delete_unscheduled_task_via_ui,
     derive_smoke_room_prefix,
+    ensure_activity_doc_present,
     extract_couchdb_url,
     fetch_remote_docs,
     fill_locator_value,
@@ -25,8 +29,11 @@ from scripts.playwright_preview_smoke import (
     is_preview_host,
     open_scheduled_edit_form,
     parse_cli_args,
+    queue_activity_smoke_failure,
+    supports_activity_smoke_failure_host,
     summarize_docs,
     task_form_input_selector,
+    wait_for_activity_failure_alert,
     wait_for_demo_start,
     wait_for_room_code,
     wait_for_text_in_locator,
@@ -254,6 +261,12 @@ class SnapshotAssertionTests(unittest.TestCase):
 
 
 class CliHelpersTests(unittest.TestCase):
+    def test_activity_smoke_failure_hosts_allow_preview_and_local_only(self):
+        self.assertTrue(supports_activity_smoke_failure_host("127.0.0.1"))
+        self.assertTrue(supports_activity_smoke_failure_host("localhost"))
+        self.assertTrue(supports_activity_smoke_failure_host("fortudo--pr53.web.app"))
+        self.assertFalse(supports_activity_smoke_failure_host("fortudo.web.app"))
+
     def test_parse_cli_args_defaults_to_visible_chrome(self):
         parsed = parse_cli_args(["https://example.test"])
 
@@ -353,6 +366,7 @@ class CliHelpersTests(unittest.TestCase):
                 "legacy": "preview-pr53-smoke-legacy",
                 "beta": "preview-pr53-smoke-beta",
                 "taxonomy": "preview-pr53-smoke-taxonomy",
+                "activities": "preview-pr53-smoke-activities",
             },
         )
 
@@ -472,9 +486,11 @@ class FakeLocator:
 
 
 class FakePage:
-    def __init__(self, locators):
+    def __init__(self, locators, *, url="https://fortudo--pr53.web.app"):
         self._locators = locators
+        self.url = url
         self.waits = []
+        self.evaluations = []
 
     def locator(self, selector):
         locator = self._locators.get(selector)
@@ -484,6 +500,9 @@ class FakePage:
 
     def wait_for_timeout(self, timeout_ms):
         self.waits.append(timeout_ms)
+
+    def evaluate(self, script, payload):
+        self.evaluations.append((script, payload))
 
 
 class DeleteStatePage(FakePage):
@@ -518,6 +537,107 @@ class DeleteStatePage(FakePage):
 
 
 class PreviewWaitHelperTests(unittest.TestCase):
+    def test_queue_activity_smoke_failure_rejects_unsupported_hosts(self):
+        page = FakePage({}, url="https://fortudo.web.app")
+
+        with self.assertRaisesRegex(ValueError, "preview or local host"):
+            queue_activity_smoke_failure(page, "manual-add", 1)
+
+    def test_queue_activity_smoke_failure_writes_local_storage_payload(self):
+        page = FakePage({})
+
+        queue_activity_smoke_failure(page, "manual-add", 2)
+
+        self.assertEqual(len(page.evaluations), 1)
+        _script, payload = page.evaluations[0]
+        self.assertEqual(payload["failureKind"], "manual-add")
+        self.assertEqual(payload["count"], 2)
+
+    def test_add_activity_uses_activity_mode_and_shared_duration_inputs(self):
+        activity_radio = FakeLocator()
+        description = FakeLocator()
+        start_time = FakeLocator()
+        duration_hours = FakeLocator()
+        duration_minutes = FakeLocator()
+        submit_button = FakeLocator()
+        page = FakePage(
+            {
+                "#activity": activity_radio,
+                task_form_input_selector("description"): description,
+                task_form_input_selector("start-time"): start_time,
+                task_form_input_selector("duration-hours"): duration_hours,
+                task_form_input_selector("duration-minutes"): duration_minutes,
+                "#task-form button[type='submit']": submit_button,
+            }
+        )
+        activity_radio.check = lambda: setattr(activity_radio, "value", "checked")
+
+        add_activity(page, "Playwright activity", "13:00", 90)
+
+        self.assertEqual(activity_radio.value, "checked")
+        self.assertEqual(description.value, "Playwright activity")
+        self.assertEqual(start_time.value, "13:00")
+        self.assertEqual(duration_hours.value, "1")
+        self.assertEqual(duration_minutes.value, "30")
+        self.assertEqual(submit_button.clicks, 1)
+
+    def test_ensure_activity_doc_present_requires_activity_doc_type(self):
+        docs = [
+            {"_id": "task-1", "docType": "task", "description": "Not activity"},
+            {"_id": "activity-1", "docType": "activity", "description": "Focus block"},
+        ]
+
+        result = ensure_activity_doc_present("room-a", "Focus block", docs)
+
+        self.assertEqual(result["id"], "activity-1")
+
+    def test_complete_scheduled_task_via_ui_clicks_task_checkbox(self):
+        checkbox = FakeLocator()
+        page = FakePage({'[data-task-id="sched-123"] .checkbox': checkbox})
+
+        complete_scheduled_task_via_ui(page, "sched-123")
+
+        self.assertEqual(checkbox.clicks, 1)
+
+    def test_arm_unscheduled_delete_confirm_waits_for_confirming_state(self):
+        page = DeleteStatePage("unsched-123")
+
+        original_click = page.button.click
+
+        def click_and_advance():
+            original_click()
+            page.state = "confirming"
+
+        page.button.click = click_and_advance
+
+        arm_unscheduled_delete_confirm(page, "unsched-123", timeout_s=0.05, interval_s=0)
+
+        self.assertEqual(page.button.clicks, 1)
+        self.assertEqual(page.state, "confirming")
+
+    @patch("scripts.playwright_preview_smoke.wait_until")
+    def test_wait_for_activity_failure_alert_accepts_visible_modal(self, mock_wait_until):
+        page = FakePage({"#custom-alert-modal": FakeLocator(visible=True)})
+        mock_wait_until.side_effect = lambda predicate, *_args, **_kwargs: predicate()
+
+        wait_for_activity_failure_alert(page, "room-a", "Failed activity")
+
+        self.assertEqual(mock_wait_until.call_count, 1)
+
+    @patch("scripts.playwright_preview_smoke.read_docs")
+    @patch("scripts.playwright_preview_smoke.wait_until")
+    def test_wait_for_activity_failure_alert_raises_when_activity_persists(
+        self, mock_wait_until, mock_read_docs
+    ):
+        page = FakePage({"#custom-alert-modal": FakeLocator(visible=False)})
+        mock_read_docs.return_value = [
+            {"_id": "activity-1", "docType": "activity", "description": "Failed activity"}
+        ]
+        mock_wait_until.side_effect = lambda predicate, *_args, **_kwargs: predicate()
+
+        with self.assertRaisesRegex(ValueError, "did not fire"):
+            wait_for_activity_failure_alert(page, "room-a", "Failed activity")
+
     def test_wait_for_room_code_waits_for_exact_room_match(self):
         page = FakePage(
             {

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -35,8 +35,10 @@ from scripts.playwright_preview_smoke import (
     supports_activity_smoke_failure_host,
     summarize_docs,
     task_form_input_selector,
+    wait_for_task_doc,
     wait_for_activity_doc,
     wait_for_input_value,
+    wait_for_activity_row_text,
     wait_for_activity_failure_alert,
     wait_for_demo_start,
     wait_for_room_code,
@@ -228,6 +230,21 @@ class SnapshotAssertionTests(unittest.TestCase):
             filtered_request_failures,
             ["GET https://example.cloudant.com/fortudo-preview-alpha/ 403 Forbidden"],
         )
+        self.assertEqual(filtered_response_errors, [])
+
+    def test_filter_runtime_errors_ignores_expected_smoke_forced_auto_log_failure(self):
+        filtered_console_errors, filtered_request_failures, filtered_response_errors = (
+            filter_runtime_errors(
+                [
+                    "[💪🏾 ERROR] [app-coordinator.js:78] Failed to auto-log completed task as activity: Error: Smoke forced activity auto-log failure."
+                ],
+                [],
+                [],
+            )
+        )
+
+        self.assertEqual(filtered_console_errors, [])
+        self.assertEqual(filtered_request_failures, [])
         self.assertEqual(filtered_response_errors, [])
 
     def test_expected_sync_response_error_accepts_known_cloudant_noise(self):
@@ -644,6 +661,18 @@ class PreviewWaitHelperTests(unittest.TestCase):
 
         self.assertEqual(result["id"], "activity-1")
 
+    @patch("scripts.playwright_preview_smoke.read_docs")
+    def test_wait_for_task_doc_waits_until_task_persists(self, mock_read_docs):
+        mock_read_docs.side_effect = [
+            [],
+            [{"_id": "task-1", "docType": "task", "description": "Focus task"}],
+        ]
+        page = FakePage({})
+
+        result = wait_for_task_doc(page, "room-a", "Focus task", timeout_s=0.05, interval_s=0)
+
+        self.assertEqual(result["id"], "task-1")
+
     def test_wait_for_input_value_waits_until_field_matches(self):
         input_locator = FakeLocator()
         input_locator.value = ""
@@ -671,6 +700,20 @@ class PreviewWaitHelperTests(unittest.TestCase):
         )
 
         self.assertEqual(result, "Playwright editable activity")
+
+    def test_wait_for_activity_row_text_uses_activity_scoped_selector(self):
+        row = FakeLocator(text_values=["", "Focus block"])
+        page = FakePage({'div.activity-item[data-activity-id="activity-1"]': row})
+
+        result = wait_for_activity_row_text(
+            page,
+            "activity-1",
+            "Focus block",
+            timeout_s=0.05,
+            interval_s=0,
+        )
+
+        self.assertEqual(result, "Focus block")
 
     def test_complete_scheduled_task_via_ui_clicks_task_checkbox(self):
         checkbox = FakeLocator()

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -35,6 +35,7 @@ from scripts.playwright_preview_smoke import (
     supports_activity_smoke_failure_host,
     summarize_docs,
     task_form_input_selector,
+    wait_for_activity_doc,
     wait_for_activity_failure_alert,
     wait_for_demo_start,
     wait_for_room_code,
@@ -627,6 +628,18 @@ class PreviewWaitHelperTests(unittest.TestCase):
         ]
 
         result = ensure_activity_doc_present("room-a", "Focus block", docs)
+
+        self.assertEqual(result["id"], "activity-1")
+
+    @patch("scripts.playwright_preview_smoke.read_docs")
+    def test_wait_for_activity_doc_waits_until_activity_persists(self, mock_read_docs):
+        mock_read_docs.side_effect = [
+            [],
+            [{"_id": "activity-1", "docType": "activity", "description": "Focus block"}],
+        ]
+        page = FakePage({})
+
+        result = wait_for_activity_doc(page, "room-a", "Focus block", timeout_s=0.05, interval_s=0)
 
         self.assertEqual(result["id"], "activity-1")
 


### PR DESCRIPTION
## Summary
- add the Phase 4 activity logging flow with activity state, CRUD handlers, rendering, and app/coordinator wiring
- add the activity form mode and activity list UI, including manual logging and scheduled-task auto-logging
- add the Phase 4 plan docs and broaden tests for activity edge cases, rendering fallbacks, and auto-log failure handling

## Test Plan
- [x] npm.cmd run check
- [x] npm.cmd test -- --coverage --runInBand
