### PR TITLE
feat: add activity timer workflow

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,7 @@ Historical and planned repo tasks for Fortudo.
 - [x] (v3) rename `dom-handler.js` to `dom-renderer.js` or `view.js` (it's a rendering/view layer, not a feature handler)
 
 - [ ] (vNext) add a version of my `tracks` app to this (either directly or more like a plugin, somehow..?)
+- [ ] (vNext) make Fortudo a PWA: installable and offline-friendly as a first-class web app
 - [ ] (vNext) automatically convert scheduled tasks to unscheduled when rescheduling pushes them past midnight
   - use the same scheduled-to-unscheduled conversion contract as day rollover so both paths behave the same
   - convert the task into an unscheduled task with `estDuration` copied from scheduled `duration` and default `priority` of `medium` unless a better preserved value exists by then

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -749,6 +749,33 @@ describe('activity app integration', () => {
         expect(handled).toBe(true);
         expect(resetAllConfirmingDeleteFlagsMock).toHaveBeenCalled();
         expect(refreshUIMock).toHaveBeenCalled();
+        expect(handleDeleteActivity).not.toHaveBeenCalled();
+    });
+
+    test('second click on a confirming activity delete executes the delete', async () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <article class="activity-item" data-activity-id="activity-2">
+                <button class="btn-delete-activity"><span>Delete</span></button>
+            </article>
+        `;
+        const refreshUIMock = jest.fn();
+
+        await handleActivityListClick(activityList.querySelector('.btn-delete-activity span'), {
+            refreshUI: refreshUIMock,
+            resetAllConfirmingDeleteFlags: jest.fn(() => false)
+        });
+        renderTodayActivities(true);
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('.btn-delete-activity span'),
+            {
+                refreshUI: refreshUIMock,
+                resetAllConfirmingDeleteFlags: jest.fn(() => false)
+            }
+        );
+
+        expect(handled).toBe(true);
         expect(handleDeleteActivity).toHaveBeenCalledWith('activity-2');
     });
 
@@ -778,12 +805,20 @@ describe('activity app integration', () => {
             </article>
         `;
         const deleteRefreshMock = jest.fn(() => {
-            activityList.innerHTML = '<div>rerendered again</div>';
+            activityList.innerHTML = `
+                <article class="activity-item" data-activity-id="activity-10">
+                    <button class="btn-delete-activity"><span>Delete</span></button>
+                </article>
+            `;
         });
 
         await handleActivityListClick(activityList.querySelector('.btn-delete-activity span'), {
             refreshUI: deleteRefreshMock,
             resetAllConfirmingDeleteFlags: jest.fn(() => true)
+        });
+        await handleActivityListClick(activityList.querySelector('.btn-delete-activity span'), {
+            refreshUI: deleteRefreshMock,
+            resetAllConfirmingDeleteFlags: jest.fn(() => false)
         });
 
         expect(handleDeleteActivity).toHaveBeenCalledWith('activity-10');

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -2,19 +2,27 @@
  * @jest-environment jsdom
  */
 
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn()
+}));
+
 jest.mock('../public/js/activities/form-utils.js', () => ({
     extractActivityFormData: jest.fn()
 }));
 
 jest.mock('../public/js/activities/handlers.js', () => ({
     handleAddActivity: jest.fn(() => Promise.resolve({ success: true })),
+    handleStartTimer: jest.fn(() => Promise.resolve({ success: true })),
+    handleStopTimer: jest.fn(() => Promise.resolve({ success: true })),
     handleEditActivity: jest.fn(() => Promise.resolve()),
     handleDeleteActivity: jest.fn(() => Promise.resolve()),
     handleSaveActivityEdit: jest.fn(() => Promise.resolve({ success: true }))
 }));
 
 jest.mock('../public/js/activities/manager.js', () => ({
-    getTodaysActivities: jest.fn(() => [])
+    getTodaysActivities: jest.fn(() => []),
+    getRunningActivity: jest.fn(() => null),
+    updateRunningActivity: jest.fn(() => Promise.resolve({ success: true }))
 }));
 
 jest.mock('../public/js/activities/renderer.js', () => ({
@@ -26,20 +34,35 @@ import {
     renderTodayActivities,
     handleActivityAwareFormSubmit,
     handleActivityListClick,
+    showTimerDisplay,
+    hideTimerDisplay,
+    syncTimerFormState,
+    initializeTimerUI,
     resetActivityInlineEditState
 } from '../public/js/activities/ui-handlers.js';
 import { extractActivityFormData } from '../public/js/activities/form-utils.js';
 import {
     handleAddActivity,
+    handleStartTimer,
+    handleStopTimer,
     handleDeleteActivity,
     handleSaveActivityEdit
 } from '../public/js/activities/handlers.js';
-import { getTodaysActivities } from '../public/js/activities/manager.js';
+import {
+    getTodaysActivities,
+    getRunningActivity,
+    updateRunningActivity
+} from '../public/js/activities/manager.js';
 import { renderActivities } from '../public/js/activities/renderer.js';
+import { showAlert } from '../public/js/modal-manager.js';
 
 describe('activity app integration', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        getRunningActivity.mockReturnValue(null);
+        updateRunningActivity.mockResolvedValue({ success: true });
+        handleStartTimer.mockResolvedValue({ success: true });
+        handleStopTimer.mockResolvedValue({ success: true });
         resetActivityInlineEditState();
         document.body.innerHTML = `
             <div id="activity-toggle-option" class="hidden"></div>
@@ -49,10 +72,25 @@ describe('activity app integration', () => {
             <div id="activity-list"></div>
             <div id="end-time-hint"></div>
             <div id="overlap-warning"></div>
+            <div id="task-form-fields">
+                <div id="time-inputs"></div>
+            </div>
+            <div id="timer-display" class="hidden">
+                <input id="timer-description" />
+                <select id="timer-category"></select>
+                <input id="timer-start-time" type="time" />
+                <div id="timer-elapsed"></div>
+                <button id="timer-stop-btn" type="button">Stop</button>
+            </div>
+            <button id="start-timer-btn" type="button" class="hidden">Start Timer</button>
             <button id="add-task-btn" type="submit">Add Task</button>
             <select id="category-select"></select>
             <form id="task-form">
                 <input name="description" />
+                <select name="category">
+                    <option value="">No category</option>
+                    <option value="work/deep">Deep Work</option>
+                </select>
                 <input type="radio" name="task-type" value="scheduled" checked />
                 <input type="radio" name="task-type" value="activity" />
             </form>
@@ -472,5 +510,310 @@ describe('activity app integration', () => {
             document.getElementById('activity-list'),
             expect.objectContaining({ editingActivityId: 'activity-3' })
         );
+    });
+
+    describe('timer display', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('showTimerDisplay hides form fields and shows timer state', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('timer-description').value).toBe('Timer work');
+            expect(document.getElementById('timer-category').value).toBe('work/deep');
+            expect(document.getElementById('timer-start-time').value).toBe(
+                `${String(new Date('2026-04-09T10:00:00.000Z').getHours()).padStart(2, '0')}:${String(
+                    new Date('2026-04-09T10:00:00.000Z').getMinutes()
+                ).padStart(2, '0')}`
+            );
+            expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:00');
+        });
+
+        test('elapsed counter updates while timer is visible', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            jest.advanceTimersByTime(30000);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:30');
+        });
+
+        test('hideTimerDisplay restores the form and stops elapsed updates', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            hideTimerDisplay();
+            const textAfterHide = document.getElementById('timer-elapsed').textContent;
+            jest.advanceTimersByTime(5000);
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('timer-elapsed').textContent).toBe(textAfterHide);
+        });
+    });
+
+    describe('timer form state', () => {
+        test('shows timer display when activity tab is selected and timer is running', () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            syncTimerFormState();
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
+                false
+            );
+        });
+
+        test('shows start timer button when activity tab is selected and no timer is running', () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue(null);
+
+            syncTimerFormState();
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
+                false
+            );
+        });
+
+        test('keeps timer hidden on non-activity tabs', () => {
+            document.getElementById('scheduled').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            syncTimerFormState();
+
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
+                true
+            );
+        });
+    });
+
+    test('activity form submission returns early when a timer is running', async () => {
+        const form = document.getElementById('task-form');
+        form.querySelector('input[value="scheduled"]').checked = false;
+        form.querySelector('input[value="activity"]').checked = true;
+        getRunningActivity.mockReturnValue({
+            description: 'Running',
+            startDateTime: '2026-04-09T10:00:00.000Z'
+        });
+        const handleTaskSubmitMock = jest.fn();
+
+        await handleActivityAwareFormSubmit(form, {
+            activitiesEnabled: true,
+            resetTaskFormPreviewState: jest.fn(),
+            initializeTaskTypeToggle: jest.fn(),
+            focusTaskDescriptionInput: jest.fn(),
+            handleTaskSubmit: handleTaskSubmitMock
+        });
+
+        expect(handleAddActivity).not.toHaveBeenCalled();
+        expect(handleTaskSubmitMock).not.toHaveBeenCalled();
+    });
+
+    describe('initializeTimerUI', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('start timer button uses form values and refreshes UI on success', async () => {
+            document.getElementById('activity').checked = true;
+            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
+            document.querySelector('#task-form select[name="category"]').value = 'work/deep';
+            handleStartTimer.mockResolvedValue({ success: true });
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).toHaveBeenCalledWith({
+                description: 'Feature work',
+                category: 'work/deep'
+            });
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('re-initializing timer UI does not duplicate start/stop handlers', async () => {
+            document.getElementById('activity').checked = true;
+            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
+            handleStartTimer.mockResolvedValue({ success: true });
+            handleStopTimer.mockResolvedValue({ success: true });
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            initializeTimerUI({ refreshUI });
+
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).toHaveBeenCalledTimes(1);
+            expect(handleStopTimer).toHaveBeenCalledTimes(1);
+        });
+
+        test('stop timer button delegates to handler and refreshes UI', async () => {
+            handleStopTimer.mockResolvedValue({ success: true });
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStopTimer).toHaveBeenCalled();
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('timer field edits persist running activity changes', async () => {
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity
+                .mockResolvedValueOnce({
+                    success: true,
+                    runningActivity: {
+                        description: 'Updated',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    }
+                })
+                .mockResolvedValueOnce({
+                    success: true,
+                    runningActivity: {
+                        description: 'Updated',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    }
+                })
+                .mockResolvedValueOnce({
+                    success: true,
+                    runningActivity: {
+                        description: 'Updated',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T09:30:00.000Z'
+                    }
+                });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = 'Updated';
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+            const categoryInput = document.getElementById('timer-category');
+            categoryInput.innerHTML = '<option value="work/deep">Deep Work</option>';
+            categoryInput.value = 'work/deep';
+            categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+            const startTimeInput = document.getElementById('timer-start-time');
+            startTimeInput.value = '09:30';
+            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            const expectedStartDate = new Date('2026-04-09T10:00:00.000Z');
+            expectedStartDate.setHours(9, 30, 0, 0);
+
+            expect(updateRunningActivity).toHaveBeenCalledWith({ description: 'Updated' });
+            expect(updateRunningActivity).toHaveBeenCalledWith({ category: 'work/deep' });
+            expect(updateRunningActivity).toHaveBeenCalledWith({
+                startDateTime: expectedStartDate.toISOString()
+            });
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:30:00');
+        });
+
+        test('failed timer description edits rollback the visible value and alert', async () => {
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: false,
+                reason: 'Description is required while a timer is running.'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = '';
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(descriptionInput.value).toBe('Running');
+            expect(showAlert).toHaveBeenCalledWith(
+                'Description is required while a timer is running.',
+                'sky'
+            );
+        });
     });
 });

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -124,6 +124,136 @@ describe('activity app integration', () => {
         );
     });
 
+    test('clicking a parent summary legend expands that parent group', async () => {
+        const activities = [{ id: 'activity-1', description: 'Focus' }];
+        getTodaysActivities.mockReturnValue(activities);
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <button data-summary-parent-legend="work" data-summary-parent-key="work" type="button">
+                <span>Work</span>
+            </button>
+        `;
+
+        const handled = await handleActivityListClick(activityList.querySelector('span'), {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        renderTodayActivities(true);
+
+        expect(handled).toBe(true);
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            activities,
+            document.getElementById('activity-list'),
+            expect.objectContaining({ expandedParentGroupKey: 'work' })
+        );
+    });
+
+    test('clicking the same parent summary legend again collapses the expanded group', async () => {
+        const activities = [{ id: 'activity-1', description: 'Focus' }];
+        getTodaysActivities.mockReturnValue(activities);
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <button data-summary-parent-legend="work" data-summary-parent-key="work" type="button">
+                <span>Work</span>
+            </button>
+        `;
+
+        await handleActivityListClick(activityList.querySelector('span'), {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        renderTodayActivities(true);
+
+        await handleActivityListClick(activityList.querySelector('span'), {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        renderTodayActivities(true);
+
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            activities,
+            document.getElementById('activity-list'),
+            expect.objectContaining({ expandedParentGroupKey: null })
+        );
+    });
+
+    test('clicking a different parent summary target swaps the expanded group', async () => {
+        const activities = [{ id: 'activity-1', description: 'Focus' }];
+        getTodaysActivities.mockReturnValue(activities);
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <button data-summary-parent-legend="work" data-summary-parent-key="work" type="button">
+                <span>Work</span>
+            </button>
+            <button data-summary-parent-segment="personal" data-summary-parent-key="personal" type="button">
+                <span>Personal</span>
+            </button>
+        `;
+
+        await handleActivityListClick(
+            activityList.querySelector('[data-summary-parent-legend] span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
+
+        await handleActivityListClick(
+            activityList.querySelector('[data-summary-parent-segment] span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
+
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            activities,
+            document.getElementById('activity-list'),
+            expect.objectContaining({ expandedParentGroupKey: 'personal' })
+        );
+    });
+
+    test('clicking uncategorized summary does nothing and preserves the current expansion', async () => {
+        const activities = [{ id: 'activity-1', description: 'Focus' }];
+        getTodaysActivities.mockReturnValue(activities);
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <button data-summary-parent-legend="work" data-summary-parent-key="work" type="button">
+                <span>Work</span>
+            </button>
+            <button data-summary-parent-legend="uncategorized" data-summary-parent-key="uncategorized" type="button">
+                <span>Uncategorized</span>
+            </button>
+        `;
+
+        await handleActivityListClick(
+            activityList.querySelector('[data-summary-parent-key="work"] span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
+
+        const handled = await handleActivityListClick(
+            activityList.querySelector('[data-summary-parent-key="uncategorized"] span'),
+            {
+                refreshUI: jest.fn(),
+                resetAllConfirmingDeleteFlags: jest.fn()
+            }
+        );
+        renderTodayActivities(true);
+
+        expect(handled).toBe(true);
+        expect(renderActivities).toHaveBeenLastCalledWith(
+            activities,
+            document.getElementById('activity-list'),
+            expect.objectContaining({ expandedParentGroupKey: 'work' })
+        );
+    });
+
     test('does not render today activities when disabled', () => {
         renderTodayActivities(false);
 

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -31,6 +31,9 @@ import {
     renderTodayActivities,
     handleActivityAwareFormSubmit,
     handleActivityListClick,
+    handleActivityListSubmit,
+    handleActivityListKeydown,
+    handleActivityListInput,
     resetActivityInlineEditState
 } from '../public/js/activities/ui-handlers.js';
 import { extractActivityFormData } from '../public/js/activities/form-utils.js';
@@ -289,6 +292,204 @@ describe('activity app integration', () => {
             activityList.querySelector('form')
         );
         expect(refreshUIMock).toHaveBeenCalled();
+    });
+
+    test('submitting inline activity edits delegates the form to the activity edit handler', async () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <input name="duration-hours" value="1" />
+                <input name="duration-minutes" value="15" />
+                <select name="category"><option value="work/deep" selected>Deep Work</option></select>
+                <button class="btn-save-activity-edit" type="submit"><span>Save</span></button>
+            </form>
+        `;
+        const refreshUIMock = jest.fn();
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+
+        Object.defineProperty(submitEvent, 'target', {
+            value: activityList.querySelector('form'),
+            configurable: true
+        });
+
+        const handled = handleActivityListSubmit(submitEvent, {
+            refreshUI: refreshUIMock,
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(handled).toBe(true);
+        expect(handleSaveActivityEdit).toHaveBeenCalledWith(
+            'activity-11',
+            activityList.querySelector('form')
+        );
+        expect(refreshUIMock).toHaveBeenCalled();
+    });
+
+    test('pressing Enter in inline activity edit delegates save to the activity edit handler', async () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <input name="duration-hours" value="1" />
+                <input name="duration-minutes" value="15" />
+                <select name="category"><option value="work/deep" selected>Deep Work</option></select>
+                <button class="btn-save-activity-edit" type="submit"><span>Save</span></button>
+            </form>
+        `;
+        const refreshUIMock = jest.fn();
+        const enterEvent = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            bubbles: true,
+            cancelable: true
+        });
+
+        Object.defineProperty(enterEvent, 'target', {
+            value: activityList.querySelector('input[name="description"]'),
+            configurable: true
+        });
+
+        const handled = handleActivityListKeydown(enterEvent, {
+            refreshUI: refreshUIMock,
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(handled).toBe(true);
+        expect(handleSaveActivityEdit).toHaveBeenCalledWith(
+            'activity-11',
+            activityList.querySelector('form')
+        );
+        expect(refreshUIMock).toHaveBeenCalled();
+    });
+
+    test('non-Enter key in inline activity edit does not trigger save', () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+            </form>
+        `;
+        const keydownEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true
+        });
+
+        Object.defineProperty(keydownEvent, 'target', {
+            value: activityList.querySelector('input[name="description"]'),
+            configurable: true
+        });
+
+        const handled = handleActivityListKeydown(keydownEvent, {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+
+        expect(handled).toBe(false);
+        expect(handleSaveActivityEdit).not.toHaveBeenCalled();
+    });
+
+    test('non-form submit target in activity list is ignored', () => {
+        const activityList = document.getElementById('activity-list');
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+
+        Object.defineProperty(submitEvent, 'target', {
+            value: activityList,
+            configurable: true
+        });
+
+        const handled = handleActivityListSubmit(submitEvent, {
+            refreshUI: jest.fn(),
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+
+        expect(handled).toBe(false);
+        expect(handleSaveActivityEdit).not.toHaveBeenCalled();
+    });
+
+    test('input on inline activity edit updates the end-time hint', () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <div>
+                    <input name="duration-hours" value="1" />
+                    <input name="duration-minutes" value="15" />
+                    <span class="edit-end-time-hint opacity-0"></span>
+                </div>
+            </form>
+        `;
+        const startInput = activityList.querySelector('input[name="start-time"]');
+        const hintElement = activityList.querySelector('.edit-end-time-hint');
+        startInput.value = '10:00';
+        const inputEvent = new Event('input', { bubbles: true });
+
+        Object.defineProperty(inputEvent, 'target', {
+            value: startInput,
+            configurable: true
+        });
+
+        const handled = handleActivityListInput(inputEvent);
+
+        expect(handled).toBe(true);
+        expect(hintElement.textContent).toContain('AM');
+        expect(hintElement.classList.contains('opacity-0')).toBe(false);
+    });
+
+    test('input on inline activity edit clears the end-time hint when preview is invalid', () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <div>
+                    <input name="duration-hours" value="0" />
+                    <input name="duration-minutes" value="0" />
+                    <span class="edit-end-time-hint">▸ 10:00 AM</span>
+                </div>
+            </form>
+        `;
+        const hoursInput = activityList.querySelector('input[name="duration-hours"]');
+        const hintElement = activityList.querySelector('.edit-end-time-hint');
+        const inputEvent = new Event('input', { bubbles: true });
+
+        Object.defineProperty(inputEvent, 'target', {
+            value: hoursInput,
+            configurable: true
+        });
+
+        const handled = handleActivityListInput(inputEvent);
+
+        expect(handled).toBe(true);
+        expect(hintElement.textContent).toBe('');
+        expect(hintElement.classList.contains('opacity-0')).toBe(true);
+    });
+
+    test('input on inline activity edit without a hint element is ignored', () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <input name="duration-hours" value="1" />
+                <input name="duration-minutes" value="15" />
+            </form>
+        `;
+        const inputEvent = new Event('input', { bubbles: true });
+
+        Object.defineProperty(inputEvent, 'target', {
+            value: activityList.querySelector('input[name="duration-hours"]'),
+            configurable: true
+        });
+
+        const handled = handleActivityListInput(inputEvent);
+
+        expect(handled).toBe(false);
     });
 
     test('canceling inline activity edit clears the inline edit state', async () => {

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -527,6 +527,63 @@ describe('activity app integration', () => {
         expect(refreshUIMock).toHaveBeenCalled();
     });
 
+    test('keydown and submit from the same inline activity edit save only once', async () => {
+        let resolveSave;
+        handleSaveActivityEdit.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolveSave = resolve;
+            })
+        );
+
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <input name="description" value="Row description" />
+                <input name="start-time" value="09:00" />
+                <input name="duration-hours" value="1" />
+                <input name="duration-minutes" value="15" />
+                <select name="category"><option value="work/deep" selected>Deep Work</option></select>
+                <button class="btn-save-activity-edit" type="submit"><span>Save</span></button>
+            </form>
+        `;
+        const refreshUIMock = jest.fn();
+        const form = activityList.querySelector('form');
+
+        const enterEvent = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            bubbles: true,
+            cancelable: true
+        });
+        Object.defineProperty(enterEvent, 'target', {
+            value: activityList.querySelector('input[name="duration-minutes"]'),
+            configurable: true
+        });
+
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        Object.defineProperty(submitEvent, 'target', {
+            value: form,
+            configurable: true
+        });
+
+        const keyHandled = handleActivityListKeydown(enterEvent, {
+            refreshUI: refreshUIMock,
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+        const submitHandled = handleActivityListSubmit(submitEvent, {
+            refreshUI: refreshUIMock,
+            resetAllConfirmingDeleteFlags: jest.fn()
+        });
+
+        expect(keyHandled).toBe(true);
+        expect(submitHandled).toBe(true);
+        expect(handleSaveActivityEdit).toHaveBeenCalledTimes(1);
+
+        resolveSave({ success: true });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(refreshUIMock).toHaveBeenCalledTimes(1);
+    });
+
     test('non-Enter key in inline activity edit does not trigger save', () => {
         const activityList = document.getElementById('activity-list');
         activityList.innerHTML = `

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -28,6 +28,12 @@ jest.mock('../public/js/activities/renderer.js', () => ({
     renderActivitySummaryOnly: jest.fn()
 }));
 
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    resolveCategoryKey: jest.fn((key) =>
+        key === 'work/deep' ? { kind: 'category', record: { key, color: '#0ea5e9' } } : null
+    )
+}));
+
 import {
     syncActivitiesUI,
     renderTodayActivities,
@@ -594,6 +600,41 @@ describe('activity app integration', () => {
         expect(handled).toBe(true);
         expect(hintElement.textContent).toContain('AM');
         expect(hintElement.classList.contains('opacity-0')).toBe(false);
+    });
+
+    test('changing inline activity category updates the category color dot', () => {
+        const activityList = document.getElementById('activity-list');
+        activityList.innerHTML = `
+            <form class="activity-inline-edit-form" data-activity-id="activity-11" data-activity-date="2026-04-07">
+                <div class="flex items-center gap-2">
+                    <span class="activity-edit-category-dot" style="background-color: rgb(100, 116, 139);"></span>
+                    <select name="category">
+                        <option value="">No category</option>
+                        <option value="work/deep">Deep Work</option>
+                    </select>
+                </div>
+                <input name="start-time" value="09:00" />
+                <div>
+                    <input name="duration-hours" value="1" />
+                    <input name="duration-minutes" value="15" />
+                    <span class="edit-end-time-hint opacity-0"></span>
+                </div>
+            </form>
+        `;
+        const categorySelect = activityList.querySelector('select[name="category"]');
+        const categoryDot = activityList.querySelector('.activity-edit-category-dot');
+        categorySelect.value = 'work/deep';
+        const inputEvent = new Event('input', { bubbles: true });
+
+        Object.defineProperty(inputEvent, 'target', {
+            value: categorySelect,
+            configurable: true
+        });
+
+        const handled = handleActivityListInput(inputEvent);
+
+        expect(handled).toBe(true);
+        expect(categoryDot.style.backgroundColor).toBe('rgb(14, 165, 233)');
     });
 
     test('input on inline activity edit clears the end-time hint when preview is invalid', () => {

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -12,8 +12,6 @@ jest.mock('../public/js/activities/form-utils.js', () => ({
 
 jest.mock('../public/js/activities/handlers.js', () => ({
     handleAddActivity: jest.fn(() => Promise.resolve({ success: true })),
-    handleStartTimer: jest.fn(() => Promise.resolve({ success: true })),
-    handleStopTimer: jest.fn(() => Promise.resolve({ success: true })),
     handleEditActivity: jest.fn(() => Promise.resolve()),
     handleDeleteActivity: jest.fn(() => Promise.resolve()),
     handleSaveActivityEdit: jest.fn(() => Promise.resolve({ success: true }))
@@ -21,8 +19,7 @@ jest.mock('../public/js/activities/handlers.js', () => ({
 
 jest.mock('../public/js/activities/manager.js', () => ({
     getTodaysActivities: jest.fn(() => []),
-    getRunningActivity: jest.fn(() => null),
-    updateRunningActivity: jest.fn(() => Promise.resolve({ success: true }))
+    getRunningActivity: jest.fn(() => null)
 }));
 
 jest.mock('../public/js/activities/renderer.js', () => ({
@@ -34,35 +31,21 @@ import {
     renderTodayActivities,
     handleActivityAwareFormSubmit,
     handleActivityListClick,
-    showTimerDisplay,
-    hideTimerDisplay,
-    syncTimerFormState,
-    initializeTimerUI,
     resetActivityInlineEditState
 } from '../public/js/activities/ui-handlers.js';
 import { extractActivityFormData } from '../public/js/activities/form-utils.js';
 import {
     handleAddActivity,
-    handleStartTimer,
-    handleStopTimer,
     handleDeleteActivity,
     handleSaveActivityEdit
 } from '../public/js/activities/handlers.js';
-import {
-    getTodaysActivities,
-    getRunningActivity,
-    updateRunningActivity
-} from '../public/js/activities/manager.js';
+import { getTodaysActivities, getRunningActivity } from '../public/js/activities/manager.js';
 import { renderActivities } from '../public/js/activities/renderer.js';
-import { showAlert } from '../public/js/modal-manager.js';
 
 describe('activity app integration', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         getRunningActivity.mockReturnValue(null);
-        updateRunningActivity.mockResolvedValue({ success: true });
-        handleStartTimer.mockResolvedValue({ success: true });
-        handleStopTimer.mockResolvedValue({ success: true });
         resetActivityInlineEditState();
         document.body.innerHTML = `
             <div id="activity-toggle-option" class="hidden"></div>
@@ -512,126 +495,6 @@ describe('activity app integration', () => {
         );
     });
 
-    describe('timer display', () => {
-        beforeEach(() => {
-            jest.useFakeTimers();
-            jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
-        });
-
-        afterEach(() => {
-            jest.useRealTimers();
-        });
-
-        test('showTimerDisplay hides form fields and shows timer state', () => {
-            showTimerDisplay({
-                description: 'Timer work',
-                category: 'work/deep',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
-                true
-            );
-            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
-                false
-            );
-            expect(document.getElementById('timer-description').value).toBe('Timer work');
-            expect(document.getElementById('timer-category').value).toBe('work/deep');
-            expect(document.getElementById('timer-start-time').value).toBe(
-                `${String(new Date('2026-04-09T10:00:00.000Z').getHours()).padStart(2, '0')}:${String(
-                    new Date('2026-04-09T10:00:00.000Z').getMinutes()
-                ).padStart(2, '0')}`
-            );
-            expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:00');
-        });
-
-        test('elapsed counter updates while timer is visible', () => {
-            showTimerDisplay({
-                description: 'Timer work',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            jest.advanceTimersByTime(30000);
-
-            expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:30');
-        });
-
-        test('hideTimerDisplay restores the form and stops elapsed updates', () => {
-            showTimerDisplay({
-                description: 'Timer work',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            hideTimerDisplay();
-            const textAfterHide = document.getElementById('timer-elapsed').textContent;
-            jest.advanceTimersByTime(5000);
-
-            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
-                false
-            );
-            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
-                true
-            );
-            expect(document.getElementById('timer-elapsed').textContent).toBe(textAfterHide);
-        });
-    });
-
-    describe('timer form state', () => {
-        test('shows timer display when activity tab is selected and timer is running', () => {
-            document.getElementById('activity').checked = true;
-            getRunningActivity.mockReturnValue({
-                description: 'Running',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            syncTimerFormState();
-
-            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
-                true
-            );
-            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
-                false
-            );
-            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
-                false
-            );
-        });
-
-        test('shows start timer button when activity tab is selected and no timer is running', () => {
-            document.getElementById('activity').checked = true;
-            getRunningActivity.mockReturnValue(null);
-
-            syncTimerFormState();
-
-            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
-                false
-            );
-            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
-                true
-            );
-            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
-                false
-            );
-        });
-
-        test('keeps timer hidden on non-activity tabs', () => {
-            document.getElementById('scheduled').checked = true;
-            getRunningActivity.mockReturnValue({
-                description: 'Running',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            syncTimerFormState();
-
-            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
-                true
-            );
-            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
-                true
-            );
-        });
-    });
-
     test('activity form submission returns early when a timer is running', async () => {
         const form = document.getElementById('task-form');
         form.querySelector('input[value="scheduled"]').checked = false;
@@ -652,168 +515,5 @@ describe('activity app integration', () => {
 
         expect(handleAddActivity).not.toHaveBeenCalled();
         expect(handleTaskSubmitMock).not.toHaveBeenCalled();
-    });
-
-    describe('initializeTimerUI', () => {
-        beforeEach(() => {
-            jest.useFakeTimers();
-            jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
-        });
-
-        afterEach(() => {
-            jest.useRealTimers();
-        });
-
-        test('start timer button uses form values and refreshes UI on success', async () => {
-            document.getElementById('activity').checked = true;
-            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
-            document.querySelector('#task-form select[name="category"]').value = 'work/deep';
-            handleStartTimer.mockResolvedValue({ success: true });
-            const refreshUI = jest.fn();
-
-            initializeTimerUI({ refreshUI });
-            document
-                .getElementById('start-timer-btn')
-                .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
-
-            expect(handleStartTimer).toHaveBeenCalledWith({
-                description: 'Feature work',
-                category: 'work/deep'
-            });
-            expect(refreshUI).toHaveBeenCalled();
-        });
-
-        test('re-initializing timer UI does not duplicate start/stop handlers', async () => {
-            document.getElementById('activity').checked = true;
-            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
-            handleStartTimer.mockResolvedValue({ success: true });
-            handleStopTimer.mockResolvedValue({ success: true });
-            const refreshUI = jest.fn();
-
-            initializeTimerUI({ refreshUI });
-            initializeTimerUI({ refreshUI });
-
-            document
-                .getElementById('start-timer-btn')
-                .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
-
-            document
-                .getElementById('timer-stop-btn')
-                .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
-
-            expect(handleStartTimer).toHaveBeenCalledTimes(1);
-            expect(handleStopTimer).toHaveBeenCalledTimes(1);
-        });
-
-        test('stop timer button delegates to handler and refreshes UI', async () => {
-            handleStopTimer.mockResolvedValue({ success: true });
-            const refreshUI = jest.fn();
-
-            initializeTimerUI({ refreshUI });
-            document
-                .getElementById('timer-stop-btn')
-                .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
-
-            expect(handleStopTimer).toHaveBeenCalled();
-            expect(refreshUI).toHaveBeenCalled();
-        });
-
-        test('timer field edits persist running activity changes', async () => {
-            getRunningActivity.mockReturnValue({
-                description: 'Running',
-                category: 'work/deep',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-            updateRunningActivity
-                .mockResolvedValueOnce({
-                    success: true,
-                    runningActivity: {
-                        description: 'Updated',
-                        category: 'work/deep',
-                        startDateTime: '2026-04-09T10:00:00.000Z'
-                    }
-                })
-                .mockResolvedValueOnce({
-                    success: true,
-                    runningActivity: {
-                        description: 'Updated',
-                        category: 'work/deep',
-                        startDateTime: '2026-04-09T10:00:00.000Z'
-                    }
-                })
-                .mockResolvedValueOnce({
-                    success: true,
-                    runningActivity: {
-                        description: 'Updated',
-                        category: 'work/deep',
-                        startDateTime: '2026-04-09T09:30:00.000Z'
-                    }
-                });
-
-            initializeTimerUI({ refreshUI: jest.fn() });
-            showTimerDisplay({
-                description: 'Running',
-                category: 'work/deep',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            const descriptionInput = document.getElementById('timer-description');
-            descriptionInput.value = 'Updated';
-            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
-
-            const categoryInput = document.getElementById('timer-category');
-            categoryInput.innerHTML = '<option value="work/deep">Deep Work</option>';
-            categoryInput.value = 'work/deep';
-            categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
-
-            const startTimeInput = document.getElementById('timer-start-time');
-            startTimeInput.value = '09:30';
-            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
-
-            const expectedStartDate = new Date('2026-04-09T10:00:00.000Z');
-            expectedStartDate.setHours(9, 30, 0, 0);
-
-            expect(updateRunningActivity).toHaveBeenCalledWith({ description: 'Updated' });
-            expect(updateRunningActivity).toHaveBeenCalledWith({ category: 'work/deep' });
-            expect(updateRunningActivity).toHaveBeenCalledWith({
-                startDateTime: expectedStartDate.toISOString()
-            });
-            expect(document.getElementById('timer-elapsed').textContent).toBe('00:30:00');
-        });
-
-        test('failed timer description edits rollback the visible value and alert', async () => {
-            getRunningActivity.mockReturnValue({
-                description: 'Running',
-                category: 'work/deep',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-            updateRunningActivity.mockResolvedValueOnce({
-                success: false,
-                reason: 'Description is required while a timer is running.'
-            });
-
-            initializeTimerUI({ refreshUI: jest.fn() });
-            showTimerDisplay({
-                description: 'Running',
-                category: 'work/deep',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            const descriptionInput = document.getElementById('timer-description');
-            descriptionInput.value = '';
-            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
-
-            expect(descriptionInput.value).toBe('Running');
-            expect(showAlert).toHaveBeenCalledWith(
-                'Description is required while a timer is running.',
-                'sky'
-            );
-        });
     });
 });

--- a/__tests__/activity-app-integration.test.js
+++ b/__tests__/activity-app-integration.test.js
@@ -19,11 +19,13 @@ jest.mock('../public/js/activities/handlers.js', () => ({
 
 jest.mock('../public/js/activities/manager.js', () => ({
     getTodaysActivities: jest.fn(() => []),
-    getRunningActivity: jest.fn(() => null)
+    getRunningActivity: jest.fn(() => null),
+    getLiveTodayActivitySummary: jest.fn(() => null)
 }));
 
 jest.mock('../public/js/activities/renderer.js', () => ({
-    renderActivities: jest.fn()
+    renderActivities: jest.fn(),
+    renderActivitySummaryOnly: jest.fn()
 }));
 
 import {
@@ -42,13 +44,18 @@ import {
     handleDeleteActivity,
     handleSaveActivityEdit
 } from '../public/js/activities/handlers.js';
-import { getTodaysActivities, getRunningActivity } from '../public/js/activities/manager.js';
+import {
+    getTodaysActivities,
+    getRunningActivity,
+    getLiveTodayActivitySummary
+} from '../public/js/activities/manager.js';
 import { renderActivities } from '../public/js/activities/renderer.js';
 
 describe('activity app integration', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         getRunningActivity.mockReturnValue(null);
+        getLiveTodayActivitySummary.mockReturnValue(null);
         resetActivityInlineEditState();
         document.body.innerHTML = `
             <div id="activity-toggle-option" class="hidden"></div>
@@ -120,7 +127,25 @@ describe('activity app integration', () => {
         expect(renderActivities).toHaveBeenCalledWith(
             activities,
             document.getElementById('activity-list'),
-            expect.objectContaining({ editingActivityId: null })
+            expect.objectContaining({
+                editingActivityId: null,
+                summaryActivities: activities
+            })
+        );
+    });
+
+    test('renders the summary with the live running activity included', () => {
+        const activities = [{ id: 'activity-1', description: 'Focus' }];
+        const runningSummary = { id: 'running-activity-summary', description: 'Running' };
+        getTodaysActivities.mockReturnValue(activities);
+        getLiveTodayActivitySummary.mockReturnValue(runningSummary);
+
+        renderTodayActivities(true);
+
+        expect(renderActivities).toHaveBeenCalledWith(
+            activities,
+            document.getElementById('activity-list'),
+            expect.objectContaining({ summaryActivities: [...activities, runningSummary] })
         );
     });
 

--- a/__tests__/activity-app-wiring.test.js
+++ b/__tests__/activity-app-wiring.test.js
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/activities/ui-handlers.js', () => ({
+    handleActivityAwareFormSubmit: jest.fn(() => Promise.resolve()),
+    handleActivityListClick: jest.fn(() => false),
+    handleActivityListSubmit: jest.fn(() => false),
+    handleActivityListKeydown: jest.fn(() => false),
+    handleActivityListInput: jest.fn(() => false),
+    refreshTodayActivitySummary: jest.fn()
+}));
+
+jest.mock('../public/js/activities/timer-ui.js', () => ({
+    initializeTimerUI: jest.fn(),
+    syncTimerFormState: jest.fn()
+}));
+
+jest.mock('../public/js/activities/manager.js', () => ({
+    getRunningActivity: jest.fn(() => null)
+}));
+
+import {
+    createActivityAppCallbacks,
+    initializeActivityUi,
+    syncRestoredRunningTimer
+} from '../public/js/activities/app-wiring.js';
+import {
+    handleActivityAwareFormSubmit,
+    handleActivityListClick,
+    handleActivityListSubmit,
+    handleActivityListKeydown,
+    handleActivityListInput,
+    refreshTodayActivitySummary
+} from '../public/js/activities/ui-handlers.js';
+import { initializeTimerUI, syncTimerFormState } from '../public/js/activities/timer-ui.js';
+import { getRunningActivity } from '../public/js/activities/manager.js';
+
+describe('activity app wiring', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = `
+            <form id="task-form"></form>
+            <div id="activity-list"></div>
+            <input type="radio" id="activity" name="task-type" value="activity">
+        `;
+    });
+
+    test('creates activity-aware app callbacks for submit and global click', async () => {
+        const refreshUI = jest.fn();
+        const resetAllConfirmingDeleteFlags = jest.fn();
+        const handleTaskSubmit = jest.fn();
+        const focusTaskDescriptionInput = jest.fn();
+        const resetTaskFormPreviewState = jest.fn();
+        const initializeTaskTypeToggle = jest.fn();
+
+        const callbacks = createActivityAppCallbacks({
+            getActivitiesEnabled: () => true,
+            refreshUI,
+            resetAllConfirmingDeleteFlags,
+            handleTaskSubmit,
+            focusTaskDescriptionInput,
+            resetTaskFormPreviewState,
+            initializeTaskTypeToggle
+        });
+
+        const form = document.getElementById('task-form');
+        await callbacks.onTaskFormSubmit(form);
+        callbacks.onGlobalClick({ target: document.body });
+
+        expect(handleActivityAwareFormSubmit).toHaveBeenCalledWith(
+            form,
+            expect.objectContaining({
+                activitiesEnabled: true,
+                handleTaskSubmit,
+                focusTaskDescriptionInput,
+                resetTaskFormPreviewState,
+                initializeTaskTypeToggle
+            })
+        );
+        expect(handleActivityListClick).toHaveBeenCalledWith(document.body, {
+            refreshUI,
+            resetAllConfirmingDeleteFlags
+        });
+    });
+
+    test('initializes timer ui and delegates activity list events', () => {
+        const refreshUI = jest.fn();
+        const refreshTaskDisplays = jest.fn();
+        const signal = new AbortController().signal;
+
+        initializeActivityUi({
+            signal,
+            refreshUI,
+            refreshTaskDisplays,
+            getActivitiesEnabled: () => true
+        });
+
+        expect(initializeTimerUI).toHaveBeenCalledWith({
+            refreshUI: refreshTaskDisplays,
+            refreshActivitySummary: expect.any(Function)
+        });
+
+        const activityList = document.getElementById('activity-list');
+        activityList.dispatchEvent(new Event('submit', { bubbles: true }));
+        activityList.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        activityList.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(handleActivityListSubmit).toHaveBeenCalled();
+        expect(handleActivityListKeydown).toHaveBeenCalled();
+        expect(handleActivityListInput).toHaveBeenCalled();
+
+        const refreshSummary = initializeTimerUI.mock.calls[0][0].refreshActivitySummary;
+        refreshSummary();
+        expect(refreshTodayActivitySummary).toHaveBeenCalledWith(true);
+    });
+
+    test('restores activity mode before syncing timer ui when a running timer exists', () => {
+        const activityRadio = document.getElementById('activity');
+        const dispatchSpy = jest.spyOn(activityRadio, 'dispatchEvent');
+        getRunningActivity.mockReturnValueOnce({
+            description: 'Restored timer',
+            startDateTime: '2026-04-21T09:00:00.000Z'
+        });
+
+        syncRestoredRunningTimer(true);
+
+        expect(activityRadio.checked).toBe(true);
+        expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Event));
+        expect(syncTimerFormState).toHaveBeenCalled();
+    });
+
+    test('only syncs timer ui when activities are enabled but no timer is running', () => {
+        syncRestoredRunningTimer(true);
+
+        expect(syncTimerFormState).toHaveBeenCalled();
+    });
+
+    test('does nothing when activities are disabled', () => {
+        syncRestoredRunningTimer(false);
+
+        expect(syncTimerFormState).not.toHaveBeenCalled();
+        expect(getRunningActivity).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/activity-form-layout.test.js
+++ b/__tests__/activity-form-layout.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+describe('activity form layout', () => {
+    test('activity layout keeps the production shared row and uses an explicit activity-only action group', () => {
+        const indexHtml = fs.readFileSync(path.join(process.cwd(), 'public', 'index.html'), 'utf8');
+        const customCss = fs.readFileSync(
+            path.join(process.cwd(), 'public', 'css', 'custom.css'),
+            'utf8'
+        );
+
+        expect(indexHtml).toContain('id="task-form-main-row"');
+        expect(indexHtml).not.toContain('id="task-form-actions-row"');
+        expect(indexHtml).toContain('id="activity-action-group"');
+        expect(customCss).toContain('#activity-action-group');
+        expect(customCss).toContain('display: contents;');
+        expect(customCss).toContain('#task-form.task-form--activity #task-form-main-row');
+        expect(customCss).toContain('flex-direction: column;');
+        expect(customCss).toContain('#task-form.task-form--activity #activity-action-group');
+        expect(customCss).toContain('#task-form.task-form--activity #time-inputs');
+        expect(customCss).toContain('grid-template-columns: minmax(8.5rem, 1fr) auto;');
+        expect(customCss).toContain("#task-form.task-form--activity input[name='duration-hours']");
+        expect(customCss).toContain(
+            "#task-form.task-form--activity input[name='duration-minutes']"
+        );
+        expect(customCss).toContain('width: 4.5rem;');
+        expect(customCss).toContain('@media (min-width: 640px)');
+        expect(customCss).toContain('#task-form.task-form--activity #activity-action-group');
+        expect(customCss).toContain('justify-content: flex-end;');
+        expect(customCss).toContain('flex-direction: row;');
+        expect(customCss).not.toContain('grid-template-columns: minmax(0, 1fr) auto auto;');
+    });
+});

--- a/__tests__/activity-form-layout.test.js
+++ b/__tests__/activity-form-layout.test.js
@@ -35,4 +35,11 @@ describe('activity form layout', () => {
         expect(customCss).toContain('flex-direction: row;');
         expect(customCss).not.toContain('grid-template-columns: minmax(0, 1fr) auto auto;');
     });
+
+    test('timer display actions stack on mobile before switching back to an inline row', () => {
+        const indexHtml = fs.readFileSync(path.join(process.cwd(), 'public', 'index.html'), 'utf8');
+
+        expect(indexHtml).toContain('id="timer-action-group"');
+        expect(indexHtml).toContain('class="flex flex-col gap-3 sm:flex-row sm:justify-end"');
+    });
 });

--- a/__tests__/activity-form-layout.test.js
+++ b/__tests__/activity-form-layout.test.js
@@ -13,6 +13,7 @@ describe('activity form layout', () => {
             'utf8'
         );
 
+        expect(indexHtml).toContain('id="task-form-fields"');
         expect(indexHtml).toContain('id="task-form-main-row"');
         expect(indexHtml).not.toContain('id="task-form-actions-row"');
         expect(indexHtml).toContain('id="activity-action-group"');

--- a/__tests__/activity-handlers.test.js
+++ b/__tests__/activity-handlers.test.js
@@ -6,9 +6,8 @@ jest.mock('../public/js/activities/manager.js', () => ({
     addActivity: jest.fn(),
     editActivity: jest.fn(),
     removeActivity: jest.fn(),
-    startTimer: jest.fn(),
-    stopTimer: jest.fn(),
-    getRunningActivity: jest.fn()
+    startTimerReplacingCurrent: jest.fn(),
+    stopTimer: jest.fn()
 }));
 
 jest.mock('../public/js/app-coordinator.js', () => ({
@@ -38,9 +37,8 @@ import {
     addActivity,
     editActivity,
     removeActivity,
-    startTimer,
-    stopTimer,
-    getRunningActivity
+    startTimerReplacingCurrent,
+    stopTimer
 } from '../public/js/activities/manager.js';
 import {
     onActivityCreated,
@@ -245,14 +243,14 @@ describe('activity handlers', () => {
     });
 
     test('handleStartTimer starts a timer and shows a toast', async () => {
-        getRunningActivity.mockReturnValue(null);
-        startTimer.mockResolvedValue({
+        startTimerReplacingCurrent.mockResolvedValue({
             success: true,
             runningActivity: {
                 description: 'Focus block',
                 category: 'work/deep',
                 startDateTime: '2026-04-09T10:00:00.000Z'
-            }
+            },
+            stoppedActivity: null
         });
 
         const result = await handleStartTimer({
@@ -260,7 +258,7 @@ describe('activity handlers', () => {
             category: 'work/deep'
         });
 
-        expect(startTimer).toHaveBeenCalledWith({
+        expect(startTimerReplacingCurrent).toHaveBeenCalledWith({
             description: 'Focus block',
             category: 'work/deep'
         });
@@ -270,16 +268,9 @@ describe('activity handlers', () => {
     });
 
     test('handleStartTimer auto-stops an existing timer before starting a new one', async () => {
-        getRunningActivity.mockReturnValueOnce({
-            description: 'Current timer',
-            startDateTime: '2026-04-09T09:30:00.000Z'
-        });
-        stopTimer.mockResolvedValueOnce({
+        startTimerReplacingCurrent.mockResolvedValueOnce({
             success: true,
-            activity: { id: 'activity-1', description: 'Current timer', duration: 30 }
-        });
-        startTimer.mockResolvedValueOnce({
-            success: true,
+            stoppedActivity: { id: 'activity-1', description: 'Current timer', duration: 30 },
             runningActivity: {
                 description: 'Next timer',
                 startDateTime: '2026-04-09T10:00:00.000Z'
@@ -288,20 +279,18 @@ describe('activity handlers', () => {
 
         const result = await handleStartTimer({ description: 'Next timer', category: null });
 
-        expect(stopTimer).toHaveBeenCalled();
         expect(onActivityCreated).toHaveBeenCalledWith({
             activity: { id: 'activity-1', description: 'Current timer', duration: 30 }
         });
-        expect(startTimer).toHaveBeenCalledWith({ description: 'Next timer', category: null });
+        expect(startTimerReplacingCurrent).toHaveBeenCalledWith({
+            description: 'Next timer',
+            category: null
+        });
         expect(result.success).toBe(true);
     });
 
     test('handleStartTimer stops when auto-stop fails', async () => {
-        getRunningActivity.mockReturnValueOnce({
-            description: 'Current timer',
-            startDateTime: '2026-04-09T09:30:00.000Z'
-        });
-        stopTimer.mockResolvedValueOnce({
+        startTimerReplacingCurrent.mockResolvedValueOnce({
             success: false,
             reason: 'Could not stop timer.'
         });
@@ -312,7 +301,26 @@ describe('activity handlers', () => {
             success: false,
             reason: 'Could not stop timer.'
         });
-        expect(startTimer).not.toHaveBeenCalled();
+        expect(startTimerReplacingCurrent).toHaveBeenCalledWith({ description: 'Next timer' });
+    });
+
+    test('handleStartTimer still emits the stopped activity when replacement start fails', async () => {
+        startTimerReplacingCurrent.mockResolvedValueOnce({
+            success: false,
+            reason: 'Description is required to start a timer.',
+            stoppedActivity: { id: 'activity-9', description: 'Stopped timer', duration: 15 }
+        });
+
+        const result = await handleStartTimer({ description: '' });
+
+        expect(result).toEqual({
+            success: false,
+            reason: 'Description is required to start a timer.'
+        });
+        expect(onActivityCreated).toHaveBeenCalledWith({
+            activity: { id: 'activity-9', description: 'Stopped timer', duration: 15 }
+        });
+        expect(showAlert).toHaveBeenCalledWith('Description is required to start a timer.', 'sky');
     });
 
     test('handleStopTimer emits coordinator + toast on success', async () => {

--- a/__tests__/activity-handlers.test.js
+++ b/__tests__/activity-handlers.test.js
@@ -24,6 +24,10 @@ jest.mock('../public/js/toast-manager.js', () => ({
     showToast: jest.fn()
 }));
 
+jest.mock('../public/js/tasks/manager.js', () => ({
+    consumeUnscheduledTask: jest.fn(() => ({ success: true }))
+}));
+
 import {
     handleAddActivity,
     handleEditActivity,
@@ -47,6 +51,7 @@ import {
 } from '../public/js/app-coordinator.js';
 import { showAlert } from '../public/js/modal-manager.js';
 import { showToast } from '../public/js/toast-manager.js';
+import { consumeUnscheduledTask } from '../public/js/tasks/manager.js';
 
 describe('activity handlers', () => {
     beforeEach(() => {
@@ -270,7 +275,12 @@ describe('activity handlers', () => {
     test('handleStartTimer auto-stops an existing timer before starting a new one', async () => {
         startTimerReplacingCurrent.mockResolvedValueOnce({
             success: true,
-            stoppedActivity: { id: 'activity-1', description: 'Current timer', duration: 30 },
+            stoppedActivity: {
+                id: 'activity-1',
+                description: 'Current timer',
+                duration: 30,
+                sourceTaskId: 'unsched-7'
+            },
             runningActivity: {
                 description: 'Next timer',
                 startDateTime: '2026-04-09T10:00:00.000Z'
@@ -280,12 +290,18 @@ describe('activity handlers', () => {
         const result = await handleStartTimer({ description: 'Next timer', category: null });
 
         expect(onActivityCreated).toHaveBeenCalledWith({
-            activity: { id: 'activity-1', description: 'Current timer', duration: 30 }
+            activity: {
+                id: 'activity-1',
+                description: 'Current timer',
+                duration: 30,
+                sourceTaskId: 'unsched-7'
+            }
         });
         expect(startTimerReplacingCurrent).toHaveBeenCalledWith({
             description: 'Next timer',
             category: null
         });
+        expect(consumeUnscheduledTask).toHaveBeenCalledWith('unsched-7');
         expect(result.success).toBe(true);
     });
 
@@ -308,7 +324,12 @@ describe('activity handlers', () => {
         startTimerReplacingCurrent.mockResolvedValueOnce({
             success: false,
             reason: 'Description is required to start a timer.',
-            stoppedActivity: { id: 'activity-9', description: 'Stopped timer', duration: 15 }
+            stoppedActivity: {
+                id: 'activity-9',
+                description: 'Stopped timer',
+                duration: 15,
+                sourceTaskId: 'unsched-9'
+            }
         });
 
         const result = await handleStartTimer({ description: '' });
@@ -318,15 +339,25 @@ describe('activity handlers', () => {
             reason: 'Description is required to start a timer.'
         });
         expect(onActivityCreated).toHaveBeenCalledWith({
-            activity: { id: 'activity-9', description: 'Stopped timer', duration: 15 }
+            activity: {
+                id: 'activity-9',
+                description: 'Stopped timer',
+                duration: 15,
+                sourceTaskId: 'unsched-9'
+            }
         });
+        expect(consumeUnscheduledTask).toHaveBeenCalledWith('unsched-9');
         expect(showAlert).toHaveBeenCalledWith('Description is required to start a timer.', 'sky');
     });
 
     test('handleStopTimer emits coordinator + toast on success', async () => {
         stopTimer.mockResolvedValueOnce({
             success: true,
-            activity: { id: 'activity-stop-1', description: 'Stopped timer' }
+            activity: {
+                id: 'activity-stop-1',
+                description: 'Stopped timer',
+                sourceTaskId: 'unsched-88'
+            }
         });
 
         const result = await handleStopTimer();
@@ -334,8 +365,13 @@ describe('activity handlers', () => {
         expect(stopTimer).toHaveBeenCalled();
         expect(result.success).toBe(true);
         expect(onActivityCreated).toHaveBeenCalledWith({
-            activity: { id: 'activity-stop-1', description: 'Stopped timer' }
+            activity: {
+                id: 'activity-stop-1',
+                description: 'Stopped timer',
+                sourceTaskId: 'unsched-88'
+            }
         });
+        expect(consumeUnscheduledTask).toHaveBeenCalledWith('unsched-88');
         expect(showToast).toHaveBeenCalledWith('Timer stopped.', { theme: 'sky' });
     });
 

--- a/__tests__/activity-handlers.test.js
+++ b/__tests__/activity-handlers.test.js
@@ -5,7 +5,10 @@
 jest.mock('../public/js/activities/manager.js', () => ({
     addActivity: jest.fn(),
     editActivity: jest.fn(),
-    removeActivity: jest.fn()
+    removeActivity: jest.fn(),
+    startTimer: jest.fn(),
+    stopTimer: jest.fn(),
+    getRunningActivity: jest.fn()
 }));
 
 jest.mock('../public/js/app-coordinator.js', () => ({
@@ -27,9 +30,18 @@ import {
     handleEditActivity,
     handleDeleteActivity,
     handleSaveActivityEdit,
+    handleStartTimer,
+    handleStopTimer,
     createActivityCallbacks
 } from '../public/js/activities/handlers.js';
-import { addActivity, editActivity, removeActivity } from '../public/js/activities/manager.js';
+import {
+    addActivity,
+    editActivity,
+    removeActivity,
+    startTimer,
+    stopTimer,
+    getRunningActivity
+} from '../public/js/activities/manager.js';
 import {
     onActivityCreated,
     onActivityEdited,
@@ -230,5 +242,107 @@ describe('activity handlers', () => {
             onDeleteActivity: handleDeleteActivity,
             onSaveActivityEdit: handleSaveActivityEdit
         });
+    });
+
+    test('handleStartTimer starts a timer and shows a toast', async () => {
+        getRunningActivity.mockReturnValue(null);
+        startTimer.mockResolvedValue({
+            success: true,
+            runningActivity: {
+                description: 'Focus block',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            }
+        });
+
+        const result = await handleStartTimer({
+            description: 'Focus block',
+            category: 'work/deep'
+        });
+
+        expect(startTimer).toHaveBeenCalledWith({
+            description: 'Focus block',
+            category: 'work/deep'
+        });
+        expect(result.success).toBe(true);
+        expect(showToast).toHaveBeenCalledWith('Timer started.', { theme: 'sky' });
+        expect(onActivityCreated).not.toHaveBeenCalled();
+    });
+
+    test('handleStartTimer auto-stops an existing timer before starting a new one', async () => {
+        getRunningActivity.mockReturnValueOnce({
+            description: 'Current timer',
+            startDateTime: '2026-04-09T09:30:00.000Z'
+        });
+        stopTimer.mockResolvedValueOnce({
+            success: true,
+            activity: { id: 'activity-1', description: 'Current timer', duration: 30 }
+        });
+        startTimer.mockResolvedValueOnce({
+            success: true,
+            runningActivity: {
+                description: 'Next timer',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            }
+        });
+
+        const result = await handleStartTimer({ description: 'Next timer', category: null });
+
+        expect(stopTimer).toHaveBeenCalled();
+        expect(onActivityCreated).toHaveBeenCalledWith({
+            activity: { id: 'activity-1', description: 'Current timer', duration: 30 }
+        });
+        expect(startTimer).toHaveBeenCalledWith({ description: 'Next timer', category: null });
+        expect(result.success).toBe(true);
+    });
+
+    test('handleStartTimer stops when auto-stop fails', async () => {
+        getRunningActivity.mockReturnValueOnce({
+            description: 'Current timer',
+            startDateTime: '2026-04-09T09:30:00.000Z'
+        });
+        stopTimer.mockResolvedValueOnce({
+            success: false,
+            reason: 'Could not stop timer.'
+        });
+
+        const result = await handleStartTimer({ description: 'Next timer' });
+
+        expect(result).toEqual({
+            success: false,
+            reason: 'Could not stop timer.'
+        });
+        expect(startTimer).not.toHaveBeenCalled();
+    });
+
+    test('handleStopTimer emits coordinator + toast on success', async () => {
+        stopTimer.mockResolvedValueOnce({
+            success: true,
+            activity: { id: 'activity-stop-1', description: 'Stopped timer' }
+        });
+
+        const result = await handleStopTimer();
+
+        expect(stopTimer).toHaveBeenCalled();
+        expect(result.success).toBe(true);
+        expect(onActivityCreated).toHaveBeenCalledWith({
+            activity: { id: 'activity-stop-1', description: 'Stopped timer' }
+        });
+        expect(showToast).toHaveBeenCalledWith('Timer stopped.', { theme: 'sky' });
+    });
+
+    test('handleStopTimer shows alert on stop failure', async () => {
+        stopTimer.mockResolvedValueOnce({
+            success: false,
+            reason: 'No timer is currently running.'
+        });
+
+        const result = await handleStopTimer();
+
+        expect(result).toEqual({
+            success: false,
+            reason: 'No timer is currently running.'
+        });
+        expect(showAlert).toHaveBeenCalledWith('No timer is currently running.', 'sky');
     });
 });

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -5,7 +5,9 @@
 jest.mock('../public/js/storage.js', () => ({
     putActivity: jest.fn(() => Promise.resolve()),
     loadActivities: jest.fn(() => Promise.resolve([])),
-    deleteActivity: jest.fn(() => Promise.resolve())
+    deleteActivity: jest.fn(() => Promise.resolve()),
+    putConfig: jest.fn(() => Promise.resolve()),
+    deleteConfig: jest.fn(() => Promise.resolve())
 }));
 
 import * as activityManager from '../public/js/activities/manager.js';
@@ -14,13 +16,15 @@ import {
     getActivityState,
     getActivityById,
     getTodaysActivities,
+    getLiveTodayActivitySummary,
     getSuggestedActivityStartTime,
     loadActivitiesState,
     removeActivity,
     editActivity,
     resetActivityState,
     updateActivityState,
-    createActivityFromTask
+    createActivityFromTask,
+    startTimer
 } from '../public/js/activities/manager.js';
 import { putActivity, loadActivities, deleteActivity } from '../public/js/storage.js';
 import { extractTimeFromDateTime } from '../public/js/utils.js';
@@ -289,6 +293,42 @@ describe('activity manager', () => {
             ]);
 
             expect(getSuggestedActivityStartTime()).toBeNull();
+        });
+    });
+
+    describe('getLiveTodayActivitySummary', () => {
+        test('returns a live summary activity for a running timer on the current day', async () => {
+            await startTimer({
+                description: 'Running',
+                category: 'work/deep'
+            });
+            await activityManager.updateRunningActivity({
+                startDateTime: '2026-04-15T09:00:00.000Z'
+            });
+
+            const summary = getLiveTodayActivitySummary(new Date('2026-04-15T09:17:00.000Z'));
+
+            expect(summary).toEqual(
+                expect.objectContaining({
+                    id: 'running-activity-summary',
+                    description: 'Running',
+                    category: 'work/deep',
+                    duration: 17,
+                    endDateTime: '2026-04-15T09:17:00.000Z'
+                })
+            );
+        });
+
+        test('returns null when the running timer is not from today', async () => {
+            await startTimer({
+                description: 'Running',
+                category: 'work/deep'
+            });
+            await activityManager.updateRunningActivity({
+                startDateTime: '2026-04-14T12:00:00.000Z'
+            });
+
+            expect(getLiveTodayActivitySummary(new Date('2026-04-15T12:15:00.000Z'))).toBeNull();
         });
     });
 

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -66,7 +66,7 @@ describe('activity manager', () => {
             expect(putActivity).not.toHaveBeenCalled();
         });
 
-        test('rejects activity with zero duration', async () => {
+        test('rounds manual zero-duration activity payloads up to one minute', async () => {
             const result = await addActivity({
                 description: 'Test',
                 startDateTime: '2026-04-07T09:00:00.000Z',
@@ -76,11 +76,12 @@ describe('activity manager', () => {
                 sourceTaskId: null
             });
 
-            expect(result.success).toBe(false);
-            expect(result.reason).toMatch(/duration/i);
+            expect(result.success).toBe(true);
+            expect(result.activity.duration).toBe(1);
+            expect(result.activity.endDateTime).toBe('2026-04-07T09:01:00.000Z');
         });
 
-        test('allows activity with zero duration when source is timer', async () => {
+        test('rounds sub-minute completed activities up to one minute at the shared addActivity seam', async () => {
             const result = await addActivity({
                 description: 'Instant stop',
                 startDateTime: '2026-04-07T09:00:00.000Z',
@@ -91,8 +92,15 @@ describe('activity manager', () => {
             });
 
             expect(result.success).toBe(true);
-            expect(result.activity.duration).toBe(0);
-            expect(putActivity).toHaveBeenCalledWith(expect.objectContaining({ source: 'timer' }));
+            expect(result.activity.duration).toBe(1);
+            expect(result.activity.endDateTime).toBe('2026-04-07T09:01:00.000Z');
+            expect(putActivity).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    source: 'timer',
+                    duration: 1,
+                    endDateTime: '2026-04-07T09:01:00.000Z'
+                })
+            );
         });
 
         test('rejects activity with missing times', async () => {

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -184,7 +184,7 @@ describe('activity manager', () => {
             jest.useRealTimers();
         });
 
-        test('returns only activities from today sorted by start time', async () => {
+        test('returns only activities from today in reverse chronological end-time order', async () => {
             await addActivity({
                 description: 'Yesterday',
                 startDateTime: '2026-04-06T09:00:00.000Z',
@@ -213,8 +213,35 @@ describe('activity manager', () => {
             const todays = getTodaysActivities();
 
             expect(todays).toHaveLength(2);
-            expect(todays[0].description).toBe('Today earlier');
-            expect(todays[1].description).toBe('Today later');
+            expect(todays[0].description).toBe('Today later');
+            expect(todays[1].description).toBe('Today earlier');
+        });
+
+        test('suggested activity start time uses the latest end time even when list order is reversed', () => {
+            updateActivityState([
+                {
+                    id: 'activity-1',
+                    description: 'Earlier',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 45,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Latest end',
+                    startDateTime: '2026-04-07T09:30:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 60,
+                    source: 'auto',
+                    sourceTaskId: 'sched-1'
+                }
+            ]);
+
+            expect(getSuggestedActivityStartTime()).toBe(
+                extractTimeFromDateTime(new Date('2026-04-07T10:30:00.000Z'))
+            );
         });
 
         test('returns the latest activity end time as the suggested activity start time', async () => {

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -78,6 +78,21 @@ describe('activity manager', () => {
             expect(result.reason).toMatch(/duration/i);
         });
 
+        test('allows activity with zero duration when source is timer', async () => {
+            const result = await addActivity({
+                description: 'Instant stop',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:00:00.000Z',
+                duration: 0,
+                source: 'timer',
+                sourceTaskId: null
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.activity.duration).toBe(0);
+            expect(putActivity).toHaveBeenCalledWith(expect.objectContaining({ source: 'timer' }));
+        });
+
         test('rejects activity with missing times', async () => {
             const result = await addActivity({
                 description: 'Test',
@@ -378,6 +393,14 @@ describe('activity manager', () => {
     });
 
     describe('createActivityFromTask', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
         test('maps a scheduled task into auto activity data', () => {
             const activity = createActivityFromTask({
                 id: 'sched-1',
@@ -409,6 +432,23 @@ describe('activity manager', () => {
 
             expect(activity.category).toBeNull();
             expect(activity.sourceTaskId).toBeNull();
+        });
+
+        test('shifts auto-log times when a task is completed before its planned start', () => {
+            jest.setSystemTime(new Date('2026-04-07T09:00:00.000Z'));
+
+            const activity = createActivityFromTask({
+                id: 'sched-2',
+                description: 'Deep work',
+                category: 'work/deep',
+                startDateTime: '2026-04-07T10:00:00.000Z',
+                endDateTime: '2026-04-07T11:00:00.000Z',
+                duration: 60
+            });
+
+            expect(activity.startDateTime).toBe('2026-04-07T08:00:00.000Z');
+            expect(activity.endDateTime).toBe('2026-04-07T09:00:00.000Z');
+            expect(activity.duration).toBe(60);
         });
     });
 });

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -14,6 +14,7 @@ import {
     getActivityState,
     getActivityById,
     getTodaysActivities,
+    getSuggestedActivityStartTime,
     loadActivitiesState,
     removeActivity,
     editActivity,
@@ -22,6 +23,7 @@ import {
     createActivityFromTask
 } from '../public/js/activities/manager.js';
 import { putActivity, loadActivities, deleteActivity } from '../public/js/storage.js';
+import { extractTimeFromDateTime } from '../public/js/utils.js';
 
 describe('activity manager', () => {
     beforeEach(() => {
@@ -213,6 +215,45 @@ describe('activity manager', () => {
             expect(todays).toHaveLength(2);
             expect(todays[0].description).toBe('Today earlier');
             expect(todays[1].description).toBe('Today later');
+        });
+
+        test('returns the latest activity end time as the suggested activity start time', async () => {
+            await addActivity({
+                description: 'Earlier',
+                startDateTime: '2026-04-07T09:00:00.000Z',
+                endDateTime: '2026-04-07T09:45:00.000Z',
+                duration: 45,
+                source: 'manual',
+                sourceTaskId: null
+            });
+            await addActivity({
+                description: 'Later',
+                startDateTime: '2026-04-07T10:00:00.000Z',
+                endDateTime: '2026-04-07T10:30:00.000Z',
+                duration: 30,
+                source: 'auto',
+                sourceTaskId: 'sched-1'
+            });
+
+            expect(getSuggestedActivityStartTime()).toBe(
+                extractTimeFromDateTime(new Date('2026-04-07T10:30:00.000Z'))
+            );
+        });
+
+        test('falls back to null when there are no activities for today', () => {
+            updateActivityState([
+                {
+                    id: 'activity-yesterday',
+                    description: 'Yesterday',
+                    startDateTime: '2026-04-06T09:00:00.000Z',
+                    endDateTime: '2026-04-06T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ]);
+
+            expect(getSuggestedActivityStartTime()).toBeNull();
         });
     });
 

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -264,6 +264,33 @@ describe('activity renderer', () => {
         expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
     });
 
+    test('renders a confirming delete affordance for the selected activity row', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-delete',
+                    description: 'Standup',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container,
+            { confirmingDeleteActivityId: 'activity-delete' }
+        );
+
+        const deleteButton = container.querySelector('.btn-delete-activity');
+        const deleteIcon = deleteButton.querySelector('i');
+
+        expect(deleteButton.className).toContain('text-rose-400');
+        expect(deleteIcon.className).toContain('fa-check-circle');
+    });
+
     test('renders a parent-group summary bar above the activity list', () => {
         const container = document.getElementById('activity-list');
 

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -4,6 +4,27 @@
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
     renderCategoryBadge: jest.fn(() => '<span class="category-badge">Deep Work</span>'),
+    getCategoryBadgeData: jest.fn((categoryKey) => {
+        if (categoryKey === 'work/deep') {
+            return {
+                kind: 'category',
+                key: 'work/deep',
+                label: 'Deep Work',
+                color: '#0ea5e9'
+            };
+        }
+
+        if (categoryKey === 'break/admin') {
+            return {
+                kind: 'category',
+                key: 'break/admin',
+                label: 'Admin',
+                color: '#14b8a6'
+            };
+        }
+
+        return null;
+    }),
     getSelectableCategoryOptions: jest.fn(() => [
         { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
     ])
@@ -62,6 +83,87 @@ describe('activity renderer', () => {
         expect(container.textContent).toContain('1h');
         expect(container.querySelector('.btn-edit-activity')).not.toBeNull();
         expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
+    });
+
+    test('renders a category summary bar above the activity list', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Admin',
+                    category: 'break/admin',
+                    startDateTime: '2026-04-07T10:00:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-3',
+                    description: 'Catch-up',
+                    category: null,
+                    startDateTime: '2026-04-07T10:30:00.000Z',
+                    endDateTime: '2026-04-07T11:00:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const summary = container.querySelector('[data-activity-summary]');
+        expect(summary).not.toBeNull();
+        expect(summary.textContent).toContain('Category Breakdown');
+        expect(summary.textContent).toContain('Total 2h');
+        expect(summary.textContent).toContain('Deep Work 1h');
+        expect(summary.textContent).toContain('Admin 30m');
+        expect(summary.textContent).toContain('Uncategorized 30m');
+        expect(summary.querySelectorAll('[data-summary-segment]')).toHaveLength(3);
+    });
+
+    test('renders uncategorized summary items with the dedicated uncategorized style', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-uncategorized',
+                    description: 'Loose notes',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 45,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const uncategorizedSegment = container.querySelector(
+            '[data-summary-segment="uncategorized"]'
+        );
+        const uncategorizedLegend = container.querySelector(
+            '[data-summary-legend-swatch="uncategorized"]'
+        );
+
+        expect(uncategorizedSegment).not.toBeNull();
+        expect(uncategorizedLegend).not.toBeNull();
+        expect(uncategorizedSegment.getAttribute('style')).toContain('repeating-linear-gradient');
+        expect(uncategorizedLegend.getAttribute('style')).toContain('repeating-linear-gradient');
     });
 
     test('renders auto activity with source indicator and edit/delete actions', () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -227,6 +227,59 @@ describe('activity renderer', () => {
         expect(editForm.querySelector('.btn-save-activity-edit')).not.toBeNull();
     });
 
+    test('renders an end-time hint for inline activity edit duration', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-hint',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 90,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container,
+            { editingActivityId: 'activity-hint' }
+        );
+
+        const hintEl = container.querySelector('.edit-end-time-hint');
+
+        expect(hintEl).not.toBeNull();
+        expect(hintEl.textContent).toContain('AM');
+        expect(hintEl.classList.contains('opacity-0')).toBe(false);
+    });
+
+    test('reserves row space for the inline activity edit end-time hint on larger widths', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-layout',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 90,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container,
+            { editingActivityId: 'activity-layout' }
+        );
+
+        const row = container.querySelector('form.activity-inline-edit-form > div:last-of-type');
+
+        expect(row).not.toBeNull();
+        expect(row.className).toContain('sm:pb-5');
+    });
+
     test('escapes activity descriptions', () => {
         const container = document.getElementById('activity-list');
 

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -4,22 +4,121 @@
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
     renderCategoryBadge: jest.fn(() => '<span class="category-badge">Deep Work</span>'),
-    getCategoryBadgeData: jest.fn((categoryKey) => {
-        if (categoryKey === 'work/deep') {
+    getGroupByKey: jest.fn((key) => {
+        if (key === 'work') {
             return {
-                kind: 'category',
+                key: 'work',
+                label: 'Work',
+                color: '#0f172a'
+            };
+        }
+
+        if (key === 'personal') {
+            return {
+                key: 'personal',
+                label: 'Personal',
+                color: '#f97316'
+            };
+        }
+
+        return null;
+    }),
+    getCategoryByKey: jest.fn((key) => {
+        if (key === 'work/deep') {
+            return {
                 key: 'work/deep',
                 label: 'Deep Work',
+                groupKey: 'work',
                 color: '#0ea5e9'
             };
         }
 
-        if (categoryKey === 'break/admin') {
+        if (key === 'work/admin') {
+            return {
+                key: 'work/admin',
+                label: 'Admin',
+                groupKey: 'work',
+                color: '#14b8a6'
+            };
+        }
+
+        if (key === 'personal/planning') {
+            return {
+                key: 'personal/planning',
+                label: 'Planning',
+                groupKey: 'personal',
+                color: '#f97316'
+            };
+        }
+
+        if (key === 'ghost/focus') {
+            return {
+                key: 'ghost/focus',
+                label: 'Focus',
+                groupKey: 'ghost',
+                color: '#22c55e'
+            };
+        }
+
+        return null;
+    }),
+    resolveCategoryKey: jest.fn((key) => {
+        if (key === 'work') {
+            return {
+                kind: 'group',
+                record: {
+                    key: 'work',
+                    label: 'Work',
+                    color: '#0f172a'
+                }
+            };
+        }
+
+        if (key === 'work/deep') {
             return {
                 kind: 'category',
-                key: 'break/admin',
-                label: 'Admin',
-                color: '#14b8a6'
+                record: {
+                    key: 'work/deep',
+                    label: 'Deep Work',
+                    groupKey: 'work',
+                    color: '#0ea5e9'
+                }
+            };
+        }
+
+        if (key === 'work/admin') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'work/admin',
+                    label: 'Admin',
+                    groupKey: 'work',
+                    color: '#14b8a6'
+                }
+            };
+        }
+
+        if (key === 'personal/planning') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'personal/planning',
+                    label: 'Planning',
+                    groupKey: 'personal',
+                    color: '#f97316'
+                }
+            };
+        }
+
+        if (key === 'ghost/focus') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'ghost/focus',
+                    label: 'Focus',
+                    groupKey: 'ghost',
+                    color: '#22c55e'
+                }
             };
         }
 
@@ -85,7 +184,7 @@ describe('activity renderer', () => {
         expect(container.querySelector('.btn-delete-activity')).not.toBeNull();
     });
 
-    test('renders a category summary bar above the activity list', () => {
+    test('renders a parent-group summary bar above the activity list', () => {
         const container = document.getElementById('activity-list');
 
         renderActivities(
@@ -102,8 +201,8 @@ describe('activity renderer', () => {
                 },
                 {
                     id: 'activity-2',
-                    description: 'Admin',
-                    category: 'break/admin',
+                    description: 'Planning',
+                    category: 'personal/planning',
                     startDateTime: '2026-04-07T10:00:00.000Z',
                     endDateTime: '2026-04-07T10:30:00.000Z',
                     duration: 30,
@@ -128,10 +227,224 @@ describe('activity renderer', () => {
         expect(summary).not.toBeNull();
         expect(summary.textContent).toContain('Category Breakdown');
         expect(summary.textContent).toContain('Total 2h');
-        expect(summary.textContent).toContain('Deep Work 1h');
-        expect(summary.textContent).toContain('Admin 30m');
+        expect(summary.textContent).toContain('Work 1h');
+        expect(summary.textContent).toContain('Personal 30m');
         expect(summary.textContent).toContain('Uncategorized 30m');
-        expect(summary.querySelectorAll('[data-summary-segment]')).toHaveLength(3);
+        expect(summary.textContent).not.toContain('Deep Work');
+        expect(summary.querySelectorAll('[data-summary-parent-segment]')).toHaveLength(3);
+    });
+
+    test('parent-group default summary aggregates child and parent activities', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 45,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Parent work',
+                    category: 'work',
+                    startDateTime: '2026-04-07T09:45:00.000Z',
+                    endDateTime: '2026-04-07T10:20:00.000Z',
+                    duration: 35,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-3',
+                    description: 'Planning',
+                    category: 'personal/planning',
+                    startDateTime: '2026-04-07T10:20:00.000Z',
+                    endDateTime: '2026-04-07T10:50:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-4',
+                    description: 'Loose notes',
+                    category: null,
+                    startDateTime: '2026-04-07T10:50:00.000Z',
+                    endDateTime: '2026-04-07T11:05:00.000Z',
+                    duration: 15,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const summary = container.querySelector('[data-activity-summary]');
+
+        expect(summary).not.toBeNull();
+        expect(summary.textContent).toContain('Work 1h 20m');
+        expect(summary.textContent).toContain('Personal 30m');
+        expect(summary.textContent).toContain('Uncategorized 15m');
+        expect(summary.textContent).not.toContain('Deep Work');
+        expect(summary.querySelectorAll('[data-summary-parent-segment]')).toHaveLength(3);
+    });
+
+    test('parent-group summary rolls deleted child categories up to their inferred parent', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Missing child',
+                    category: 'work/missing',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:20:00.000Z',
+                    duration: 20,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:20:00.000Z',
+                    endDateTime: '2026-04-07T09:50:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const summary = container.querySelector('[data-activity-summary]');
+
+        expect(summary).not.toBeNull();
+        expect(summary.textContent).toContain('Work 50m');
+        expect(summary.textContent).not.toContain('work/missing');
+        expect(summary.querySelectorAll('[data-summary-parent-segment]')).toHaveLength(1);
+    });
+
+    test('parent-group summary keeps missing parent groups in one fallback bucket', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Ghost child',
+                    category: 'ghost/focus',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:20:00.000Z',
+                    duration: 20,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Ghost parent',
+                    category: 'ghost',
+                    startDateTime: '2026-04-07T09:20:00.000Z',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 25,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const summary = container.querySelector('[data-activity-summary]');
+
+        expect(summary).not.toBeNull();
+        expect(summary.textContent).toContain('Ghost 45m');
+        expect(summary.textContent).not.toContain('Focus');
+        expect(summary.querySelectorAll('[data-summary-parent-segment]')).toHaveLength(1);
+    });
+
+    test('parent-group summary uses deterministic ordering when durations tie', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Work item',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Personal item',
+                    category: 'personal/planning',
+                    startDateTime: '2026-04-07T09:30:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const labels = Array.from(container.querySelectorAll('[data-summary-parent-legend]')).map(
+            (item) => item.textContent.trim()
+        );
+
+        expect(labels).toEqual(['Personal 30m', 'Work 30m']);
+    });
+
+    test('parent summary shows pointer affordance only for expandable groups', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Loose notes',
+                    category: null,
+                    startDateTime: '2026-04-07T09:30:00.000Z',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 15,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container
+        );
+
+        const workSegment = container.querySelector('[data-summary-parent-segment="work"]');
+        const workLegend = container.querySelector('[data-summary-parent-legend="work"]');
+        const uncategorizedSegment = container.querySelector(
+            '[data-summary-parent-segment="uncategorized"]'
+        );
+        const uncategorizedLegend = container.querySelector(
+            '[data-summary-parent-legend="uncategorized"]'
+        );
+
+        expect(workSegment.className).toContain('cursor-pointer');
+        expect(workLegend.className).toContain('cursor-pointer');
+        expect(uncategorizedSegment.className).toContain('cursor-default');
+        expect(uncategorizedLegend.className).toContain('cursor-default');
     });
 
     test('renders uncategorized summary items with the dedicated uncategorized style', () => {
@@ -164,6 +477,91 @@ describe('activity renderer', () => {
         expect(uncategorizedLegend).not.toBeNull();
         expect(uncategorizedSegment.getAttribute('style')).toContain('repeating-linear-gradient');
         expect(uncategorizedLegend.getAttribute('style')).toContain('repeating-linear-gradient');
+    });
+
+    test('renders an expanded child rail for the selected parent group', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Deep work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 45,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Admin',
+                    category: 'work/admin',
+                    startDateTime: '2026-04-07T09:45:00.000Z',
+                    endDateTime: '2026-04-07T10:05:00.000Z',
+                    duration: 20,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-3',
+                    description: 'Parent work',
+                    category: 'work',
+                    startDateTime: '2026-04-07T10:05:00.000Z',
+                    endDateTime: '2026-04-07T10:20:00.000Z',
+                    duration: 15,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-4',
+                    description: 'Planning',
+                    category: 'personal/planning',
+                    startDateTime: '2026-04-07T10:20:00.000Z',
+                    endDateTime: '2026-04-07T10:50:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container,
+            { expandedParentGroupKey: 'work' }
+        );
+
+        const expandedRail = container.querySelector('[data-summary-expanded-group="work"]');
+
+        expect(expandedRail).not.toBeNull();
+        expect(expandedRail.textContent).toContain('Work');
+        expect(expandedRail.textContent).toContain('Deep Work 45m');
+        expect(expandedRail.textContent).toContain('Admin 20m');
+        expect(expandedRail.textContent).toContain('Unspecified Work 15m');
+        expect(expandedRail.textContent).not.toContain('Zero Child');
+        expect(container.querySelectorAll('[data-summary-child-segment]')).toHaveLength(3);
+    });
+
+    test('does not render an expanded child rail for uncategorized', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Loose notes',
+                    category: null,
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:15:00.000Z',
+                    duration: 15,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container,
+            { expandedParentGroupKey: 'uncategorized' }
+        );
+
+        expect(container.querySelector('[data-summary-expanded-group]')).toBeNull();
+        expect(container.querySelectorAll('[data-summary-child-segment]')).toHaveLength(0);
     });
 
     test('renders auto activity with source indicator and edit/delete actions', () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -445,6 +445,12 @@ describe('activity renderer', () => {
         expect(workLegend.className).toContain('cursor-pointer');
         expect(uncategorizedSegment.className).toContain('cursor-default');
         expect(uncategorizedLegend.className).toContain('cursor-default');
+        expect(workSegment.tagName).toBe('BUTTON');
+        expect(workLegend.tagName).toBe('BUTTON');
+        expect(workSegment.getAttribute('type')).toBe('button');
+        expect(workLegend.getAttribute('type')).toBe('button');
+        expect(uncategorizedSegment.tagName).toBe('DIV');
+        expect(uncategorizedLegend.tagName).toBe('SPAN');
     });
 
     test('renders uncategorized summary items with the dedicated uncategorized style', () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -779,6 +779,10 @@ describe('activity renderer', () => {
         expect(editForm.querySelector('input[name="duration-hours"]').value).toBe('1');
         expect(editForm.querySelector('input[name="duration-minutes"]').value).toBe('30');
         expect(editForm.querySelector('select[name="category"]').value).toBe('work/deep');
+        expect(editForm.querySelector('.activity-edit-category-dot')).not.toBeNull();
+        expect(editForm.querySelector('.activity-edit-category-dot').style.backgroundColor).toBe(
+            'rgb(14, 165, 233)'
+        );
         expect(editForm.textContent).toContain('auto');
         expect(editForm.querySelector('.btn-delete-activity')).toBeNull();
         expect(editForm.querySelector('.btn-cancel-activity-edit')).not.toBeNull();

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -252,13 +252,21 @@ describe('activity renderer', () => {
 
         const summary = container.querySelector('[data-activity-summary]');
         expect(summary).not.toBeNull();
-        expect(summary.textContent).toContain('Category Breakdown');
+        expect(summary.textContent).toContain('Activity Breakdown');
         expect(summary.textContent).toContain('Total 2h');
         expect(summary.textContent).toContain('Work 1h');
         expect(summary.textContent).toContain('Personal 30m');
         expect(summary.textContent).toContain('Uncategorized 30m');
         expect(summary.textContent).not.toContain('Deep Work');
         expect(summary.querySelectorAll('[data-summary-parent-segment]')).toHaveLength(3);
+        expect(summary.querySelector('[data-summary-total-count]').textContent).toBe('3');
+        expect(summary.querySelector('[data-summary-parent-count="work"]').textContent).toBe('1');
+        expect(summary.querySelector('[data-summary-parent-count="personal"]').textContent).toBe(
+            '1'
+        );
+        expect(
+            summary.querySelector('[data-summary-parent-count="uncategorized"]').textContent
+        ).toBe('1');
     });
 
     test('parent-group default summary aggregates child and parent activities', () => {
@@ -318,6 +326,14 @@ describe('activity renderer', () => {
         expect(summary.textContent).toContain('Uncategorized 15m');
         expect(summary.textContent).not.toContain('Deep Work');
         expect(summary.querySelectorAll('[data-summary-parent-segment]')).toHaveLength(3);
+        expect(summary.querySelector('[data-summary-total-count]').textContent).toBe('4');
+        expect(summary.querySelector('[data-summary-parent-count="work"]').textContent).toBe('2');
+        expect(summary.querySelector('[data-summary-parent-count="personal"]').textContent).toBe(
+            '1'
+        );
+        expect(
+            summary.querySelector('[data-summary-parent-count="uncategorized"]').textContent
+        ).toBe('1');
     });
 
     test('parent-group summary rolls deleted child categories up to their inferred parent', () => {
@@ -424,7 +440,11 @@ describe('activity renderer', () => {
         );
 
         const labels = Array.from(container.querySelectorAll('[data-summary-parent-legend]')).map(
-            (item) => item.textContent.trim()
+            (item) =>
+                item.textContent
+                    .replace(/\s+/g, ' ')
+                    .replace(/\s+\d+\s*$/, '')
+                    .trim()
         );
 
         expect(labels).toEqual(['Personal 30m', 'Work 30m']);

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -156,7 +156,7 @@ jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
     ])
 }));
 
-import { renderActivities } from '../public/js/activities/renderer.js';
+import { renderActivities, renderActivitySummaryOnly } from '../public/js/activities/renderer.js';
 import { convertTo12HourTime, extractTimeFromDateTime } from '../public/js/utils.js';
 
 describe('activity renderer', () => {
@@ -175,6 +175,59 @@ describe('activity renderer', () => {
 
         expect(container.textContent).toContain('No activities tracked today');
         expect(container.querySelector('.text-center')).toBeNull();
+    });
+
+    test('renders the summary even when only a live running activity exists', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities([], container, {
+            summaryActivities: [
+                {
+                    id: 'running-activity-summary',
+                    description: 'Running',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:03:00.000Z',
+                    duration: 3,
+                    source: 'timer',
+                    sourceTaskId: null
+                }
+            ]
+        });
+
+        expect(container.querySelector('[data-activity-summary]')).not.toBeNull();
+        expect(container.textContent).toContain('Activity Breakdown');
+        expect(container.textContent).toContain('Work 3m');
+        expect(container.textContent).toContain('No completed activities logged today yet');
+        expect(container.textContent).not.toContain('No activities tracked today');
+    });
+
+    test('renderActivitySummaryOnly updates an existing summary without replacing the list', () => {
+        const container = document.getElementById('activity-list');
+        container.innerHTML = `
+            <div data-activity-summary>Old summary</div>
+            <div data-activity-id="activity-1">Persisted item</div>
+        `;
+
+        renderActivitySummaryOnly([], container, {
+            summaryActivities: [
+                {
+                    id: 'running-activity-summary',
+                    description: 'Running',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:04:00.000Z',
+                    duration: 4,
+                    source: 'timer',
+                    sourceTaskId: null
+                }
+            ]
+        });
+
+        expect(container.querySelector('[data-activity-summary]').textContent).toContain('Work 4m');
+        expect(container.querySelector('[data-activity-id="activity-1"]').textContent).toBe(
+            'Persisted item'
+        );
     });
 
     test('renders manual activity with edit and delete actions', () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -4,6 +4,14 @@
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
     renderCategoryBadge: jest.fn(() => '<span class="category-badge">Deep Work</span>'),
+    getTaxonomySnapshot: jest.fn(() => ({
+        categories: [
+            { key: 'work/deep', groupKey: 'work' },
+            { key: 'work/admin', groupKey: 'work' },
+            { key: 'personal/planning', groupKey: 'personal' },
+            { key: 'ghost/focus', groupKey: 'ghost' }
+        ]
+    })),
     getGroupByKey: jest.fn((key) => {
         if (key === 'work') {
             return {
@@ -18,6 +26,14 @@ jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
                 key: 'personal',
                 label: 'Personal',
                 color: '#f97316'
+            };
+        }
+
+        if (key === 'solo') {
+            return {
+                key: 'solo',
+                label: 'Solo',
+                color: '#a855f7'
             };
         }
 
@@ -118,6 +134,17 @@ jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
                     label: 'Focus',
                     groupKey: 'ghost',
                     color: '#22c55e'
+                }
+            };
+        }
+
+        if (key === 'solo') {
+            return {
+                kind: 'group',
+                record: {
+                    key: 'solo',
+                    label: 'Solo',
+                    color: '#a855f7'
                 }
             };
         }
@@ -541,9 +568,36 @@ describe('activity renderer', () => {
         expect(expandedRail.textContent).toContain('Work');
         expect(expandedRail.textContent).toContain('Deep Work 45m');
         expect(expandedRail.textContent).toContain('Admin 20m');
-        expect(expandedRail.textContent).toContain('Unspecified Work 15m');
+        expect(expandedRail.textContent).toContain('Unspecified 15m');
         expect(expandedRail.textContent).not.toContain('Zero Child');
         expect(container.querySelectorAll('[data-summary-child-segment]')).toHaveLength(3);
+    });
+
+    test('uses the parent label for direct parent activity when that group has no children', () => {
+        const container = document.getElementById('activity-list');
+
+        renderActivities(
+            [
+                {
+                    id: 'activity-1',
+                    description: 'Solo work',
+                    category: 'solo',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:20:00.000Z',
+                    duration: 20,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ],
+            container,
+            { expandedParentGroupKey: 'solo' }
+        );
+
+        const expandedRail = container.querySelector('[data-summary-expanded-group="solo"]');
+
+        expect(expandedRail).not.toBeNull();
+        expect(expandedRail.textContent).toContain('Solo 20m');
+        expect(expandedRail.textContent).not.toContain('Unspecified');
     });
 
     test('does not render an expanded child rail for uncategorized', () => {

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -27,6 +27,7 @@ describe('activity renderer', () => {
         renderActivities([], container);
 
         expect(container.textContent).toContain('No activities tracked today');
+        expect(container.querySelector('.text-center')).toBeNull();
     });
 
     test('renders manual activity with edit and delete actions', () => {

--- a/__tests__/activity-summary.test.js
+++ b/__tests__/activity-summary.test.js
@@ -1,0 +1,266 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    getTaxonomySnapshot: jest.fn(() => ({
+        categories: [
+            { key: 'work/deep', groupKey: 'work' },
+            { key: 'work/admin', groupKey: 'work' },
+            { key: 'personal/planning', groupKey: 'personal' },
+            { key: 'ghost/focus', groupKey: 'ghost' }
+        ]
+    })),
+    getGroupByKey: jest.fn((key) => {
+        if (key === 'work') {
+            return { key: 'work', label: 'Work', color: '#0f172a' };
+        }
+        if (key === 'personal') {
+            return { key: 'personal', label: 'Personal', color: '#f97316' };
+        }
+        if (key === 'solo') {
+            return { key: 'solo', label: 'Solo', color: '#a855f7' };
+        }
+
+        return null;
+    }),
+    getCategoryByKey: jest.fn((key) => {
+        if (key === 'work/deep') {
+            return {
+                key: 'work/deep',
+                label: 'Deep Work',
+                groupKey: 'work',
+                color: '#0ea5e9'
+            };
+        }
+        if (key === 'work/admin') {
+            return {
+                key: 'work/admin',
+                label: 'Admin',
+                groupKey: 'work',
+                color: '#14b8a6'
+            };
+        }
+        if (key === 'personal/planning') {
+            return {
+                key: 'personal/planning',
+                label: 'Planning',
+                groupKey: 'personal',
+                color: '#f97316'
+            };
+        }
+        if (key === 'ghost/focus') {
+            return {
+                key: 'ghost/focus',
+                label: 'Focus',
+                groupKey: 'ghost',
+                color: '#22c55e'
+            };
+        }
+
+        return null;
+    }),
+    resolveCategoryKey: jest.fn((key) => {
+        if (key === 'work') {
+            return {
+                kind: 'group',
+                record: { key: 'work', label: 'Work', color: '#0f172a' }
+            };
+        }
+        if (key === 'work/deep') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'work/deep',
+                    label: 'Deep Work',
+                    groupKey: 'work',
+                    color: '#0ea5e9'
+                }
+            };
+        }
+        if (key === 'work/admin') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'work/admin',
+                    label: 'Admin',
+                    groupKey: 'work',
+                    color: '#14b8a6'
+                }
+            };
+        }
+        if (key === 'personal/planning') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'personal/planning',
+                    label: 'Planning',
+                    groupKey: 'personal',
+                    color: '#f97316'
+                }
+            };
+        }
+        if (key === 'ghost/focus') {
+            return {
+                kind: 'category',
+                record: {
+                    key: 'ghost/focus',
+                    label: 'Focus',
+                    groupKey: 'ghost',
+                    color: '#22c55e'
+                }
+            };
+        }
+        if (key === 'solo') {
+            return {
+                kind: 'group',
+                record: { key: 'solo', label: 'Solo', color: '#a855f7' }
+            };
+        }
+
+        return null;
+    })
+}));
+
+import { buildActivitySummaryModel } from '../public/js/activities/summary.js';
+
+describe('activity summary selectors', () => {
+    test('builds a parent-group summary with counts and totals', () => {
+        const model = buildActivitySummaryModel([
+            {
+                id: 'activity-1',
+                category: 'work/deep',
+                duration: 45
+            },
+            {
+                id: 'activity-2',
+                category: 'work',
+                duration: 35
+            },
+            {
+                id: 'activity-3',
+                category: 'personal/planning',
+                duration: 30
+            },
+            {
+                id: 'activity-4',
+                category: null,
+                duration: 15
+            }
+        ]);
+
+        expect(model.totalDuration).toBe(125);
+        expect(model.totalCount).toBe(4);
+        expect(model.summaryItems.map((item) => item.key)).toEqual([
+            'work',
+            'personal',
+            'uncategorized'
+        ]);
+        expect(model.summaryItems[0]).toEqual(
+            expect.objectContaining({
+                key: 'work',
+                label: 'Work',
+                duration: 80,
+                count: 2
+            })
+        );
+    });
+
+    test('rolls missing child categories and missing parent groups into stable buckets', () => {
+        const model = buildActivitySummaryModel([
+            {
+                id: 'activity-1',
+                category: 'work/missing',
+                duration: 20
+            },
+            {
+                id: 'activity-2',
+                category: 'ghost/focus',
+                duration: 20
+            },
+            {
+                id: 'activity-3',
+                category: 'ghost',
+                duration: 25
+            }
+        ]);
+
+        expect(model.summaryItems).toEqual([
+            expect.objectContaining({ key: 'ghost', label: 'Ghost', duration: 45, count: 2 }),
+            expect.objectContaining({ key: 'work', label: 'Work', duration: 20, count: 1 })
+        ]);
+    });
+
+    test('builds expanded child detail for the selected group with unspecified fallback', () => {
+        const model = buildActivitySummaryModel(
+            [
+                {
+                    id: 'activity-1',
+                    category: 'work/deep',
+                    duration: 45
+                },
+                {
+                    id: 'activity-2',
+                    category: 'work/admin',
+                    duration: 20
+                },
+                {
+                    id: 'activity-3',
+                    category: 'work',
+                    duration: 15
+                },
+                {
+                    id: 'activity-4',
+                    category: 'personal/planning',
+                    duration: 30
+                }
+            ],
+            'work'
+        );
+
+        expect(model.expandedGroup).toEqual(
+            expect.objectContaining({
+                key: 'work',
+                label: 'Work',
+                totalDuration: 80
+            })
+        );
+        expect(model.expandedGroup.items).toEqual([
+            expect.objectContaining({ key: 'work/deep', label: 'Deep Work', duration: 45 }),
+            expect.objectContaining({ key: 'work/admin', label: 'Admin', duration: 20 }),
+            expect.objectContaining({
+                key: 'work::__unspecified',
+                label: 'Unspecified',
+                duration: 15
+            })
+        ]);
+    });
+
+    test('uses the parent label when the expanded group has no children', () => {
+        const model = buildActivitySummaryModel(
+            [
+                {
+                    id: 'activity-1',
+                    category: 'solo',
+                    duration: 20
+                }
+            ],
+            'solo'
+        );
+
+        expect(model.expandedGroup.items).toEqual([
+            expect.objectContaining({ key: 'solo::__unspecified', label: 'Solo', duration: 20 })
+        ]);
+    });
+
+    test('does not create expanded detail for uncategorized or unknown groups', () => {
+        expect(
+            buildActivitySummaryModel([{ id: 'a', category: null, duration: 10 }], 'uncategorized')
+                .expandedGroup
+        ).toBeNull();
+        expect(
+            buildActivitySummaryModel([{ id: 'a', category: 'work/deep', duration: 10 }], 'unknown')
+                .expandedGroup
+        ).toBeNull();
+    });
+});

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -547,6 +547,22 @@ describe('activity timer ui', () => {
             expect(refreshUI).toHaveBeenCalled();
         });
 
+        test('refreshes the activity summary when the running timer crosses a new rounded-minute boundary', () => {
+            const refreshActivitySummary = jest.fn();
+
+            initializeTimerUI({ refreshUI: jest.fn(), refreshActivitySummary });
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            jest.advanceTimersByTime(29000);
+            expect(refreshActivitySummary).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1000);
+            expect(refreshActivitySummary).toHaveBeenCalledTimes(1);
+        });
+
         test('stop timer waits for pending timer edits before delegating', async () => {
             let resolveUpdate;
             getRunningActivity.mockReturnValue({
@@ -675,6 +691,70 @@ describe('activity timer ui', () => {
             expect(document.getElementById('timer-elapsed').textContent).toBe('00:30:00');
         });
 
+        test('successful timer description edits refresh the activity summary immediately', async () => {
+            const refreshActivitySummary = jest.fn();
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: true,
+                runningActivity: {
+                    description: 'Updated',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-09T10:00:00.000Z'
+                }
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn(), refreshActivitySummary });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = 'Updated';
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(refreshActivitySummary).toHaveBeenCalled();
+        });
+
+        test('successful timer category edits refresh the activity summary immediately', async () => {
+            const refreshActivitySummary = jest.fn();
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: true,
+                runningActivity: {
+                    description: 'Running',
+                    category: 'break/admin',
+                    startDateTime: '2026-04-09T10:00:00.000Z'
+                }
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn(), refreshActivitySummary });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const categoryInput = document.getElementById('timer-category');
+            categoryInput.innerHTML =
+                '<option value="work/deep">Deep Work</option><option value="break/admin">Admin</option>';
+            categoryInput.value = 'break/admin';
+            categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(refreshActivitySummary).toHaveBeenCalled();
+        });
+
         test('failed timer description edits rollback the visible value and alert', async () => {
             getRunningActivity.mockReturnValue({
                 description: 'Running',
@@ -775,6 +855,37 @@ describe('activity timer ui', () => {
 
             expect(startTimeInput.value).toBe(previousValue);
             expect(showAlert).toHaveBeenCalledWith('Start time update failed.', 'sky');
+        });
+
+        test('successful timer start time edits refresh the activity summary immediately', async () => {
+            const refreshActivitySummary = jest.fn();
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: true,
+                runningActivity: {
+                    description: 'Running',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-09T09:15:00.000Z'
+                }
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn(), refreshActivitySummary });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const startTimeInput = document.getElementById('timer-start-time');
+            startTimeInput.value = '09:15';
+            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(refreshActivitySummary).toHaveBeenCalled();
         });
     });
 });

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -134,6 +134,21 @@ describe('activity timer ui', () => {
             expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:30');
         });
 
+        test('elapsed counter aligns updates to real second boundaries', () => {
+            jest.setSystemTime(new Date('2026-04-09T10:00:00.800Z'));
+
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:00');
+
+            jest.advanceTimersByTime(250);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:01');
+        });
+
         test('hideTimerDisplay restores the form and stops elapsed updates', () => {
             showTimerDisplay({
                 description: 'Timer work',

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -369,6 +369,55 @@ describe('activity timer ui', () => {
             );
         });
 
+        test('timer debug helper falls back to local-only values when no timer is running', async () => {
+            initializeTimerUI({ refreshUI: jest.fn() });
+
+            const snapshot = await window.dumpTimerDebug();
+
+            expect(global.fetch).not.toHaveBeenCalled();
+            expect(snapshot).toEqual(
+                expect.objectContaining({
+                    runningActivity: null,
+                    elapsedMs: null,
+                    correctedElapsedMs: null,
+                    correctedDisplayedElapsed: null,
+                    serverDateHeader: null,
+                    estimatedServerOffsetMs: null
+                })
+            );
+        });
+
+        test('timer debug helper falls back to local elapsed values when server date header is invalid', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running timer',
+                category: null,
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                source: 'timer',
+                sourceTaskId: null
+            });
+            global.fetch.mockResolvedValue({
+                headers: {
+                    get: jest.fn(() => 'not-a-date')
+                }
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            syncTimerFormState();
+
+            const snapshot = await window.dumpTimerDebug();
+
+            expect(snapshot).toEqual(
+                expect.objectContaining({
+                    serverDateHeader: 'not-a-date',
+                    estimatedServerOffsetMs: null,
+                    elapsedMs: 0,
+                    correctedElapsedMs: 0,
+                    correctedDisplayedElapsed: '00:00:00'
+                })
+            );
+        });
+
         test('start timer button alerts when description is blank', async () => {
             document.getElementById('activity').checked = true;
 

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -318,6 +318,95 @@ describe('activity timer ui', () => {
             expect(handleStopTimer).toHaveBeenCalledTimes(1);
         });
 
+        test('applies measured server clock offset to the visible elapsed timer', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running timer',
+                category: null,
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                source: 'timer',
+                sourceTaskId: null
+            });
+            global.fetch.mockResolvedValue({
+                headers: {
+                    get: jest.fn((name) =>
+                        name === 'Date' ? 'Wed, 09 Apr 2026 10:00:05 GMT' : null
+                    )
+                }
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            syncTimerFormState();
+            await flushAsyncWork(6);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:05');
+        });
+
+        test('keeps using the local clock when server offset measurement fails', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running timer',
+                category: null,
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                source: 'timer',
+                sourceTaskId: null
+            });
+            global.fetch.mockRejectedValue(new Error('network down'));
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            syncTimerFormState();
+            await flushAsyncWork(6);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:00');
+        });
+
+        test('ignores stale server offset responses from a previous timer UI session', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running timer',
+                category: null,
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                source: 'timer',
+                sourceTaskId: null
+            });
+
+            let resolveFirstFetch;
+            global.fetch
+                .mockImplementationOnce(
+                    () =>
+                        new Promise((resolve) => {
+                            resolveFirstFetch = resolve;
+                        })
+                )
+                .mockResolvedValueOnce({
+                    headers: {
+                        get: jest.fn((name) =>
+                            name === 'Date' ? 'Wed, 09 Apr 2026 10:00:05 GMT' : null
+                        )
+                    }
+                });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            syncTimerFormState();
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            syncTimerFormState();
+            await flushAsyncWork(6);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:05');
+
+            resolveFirstFetch({
+                headers: {
+                    get: jest.fn((name) =>
+                        name === 'Date' ? 'Wed, 09 Apr 2026 10:00:20 GMT' : null
+                    )
+                }
+            });
+            await flushAsyncWork(6);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:05');
+        });
+
         test('registers an async global timer debug helper with corrected timing estimate', async () => {
             document.getElementById('activity').checked = true;
             getRunningActivity.mockReturnValue({
@@ -337,6 +426,8 @@ describe('activity timer ui', () => {
 
             initializeTimerUI({ refreshUI: jest.fn() });
             syncTimerFormState();
+            await flushAsyncWork(6);
+            global.fetch.mockClear();
 
             expect(typeof window.dumpTimerDebug).toBe('function');
 
@@ -351,19 +442,16 @@ describe('activity timer ui', () => {
                     }),
                     correctedElapsedMs: 5000,
                     correctedDisplayedElapsed: '00:00:05',
-                    displayedElapsed: '00:00:00',
+                    displayedElapsed: '00:00:05',
                     isTimerVisible: true
                 })
             );
-            expect(global.fetch).toHaveBeenCalledWith('http://localhost/', {
-                method: 'HEAD',
-                cache: 'no-store'
-            });
+            expect(global.fetch).not.toHaveBeenCalled();
             expect(infoSpy).toHaveBeenCalledWith(
                 'timer-debug:snapshot',
                 expect.objectContaining({
                     correctedDisplayedElapsed: '00:00:05',
-                    displayedElapsed: '00:00:00',
+                    displayedElapsed: '00:00:05',
                     isTimerVisible: true
                 })
             );
@@ -371,6 +459,7 @@ describe('activity timer ui', () => {
 
         test('timer debug helper falls back to local-only values when no timer is running', async () => {
             initializeTimerUI({ refreshUI: jest.fn() });
+            global.fetch.mockClear();
 
             const snapshot = await window.dumpTimerDebug();
 
@@ -404,6 +493,7 @@ describe('activity timer ui', () => {
 
             initializeTimerUI({ refreshUI: jest.fn() });
             syncTimerFormState();
+            await flushAsyncWork(6);
 
             const snapshot = await window.dumpTimerDebug();
 

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -1,0 +1,360 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn()
+}));
+
+jest.mock('../public/js/activities/handlers.js', () => ({
+    handleStartTimer: jest.fn(() => Promise.resolve({ success: true })),
+    handleStopTimer: jest.fn(() => Promise.resolve({ success: true }))
+}));
+
+jest.mock('../public/js/activities/manager.js', () => ({
+    getRunningActivity: jest.fn(() => null),
+    updateRunningActivity: jest.fn(() => Promise.resolve({ success: true }))
+}));
+
+import {
+    showTimerDisplay,
+    hideTimerDisplay,
+    disposeTimerUI,
+    syncTimerFormState,
+    initializeTimerUI
+} from '../public/js/activities/timer-ui.js';
+import { handleStartTimer, handleStopTimer } from '../public/js/activities/handlers.js';
+import { getRunningActivity, updateRunningActivity } from '../public/js/activities/manager.js';
+import { showAlert } from '../public/js/modal-manager.js';
+
+describe('activity timer ui', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getRunningActivity.mockReturnValue(null);
+        updateRunningActivity.mockResolvedValue({ success: true });
+        handleStartTimer.mockResolvedValue({ success: true });
+        handleStopTimer.mockResolvedValue({ success: true });
+        document.body.innerHTML = `
+            <input id="scheduled" type="radio" name="task-type" checked />
+            <input id="activity" type="radio" name="task-type" />
+            <div id="task-form-fields">
+                <div id="time-inputs"></div>
+            </div>
+            <div id="timer-display" class="hidden">
+                <input id="timer-description" />
+                <select id="timer-category"></select>
+                <input id="timer-start-time" type="time" />
+                <div id="timer-elapsed"></div>
+                <button id="timer-stop-btn" type="button">Stop</button>
+            </div>
+            <button id="start-timer-btn" type="button" class="hidden">Start Timer</button>
+            <form id="task-form">
+                <input name="description" />
+                <select name="category">
+                    <option value="">No category</option>
+                    <option value="work/deep">Deep Work</option>
+                </select>
+                <input type="radio" name="task-type" value="scheduled" checked />
+                <input type="radio" name="task-type" value="activity" />
+            </form>
+        `;
+    });
+
+    describe('display state', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('showTimerDisplay hides form fields and shows timer state', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('timer-description').value).toBe('Timer work');
+            expect(document.getElementById('timer-category').value).toBe('work/deep');
+            expect(document.getElementById('timer-start-time').value).toBe(
+                `${String(new Date('2026-04-09T10:00:00.000Z').getHours()).padStart(2, '0')}:${String(
+                    new Date('2026-04-09T10:00:00.000Z').getMinutes()
+                ).padStart(2, '0')}`
+            );
+            expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:00');
+        });
+
+        test('elapsed counter updates while timer is visible', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            jest.advanceTimersByTime(30000);
+
+            expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:30');
+        });
+
+        test('hideTimerDisplay restores the form and stops elapsed updates', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            hideTimerDisplay();
+            const textAfterHide = document.getElementById('timer-elapsed').textContent;
+            jest.advanceTimersByTime(5000);
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('timer-elapsed').textContent).toBe(textAfterHide);
+        });
+    });
+
+    describe('form state', () => {
+        test('shows timer display when activity tab is selected and timer is running', () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            syncTimerFormState();
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
+                false
+            );
+        });
+
+        test('shows start timer button when activity tab is selected and no timer is running', () => {
+            document.getElementById('activity').checked = true;
+
+            syncTimerFormState();
+
+            expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(
+                false
+            );
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
+                false
+            );
+        });
+
+        test('keeps timer hidden on non-activity tabs', () => {
+            document.getElementById('scheduled').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            syncTimerFormState();
+
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+            expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(
+                true
+            );
+        });
+    });
+
+    describe('initializeTimerUI', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('start timer button uses form values and refreshes UI on success', async () => {
+            document.getElementById('activity').checked = true;
+            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
+            document.querySelector('#task-form select[name="category"]').value = 'work/deep';
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).toHaveBeenCalledWith({
+                description: 'Feature work',
+                category: 'work/deep'
+            });
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('re-initializing timer UI does not duplicate start/stop handlers', async () => {
+            document.getElementById('activity').checked = true;
+            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            initializeTimerUI({ refreshUI });
+
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).toHaveBeenCalledTimes(1);
+            expect(handleStopTimer).toHaveBeenCalledTimes(1);
+        });
+
+        test('disposing timer UI removes existing listeners until re-initialized', async () => {
+            document.getElementById('activity').checked = true;
+            document.querySelector('#task-form input[name="description"]').value = 'Feature work';
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            disposeTimerUI();
+
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).not.toHaveBeenCalled();
+            expect(handleStopTimer).not.toHaveBeenCalled();
+        });
+
+        test('stop timer button delegates to handler and refreshes UI', async () => {
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStopTimer).toHaveBeenCalled();
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('timer field edits persist running activity changes', async () => {
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity
+                .mockResolvedValueOnce({
+                    success: true,
+                    runningActivity: {
+                        description: 'Updated',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    }
+                })
+                .mockResolvedValueOnce({
+                    success: true,
+                    runningActivity: {
+                        description: 'Updated',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    }
+                })
+                .mockResolvedValueOnce({
+                    success: true,
+                    runningActivity: {
+                        description: 'Updated',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T09:30:00.000Z'
+                    }
+                });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = 'Updated';
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+            const categoryInput = document.getElementById('timer-category');
+            categoryInput.innerHTML = '<option value="work/deep">Deep Work</option>';
+            categoryInput.value = 'work/deep';
+            categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+            const startTimeInput = document.getElementById('timer-start-time');
+            startTimeInput.value = '09:30';
+            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            const expectedStartDate = new Date('2026-04-09T10:00:00.000Z');
+            expectedStartDate.setHours(9, 30, 0, 0);
+
+            expect(updateRunningActivity).toHaveBeenCalledWith({ description: 'Updated' });
+            expect(updateRunningActivity).toHaveBeenCalledWith({ category: 'work/deep' });
+            expect(updateRunningActivity).toHaveBeenCalledWith({
+                startDateTime: expectedStartDate.toISOString()
+            });
+            expect(document.getElementById('timer-elapsed').textContent).toBe('00:30:00');
+        });
+
+        test('failed timer description edits rollback the visible value and alert', async () => {
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: false,
+                reason: 'Description is required while a timer is running.'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = '';
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(descriptionInput.value).toBe('Running');
+            expect(showAlert).toHaveBeenCalledWith(
+                'Description is required while a timer is running.',
+                'sky'
+            );
+        });
+    });
+});

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -122,6 +122,31 @@ describe('activity timer ui', () => {
             );
             expect(document.getElementById('timer-elapsed').textContent).toBe(textAfterHide);
         });
+
+        test('showTimerDisplay returns early when required elements are missing', () => {
+            document.getElementById('task-form-fields').remove();
+
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                true
+            );
+        });
+
+        test('showTimerDisplay leaves elapsed text unchanged for invalid timer start times', () => {
+            document.getElementById('timer-elapsed').textContent = 'unchanged';
+
+            showTimerDisplay({
+                description: 'Timer work',
+                startDateTime: 'not-a-date'
+            });
+
+            expect(document.getElementById('timer-description').value).toBe('Timer work');
+            expect(document.getElementById('timer-elapsed').textContent).toBe('unchanged');
+        });
     });
 
     describe('form state', () => {
@@ -230,6 +255,47 @@ describe('activity timer ui', () => {
             expect(handleStopTimer).toHaveBeenCalledTimes(1);
         });
 
+        test('start timer button alerts when description is blank', async () => {
+            document.getElementById('activity').checked = true;
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).not.toHaveBeenCalled();
+            expect(showAlert).toHaveBeenCalledWith(
+                'Please enter a description before starting the timer.',
+                'sky'
+            );
+        });
+
+        test('start timer button uses timer display values when replacing a running timer', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            document.querySelector('#task-form input[name="description"]').value = 'Form value';
+            document.getElementById('timer-description').value = 'Replacement timer';
+            document.getElementById('timer-category').innerHTML =
+                '<option value="break/admin">Admin</option>';
+            document.getElementById('timer-category').value = 'break/admin';
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStartTimer).toHaveBeenCalledWith({
+                description: 'Replacement timer',
+                category: 'break/admin'
+            });
+        });
+
         test('disposing timer UI removes existing listeners until re-initialized', async () => {
             document.getElementById('activity').checked = true;
             document.querySelector('#task-form input[name="description"]').value = 'Feature work';
@@ -261,6 +327,19 @@ describe('activity timer ui', () => {
 
             expect(handleStopTimer).toHaveBeenCalled();
             expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('failed timer stop does not refresh the UI', async () => {
+            handleStopTimer.mockResolvedValueOnce({ success: false, reason: 'No timer running.' });
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(refreshUI).not.toHaveBeenCalled();
         });
 
         test('timer field edits persist running activity changes', async () => {
@@ -355,6 +434,78 @@ describe('activity timer ui', () => {
                 'Description is required while a timer is running.',
                 'sky'
             );
+        });
+
+        test('failed timer category edits rollback the visible value and alert', async () => {
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: false,
+                reason: 'Category update failed.'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const categoryInput = document.getElementById('timer-category');
+            categoryInput.innerHTML =
+                '<option value="work/deep">Deep Work</option><option value="break/admin">Admin</option>';
+            categoryInput.value = 'break/admin';
+            categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(categoryInput.value).toBe('work/deep');
+            expect(showAlert).toHaveBeenCalledWith('Category update failed.', 'sky');
+        });
+
+        test('timer start time changes are ignored without a running activity or time value', async () => {
+            initializeTimerUI({ refreshUI: jest.fn() });
+
+            const startTimeInput = document.getElementById('timer-start-time');
+            startTimeInput.value = '';
+            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(updateRunningActivity).not.toHaveBeenCalled();
+        });
+
+        test('failed timer start time edits rollback the visible value and alert', async () => {
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValueOnce({
+                success: false,
+                reason: 'Start time update failed.'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const startTimeInput = document.getElementById('timer-start-time');
+            startTimeInput.value = '09:15';
+            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            const previousDate = new Date('2026-04-09T10:00:00.000Z');
+            const previousValue = `${String(previousDate.getHours()).padStart(2, '0')}:${String(
+                previousDate.getMinutes()
+            ).padStart(2, '0')}`;
+
+            expect(startTimeInput.value).toBe(previousValue);
+            expect(showAlert).toHaveBeenCalledWith('Start time update failed.', 'sky');
         });
     });
 });

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -26,8 +26,11 @@ import {
 import { handleStartTimer, handleStopTimer } from '../public/js/activities/handlers.js';
 import { getRunningActivity, updateRunningActivity } from '../public/js/activities/manager.js';
 import { showAlert } from '../public/js/modal-manager.js';
+import { logger } from '../public/js/utils.js';
 
 describe('activity timer ui', () => {
+    let infoSpy;
+
     const flushAsyncWork = async (count = 4) => {
         for (let index = 0; index < count; index += 1) {
             await Promise.resolve();
@@ -44,10 +47,12 @@ describe('activity timer ui', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
         getRunningActivity.mockReturnValue(null);
         updateRunningActivity.mockResolvedValue({ success: true });
         handleStartTimer.mockResolvedValue({ success: true });
         handleStopTimer.mockResolvedValue({ success: true });
+        window.history.replaceState({}, '', 'http://localhost/');
         document.body.innerHTML = `
             <input id="scheduled" type="radio" name="task-type" checked />
             <input id="activity" type="radio" name="task-type" />
@@ -82,6 +87,10 @@ describe('activity timer ui', () => {
                 <input type="radio" name="task-type" value="activity" />
             </form>
         `;
+    });
+
+    afterEach(() => {
+        infoSpy.mockRestore();
     });
 
     describe('display state', () => {
@@ -147,6 +156,34 @@ describe('activity timer ui', () => {
             jest.advanceTimersByTime(250);
 
             expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:01');
+        });
+
+        test('timer diagnostics log display sync and periodic elapsed samples', () => {
+            showTimerDisplay({
+                description: 'Timer work',
+                category: 'work/deep',
+                source: 'timer',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            jest.advanceTimersByTime(15000);
+
+            expect(infoSpy).toHaveBeenCalledWith(
+                'timer-debug:show-display',
+                expect.objectContaining({
+                    description: 'Timer work',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-09T10:00:00.000Z'
+                })
+            );
+            expect(infoSpy).toHaveBeenCalledWith(
+                'timer-debug:tick',
+                expect.objectContaining({
+                    displayedElapsed: '01:00:15',
+                    elapsedMs: 3615000,
+                    startDateTime: '2026-04-09T10:00:00.000Z'
+                })
+            );
         });
 
         test('hideTimerDisplay restores the form and stops elapsed updates', () => {

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -52,7 +52,6 @@ describe('activity timer ui', () => {
         updateRunningActivity.mockResolvedValue({ success: true });
         handleStartTimer.mockResolvedValue({ success: true });
         handleStopTimer.mockResolvedValue({ success: true });
-        window.history.replaceState({}, '', 'http://localhost/');
         document.body.innerHTML = `
             <input id="scheduled" type="radio" name="task-type" checked />
             <input id="activity" type="radio" name="task-type" />
@@ -156,34 +155,6 @@ describe('activity timer ui', () => {
             jest.advanceTimersByTime(250);
 
             expect(document.getElementById('timer-elapsed').textContent).toBe('00:00:01');
-        });
-
-        test('timer diagnostics log display sync and periodic elapsed samples', () => {
-            showTimerDisplay({
-                description: 'Timer work',
-                category: 'work/deep',
-                source: 'timer',
-                startDateTime: '2026-04-09T10:00:00.000Z'
-            });
-
-            jest.advanceTimersByTime(15000);
-
-            expect(infoSpy).toHaveBeenCalledWith(
-                'timer-debug:show-display',
-                expect.objectContaining({
-                    description: 'Timer work',
-                    category: 'work/deep',
-                    startDateTime: '2026-04-09T10:00:00.000Z'
-                })
-            );
-            expect(infoSpy).toHaveBeenCalledWith(
-                'timer-debug:tick',
-                expect.objectContaining({
-                    displayedElapsed: '01:00:15',
-                    elapsedMs: 3615000,
-                    startDateTime: '2026-04-09T10:00:00.000Z'
-                })
-            );
         });
 
         test('hideTimerDisplay restores the form and stops elapsed updates', () => {
@@ -341,6 +312,43 @@ describe('activity timer ui', () => {
 
             expect(handleStartTimer).toHaveBeenCalledTimes(1);
             expect(handleStopTimer).toHaveBeenCalledTimes(1);
+        });
+
+        test('registers a one-shot global timer debug helper', () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Running timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                source: 'timer',
+                sourceTaskId: null
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            syncTimerFormState();
+
+            expect(typeof window.dumpTimerDebug).toBe('function');
+
+            const snapshot = window.dumpTimerDebug();
+
+            expect(snapshot).toEqual(
+                expect.objectContaining({
+                    runningActivity: expect.objectContaining({
+                        description: 'Running timer',
+                        category: 'work/deep',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    }),
+                    displayedElapsed: '00:00:00',
+                    isTimerVisible: true
+                })
+            );
+            expect(infoSpy).toHaveBeenCalledWith(
+                'timer-debug:snapshot',
+                expect.objectContaining({
+                    displayedElapsed: '00:00:00',
+                    isTimerVisible: true
+                })
+            );
         });
 
         test('start timer button alerts when description is blank', async () => {

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -28,6 +28,20 @@ import { getRunningActivity, updateRunningActivity } from '../public/js/activiti
 import { showAlert } from '../public/js/modal-manager.js';
 
 describe('activity timer ui', () => {
+    const flushAsyncWork = async (count = 4) => {
+        for (let index = 0; index < count; index += 1) {
+            await Promise.resolve();
+        }
+    };
+    const waitForCondition = async (condition, count = 20) => {
+        for (let index = 0; index < count; index += 1) {
+            if (condition()) {
+                return;
+            }
+            await Promise.resolve();
+        }
+    };
+
     beforeEach(() => {
         jest.clearAllMocks();
         getRunningActivity.mockReturnValue(null);
@@ -39,15 +53,20 @@ describe('activity timer ui', () => {
             <input id="activity" type="radio" name="task-type" />
             <div id="task-form-fields">
                 <div id="time-inputs"></div>
+                <div id="activity-action-group">
+                    <button id="add-task-btn" type="submit">Log Activity</button>
+                    <button id="start-timer-btn" type="button" class="hidden">Start Timer</button>
+                </div>
             </div>
             <div id="timer-display" class="hidden">
                 <input id="timer-description" />
                 <select id="timer-category"></select>
                 <input id="timer-start-time" type="time" />
                 <div id="timer-elapsed"></div>
-                <button id="timer-stop-btn" type="button">Stop</button>
+                <div id="timer-action-group">
+                    <button id="timer-stop-btn" type="button">Stop</button>
+                </div>
             </div>
-            <button id="start-timer-btn" type="button" class="hidden">Start Timer</button>
             <form id="task-form">
                 <input name="description" />
                 <select name="category">
@@ -91,6 +110,11 @@ describe('activity timer ui', () => {
                 ).padStart(2, '0')}`
             );
             expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:00');
+            expect(
+                document
+                    .getElementById('timer-action-group')
+                    .contains(document.getElementById('start-timer-btn'))
+            ).toBe(true);
         });
 
         test('elapsed counter updates while timer is visible', () => {
@@ -121,6 +145,11 @@ describe('activity timer ui', () => {
                 true
             );
             expect(document.getElementById('timer-elapsed').textContent).toBe(textAfterHide);
+            expect(
+                document
+                    .getElementById('activity-action-group')
+                    .contains(document.getElementById('start-timer-btn'))
+            ).toBe(true);
         });
 
         test('showTimerDisplay returns early when required elements are missing', () => {
@@ -224,7 +253,7 @@ describe('activity timer ui', () => {
             document
                 .getElementById('start-timer-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(handleStartTimer).toHaveBeenCalledWith({
                 description: 'Feature work',
@@ -244,12 +273,12 @@ describe('activity timer ui', () => {
             document
                 .getElementById('start-timer-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             document
                 .getElementById('timer-stop-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(handleStartTimer).toHaveBeenCalledTimes(1);
             expect(handleStopTimer).toHaveBeenCalledTimes(1);
@@ -262,7 +291,7 @@ describe('activity timer ui', () => {
             document
                 .getElementById('start-timer-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(handleStartTimer).not.toHaveBeenCalled();
             expect(showAlert).toHaveBeenCalledWith(
@@ -288,12 +317,120 @@ describe('activity timer ui', () => {
             document
                 .getElementById('start-timer-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(handleStartTimer).toHaveBeenCalledWith({
                 description: 'Replacement timer',
                 category: 'break/admin'
             });
+        });
+
+        test('start timer replacement ignores blur-change persistence on the current timer fields', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = 'Replacement timer';
+
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(updateRunningActivity).not.toHaveBeenCalled();
+            expect(handleStartTimer).toHaveBeenCalledWith({
+                description: 'Replacement timer',
+                category: 'work/deep'
+            });
+        });
+
+        test('start timer replacement ignores keyboard-triggered field persistence on the current timer fields', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = 'Replacement timer';
+            document.getElementById('start-timer-btn').focus();
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(updateRunningActivity).not.toHaveBeenCalled();
+            expect(handleStartTimer).toHaveBeenCalledWith({
+                description: 'Replacement timer',
+                category: 'work/deep'
+            });
+        });
+
+        test('failed replacement start re-syncs the running timer display', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            handleStartTimer.mockResolvedValueOnce({
+                success: false,
+                reason: 'Could not start timer.'
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const descriptionInput = document.getElementById('timer-description');
+            const categoryInput = document.getElementById('timer-category');
+            categoryInput.innerHTML =
+                '<option value="work/deep">Deep Work</option><option value="break/admin">Admin</option>';
+            descriptionInput.value = 'Replacement timer';
+            categoryInput.value = 'break/admin';
+
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(descriptionInput.value).toBe('Current timer');
+            expect(categoryInput.value).toBe('work/deep');
+            expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(
+                false
+            );
         });
 
         test('disposing timer UI removes existing listeners until re-initialized', async () => {
@@ -310,7 +447,7 @@ describe('activity timer ui', () => {
             document
                 .getElementById('timer-stop-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(handleStartTimer).not.toHaveBeenCalled();
             expect(handleStopTimer).not.toHaveBeenCalled();
@@ -323,9 +460,58 @@ describe('activity timer ui', () => {
             document
                 .getElementById('timer-stop-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await waitForCondition(() => refreshUI.mock.calls.length > 0);
 
             expect(handleStopTimer).toHaveBeenCalled();
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('stop timer waits for pending timer edits before delegating', async () => {
+            let resolveUpdate;
+            getRunningActivity.mockReturnValue({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveUpdate = () =>
+                            resolve({
+                                success: true,
+                                runningActivity: {
+                                    description: 'Running',
+                                    category: 'work/deep',
+                                    startDateTime: '2026-04-09T09:30:00.000Z'
+                                }
+                            });
+                    })
+            );
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            showTimerDisplay({
+                description: 'Running',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const startTimeInput = document.getElementById('timer-start-time');
+            startTimeInput.value = '09:30';
+            startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+
+            document
+                .getElementById('timer-stop-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await Promise.resolve();
+
+            expect(handleStopTimer).not.toHaveBeenCalled();
+
+            resolveUpdate();
+            await flushAsyncWork(8);
+
+            expect(handleStopTimer).toHaveBeenCalledTimes(1);
             expect(refreshUI).toHaveBeenCalled();
         });
 
@@ -337,7 +523,7 @@ describe('activity timer ui', () => {
             document
                 .getElementById('timer-stop-btn')
                 .dispatchEvent(new Event('click', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(refreshUI).not.toHaveBeenCalled();
         });
@@ -393,7 +579,9 @@ describe('activity timer ui', () => {
             const startTimeInput = document.getElementById('timer-start-time');
             startTimeInput.value = '09:30';
             startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
+            await waitForCondition(
+                () => document.getElementById('timer-elapsed').textContent === '00:30:00'
+            );
 
             const expectedStartDate = new Date('2026-04-09T10:00:00.000Z');
             expectedStartDate.setHours(9, 30, 0, 0);
@@ -427,7 +615,7 @@ describe('activity timer ui', () => {
             const descriptionInput = document.getElementById('timer-description');
             descriptionInput.value = '';
             descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(descriptionInput.value).toBe('Running');
             expect(showAlert).toHaveBeenCalledWith(
@@ -459,7 +647,7 @@ describe('activity timer ui', () => {
                 '<option value="work/deep">Deep Work</option><option value="break/admin">Admin</option>';
             categoryInput.value = 'break/admin';
             categoryInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(categoryInput.value).toBe('work/deep');
             expect(showAlert).toHaveBeenCalledWith('Category update failed.', 'sky');
@@ -471,7 +659,7 @@ describe('activity timer ui', () => {
             const startTimeInput = document.getElementById('timer-start-time');
             startTimeInput.value = '';
             startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork(6);
 
             expect(updateRunningActivity).not.toHaveBeenCalled();
         });
@@ -497,7 +685,7 @@ describe('activity timer ui', () => {
             const startTimeInput = document.getElementById('timer-start-time');
             startTimeInput.value = '09:15';
             startTimeInput.dispatchEvent(new Event('change', { bubbles: true }));
-            await Promise.resolve();
+            await flushAsyncWork();
 
             const previousDate = new Date('2026-04-09T10:00:00.000Z');
             const previousValue = `${String(previousDate.getHours()).padStart(2, '0')}:${String(

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -63,6 +63,11 @@ describe('activity timer ui', () => {
                 <select id="timer-category"></select>
                 <input id="timer-start-time" type="time" />
                 <div id="timer-elapsed"></div>
+                <div id="next-activity-strip">
+                    <input id="next-activity-description" />
+                    <select id="next-activity-category"></select>
+                    <div id="next-activity-action-group"></div>
+                </div>
                 <div id="timer-action-group">
                     <button id="timer-stop-btn" type="button">Stop</button>
                 </div>
@@ -112,9 +117,10 @@ describe('activity timer ui', () => {
             expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:00');
             expect(
                 document
-                    .getElementById('timer-action-group')
+                    .getElementById('next-activity-action-group')
                     .contains(document.getElementById('start-timer-btn'))
             ).toBe(true);
+            expect(document.getElementById('start-timer-btn').textContent).toContain('Start Timer');
         });
 
         test('elapsed counter updates while timer is visible', () => {
@@ -150,6 +156,7 @@ describe('activity timer ui', () => {
                     .getElementById('activity-action-group')
                     .contains(document.getElementById('start-timer-btn'))
             ).toBe(true);
+            expect(document.getElementById('start-timer-btn').textContent).toContain('Start Timer');
         });
 
         test('showTimerDisplay returns early when required elements are missing', () => {
@@ -300,7 +307,7 @@ describe('activity timer ui', () => {
             );
         });
 
-        test('start timer button uses timer display values when replacing a running timer', async () => {
+        test('start next timer uses dedicated next activity values when replacing a running timer', async () => {
             document.getElementById('activity').checked = true;
             getRunningActivity.mockReturnValue({
                 description: 'Current timer',
@@ -308,10 +315,14 @@ describe('activity timer ui', () => {
                 startDateTime: '2026-04-09T10:00:00.000Z'
             });
             document.querySelector('#task-form input[name="description"]').value = 'Form value';
-            document.getElementById('timer-description').value = 'Replacement timer';
+            document.getElementById('timer-description').value = 'Edited current timer';
             document.getElementById('timer-category').innerHTML =
+                '<option value="work/deep">Deep Work</option>';
+            document.getElementById('timer-category').value = 'work/deep';
+            document.getElementById('next-activity-description').value = 'Replacement timer';
+            document.getElementById('next-activity-category').innerHTML =
                 '<option value="break/admin">Admin</option>';
-            document.getElementById('timer-category').value = 'break/admin';
+            document.getElementById('next-activity-category').value = 'break/admin';
 
             initializeTimerUI({ refreshUI: jest.fn() });
             document
@@ -325,7 +336,73 @@ describe('activity timer ui', () => {
             });
         });
 
-        test('start timer replacement ignores blur-change persistence on the current timer fields', async () => {
+        test('editing current timer fields does not mutate the staged next activity draft', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            updateRunningActivity.mockResolvedValue({
+                success: true,
+                runningActivity: {
+                    description: 'Edited current timer',
+                    category: 'work/deep',
+                    startDateTime: '2026-04-09T10:00:00.000Z'
+                }
+            });
+
+            initializeTimerUI({ refreshUI: jest.fn() });
+            showTimerDisplay({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const nextDescriptionInput = document.getElementById('next-activity-description');
+            nextDescriptionInput.value = 'Planned next activity';
+            const descriptionInput = document.getElementById('timer-description');
+            descriptionInput.value = 'Edited current timer';
+            descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(nextDescriptionInput.value).toBe('Planned next activity');
+        });
+
+        test('successful replacement clears the staged next activity draft', async () => {
+            document.getElementById('activity').checked = true;
+            getRunningActivity.mockReturnValue({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+            const refreshUI = jest.fn();
+
+            initializeTimerUI({ refreshUI });
+            showTimerDisplay({
+                description: 'Current timer',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            const nextDescriptionInput = document.getElementById('next-activity-description');
+            const nextCategoryInput = document.getElementById('next-activity-category');
+            nextCategoryInput.innerHTML =
+                '<option value="">No category</option><option value="break/admin">Admin</option>';
+            nextDescriptionInput.value = 'Replacement timer';
+            nextCategoryInput.value = 'break/admin';
+
+            document
+                .getElementById('start-timer-btn')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            await flushAsyncWork(6);
+
+            expect(nextDescriptionInput.value).toBe('');
+            expect(nextCategoryInput.value).toBe('');
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('start next timer ignores blur-change persistence on the current timer fields', async () => {
             document.getElementById('activity').checked = true;
             getRunningActivity.mockReturnValue({
                 description: 'Current timer',
@@ -341,7 +418,9 @@ describe('activity timer ui', () => {
             });
 
             const descriptionInput = document.getElementById('timer-description');
+            const nextDescriptionInput = document.getElementById('next-activity-description');
             descriptionInput.value = 'Replacement timer';
+            nextDescriptionInput.value = 'Planned next timer';
 
             document
                 .getElementById('start-timer-btn')
@@ -354,12 +433,12 @@ describe('activity timer ui', () => {
 
             expect(updateRunningActivity).not.toHaveBeenCalled();
             expect(handleStartTimer).toHaveBeenCalledWith({
-                description: 'Replacement timer',
-                category: 'work/deep'
+                description: 'Planned next timer',
+                category: null
             });
         });
 
-        test('start timer replacement ignores keyboard-triggered field persistence on the current timer fields', async () => {
+        test('start next timer ignores keyboard-triggered field persistence on the current timer fields', async () => {
             document.getElementById('activity').checked = true;
             getRunningActivity.mockReturnValue({
                 description: 'Current timer',
@@ -375,7 +454,9 @@ describe('activity timer ui', () => {
             });
 
             const descriptionInput = document.getElementById('timer-description');
+            const nextDescriptionInput = document.getElementById('next-activity-description');
             descriptionInput.value = 'Replacement timer';
+            nextDescriptionInput.value = 'Planned next timer';
             document.getElementById('start-timer-btn').focus();
             descriptionInput.dispatchEvent(new Event('change', { bubbles: true }));
             document
@@ -385,8 +466,8 @@ describe('activity timer ui', () => {
 
             expect(updateRunningActivity).not.toHaveBeenCalled();
             expect(handleStartTimer).toHaveBeenCalledWith({
-                description: 'Replacement timer',
-                category: 'work/deep'
+                description: 'Planned next timer',
+                category: null
             });
         });
 

--- a/__tests__/activity-timer-ui.test.js
+++ b/__tests__/activity-timer-ui.test.js
@@ -30,6 +30,7 @@ import { logger } from '../public/js/utils.js';
 
 describe('activity timer ui', () => {
     let infoSpy;
+    let originalFetch;
 
     const flushAsyncWork = async (count = 4) => {
         for (let index = 0; index < count; index += 1) {
@@ -48,6 +49,8 @@ describe('activity timer ui', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+        originalFetch = global.fetch;
+        global.fetch = jest.fn();
         getRunningActivity.mockReturnValue(null);
         updateRunningActivity.mockResolvedValue({ success: true });
         handleStartTimer.mockResolvedValue({ success: true });
@@ -90,6 +93,7 @@ describe('activity timer ui', () => {
 
     afterEach(() => {
         infoSpy.mockRestore();
+        global.fetch = originalFetch;
     });
 
     describe('display state', () => {
@@ -314,7 +318,7 @@ describe('activity timer ui', () => {
             expect(handleStopTimer).toHaveBeenCalledTimes(1);
         });
 
-        test('registers a one-shot global timer debug helper', () => {
+        test('registers an async global timer debug helper with corrected timing estimate', async () => {
             document.getElementById('activity').checked = true;
             getRunningActivity.mockReturnValue({
                 description: 'Running timer',
@@ -323,13 +327,20 @@ describe('activity timer ui', () => {
                 source: 'timer',
                 sourceTaskId: null
             });
+            global.fetch.mockResolvedValue({
+                headers: {
+                    get: jest.fn((name) =>
+                        name === 'Date' ? 'Wed, 09 Apr 2026 10:00:05 GMT' : null
+                    )
+                }
+            });
 
             initializeTimerUI({ refreshUI: jest.fn() });
             syncTimerFormState();
 
             expect(typeof window.dumpTimerDebug).toBe('function');
 
-            const snapshot = window.dumpTimerDebug();
+            const snapshot = await window.dumpTimerDebug();
 
             expect(snapshot).toEqual(
                 expect.objectContaining({
@@ -338,13 +349,20 @@ describe('activity timer ui', () => {
                         category: 'work/deep',
                         startDateTime: '2026-04-09T10:00:00.000Z'
                     }),
+                    correctedElapsedMs: 5000,
+                    correctedDisplayedElapsed: '00:00:05',
                     displayedElapsed: '00:00:00',
                     isTimerVisible: true
                 })
             );
+            expect(global.fetch).toHaveBeenCalledWith('http://localhost/', {
+                method: 'HEAD',
+                cache: 'no-store'
+            });
             expect(infoSpy).toHaveBeenCalledWith(
                 'timer-debug:snapshot',
                 expect.objectContaining({
+                    correctedDisplayedElapsed: '00:00:05',
                     displayedElapsed: '00:00:00',
                     isTimerVisible: true
                 })

--- a/__tests__/activity-timer.test.js
+++ b/__tests__/activity-timer.test.js
@@ -10,19 +10,29 @@ jest.mock('../public/js/storage.js', () => ({
     deleteConfig: jest.fn(() => Promise.resolve())
 }));
 
+jest.mock('../public/js/activities/running-activity-repository.js', () => ({
+    loadRunningActivityConfig: jest.fn(() => Promise.resolve(null)),
+    saveRunningActivityConfig: jest.fn(() => Promise.resolve()),
+    deleteRunningActivityConfig: jest.fn(() => Promise.resolve())
+}));
+
 import {
     loadRunningActivity,
     getRunningActivity,
     startTimer,
+    startTimerReplacingCurrent,
     stopTimer,
     stopTimerAt,
     updateRunningActivity,
     resetActivityState,
     getActivityState
 } from '../public/js/activities/manager.js';
-import { putConfig, loadConfig, deleteConfig, putActivity } from '../public/js/storage.js';
-
-const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
+import { putActivity } from '../public/js/storage.js';
+import {
+    loadRunningActivityConfig,
+    saveRunningActivityConfig,
+    deleteRunningActivityConfig
+} from '../public/js/activities/running-activity-repository.js';
 
 describe('Timer state primitives', () => {
     beforeEach(() => {
@@ -48,8 +58,7 @@ describe('Timer state primitives', () => {
 
     describe('loadRunningActivity', () => {
         test('loads running activity from PouchDB config doc', async () => {
-            loadConfig.mockResolvedValueOnce({
-                id: RUNNING_ACTIVITY_CONFIG_ID,
+            loadRunningActivityConfig.mockResolvedValueOnce({
                 description: 'Working on feature',
                 category: 'work/deep',
                 startDateTime: '2026-04-09T10:00:00.000Z'
@@ -65,7 +74,7 @@ describe('Timer state primitives', () => {
         });
 
         test('sets null when no config doc exists', async () => {
-            loadConfig.mockResolvedValueOnce(null);
+            loadRunningActivityConfig.mockResolvedValueOnce(null);
 
             await loadRunningActivity();
 
@@ -112,14 +121,11 @@ describe('startTimer', () => {
     test('persists config doc to PouchDB', async () => {
         await startTimer({ description: 'Test', category: null });
 
-        expect(putConfig).toHaveBeenCalledWith(
-            expect.objectContaining({
-                id: RUNNING_ACTIVITY_CONFIG_ID,
-                description: 'Test',
-                category: null,
-                startDateTime: '2026-04-09T14:00:00.000Z'
-            })
-        );
+        expect(saveRunningActivityConfig).toHaveBeenCalledWith({
+            description: 'Test',
+            category: null,
+            startDateTime: '2026-04-09T14:00:00.000Z'
+        });
     });
 
     test('updates in-memory cache', async () => {
@@ -140,7 +146,7 @@ describe('startTimer', () => {
 
         expect(result.success).toBe(false);
         expect(result.reason).toMatch(/description/i);
-        expect(putConfig).not.toHaveBeenCalled();
+        expect(saveRunningActivityConfig).not.toHaveBeenCalled();
     });
 
     test('rejects when timer is already running', async () => {
@@ -151,7 +157,7 @@ describe('startTimer', () => {
 
         expect(result.success).toBe(false);
         expect(result.reason).toMatch(/already running/i);
-        expect(putConfig).not.toHaveBeenCalled();
+        expect(saveRunningActivityConfig).not.toHaveBeenCalled();
     });
 
     test('defaults category to null when not provided', async () => {
@@ -214,7 +220,7 @@ describe('stopTimer', () => {
         jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
         await stopTimer();
 
-        expect(deleteConfig).toHaveBeenCalledWith(RUNNING_ACTIVITY_CONFIG_ID);
+        expect(deleteRunningActivityConfig).toHaveBeenCalled();
     });
 
     test('clears the in-memory cache', async () => {
@@ -326,12 +332,11 @@ describe('updateRunningActivity', () => {
         expect(result.success).toBe(true);
         expect(result.runningActivity.description).toBe('Updated');
         expect(getRunningActivity().description).toBe('Updated');
-        expect(putConfig).toHaveBeenCalledWith(
-            expect.objectContaining({
-                id: RUNNING_ACTIVITY_CONFIG_ID,
-                description: 'Updated'
-            })
-        );
+        expect(saveRunningActivityConfig).toHaveBeenCalledWith({
+            description: 'Updated',
+            category: null,
+            startDateTime: '2026-04-09T10:00:00.000Z'
+        });
     });
 
     test('updates category on running timer', async () => {
@@ -375,5 +380,73 @@ describe('updateRunningActivity', () => {
 
         expect(result.success).toBe(false);
         expect(result.reason).toMatch(/no timer/i);
+    });
+});
+
+describe('startTimerReplacingCurrent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('starts a new timer without stopping when none is running', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+
+        const result = await startTimerReplacingCurrent({ description: 'First timer' });
+
+        expect(result).toEqual({
+            success: true,
+            runningActivity: {
+                description: 'First timer',
+                category: null,
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            },
+            stoppedActivity: null
+        });
+    });
+
+    test('stops the current timer before starting the next one', async () => {
+        jest.setSystemTime(new Date('2026-04-09T09:30:00.000Z'));
+        await startTimer({ description: 'Current timer' });
+
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        const result = await startTimerReplacingCurrent({ description: 'Next timer' });
+
+        expect(result.success).toBe(true);
+        expect(result.stoppedActivity).toEqual(
+            expect.objectContaining({
+                description: 'Current timer',
+                duration: 30,
+                source: 'timer'
+            })
+        );
+        expect(result.runningActivity).toEqual({
+            description: 'Next timer',
+            category: null,
+            startDateTime: '2026-04-09T10:00:00.000Z'
+        });
+    });
+
+    test('returns the stopped activity when replacement start fails after stopping', async () => {
+        jest.setSystemTime(new Date('2026-04-09T09:30:00.000Z'));
+        await startTimer({ description: 'Current timer' });
+
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        const result = await startTimerReplacingCurrent({ description: '' });
+
+        expect(result).toEqual({
+            success: false,
+            reason: 'Description is required to start a timer.',
+            stoppedActivity: expect.objectContaining({
+                description: 'Current timer',
+                duration: 30,
+                source: 'timer'
+            })
+        });
     });
 });

--- a/__tests__/activity-timer.test.js
+++ b/__tests__/activity-timer.test.js
@@ -16,6 +16,10 @@ jest.mock('../public/js/activities/running-activity-repository.js', () => ({
     deleteRunningActivityConfig: jest.fn(() => Promise.resolve())
 }));
 
+jest.mock('../public/js/tasks/manager.js', () => ({
+    consumeUnscheduledTask: jest.fn(() => ({ success: true }))
+}));
+
 import {
     loadRunningActivity,
     getRunningActivity,
@@ -33,6 +37,7 @@ import {
     saveRunningActivityConfig,
     deleteRunningActivityConfig
 } from '../public/js/activities/running-activity-repository.js';
+import { consumeUnscheduledTask } from '../public/js/tasks/manager.js';
 
 describe('Timer state primitives', () => {
     beforeEach(() => {
@@ -124,7 +129,26 @@ describe('startTimer', () => {
         expect(saveRunningActivityConfig).toHaveBeenCalledWith({
             description: 'Test',
             category: null,
-            startDateTime: '2026-04-09T14:00:00.000Z'
+            startDateTime: '2026-04-09T14:00:00.000Z',
+            source: 'timer',
+            sourceTaskId: null
+        });
+    });
+
+    test('persists linked source task provenance on the running timer config', async () => {
+        await startTimer({
+            description: 'Inbox zero',
+            category: 'break/admin',
+            source: 'auto',
+            sourceTaskId: 'unsched-42'
+        });
+
+        expect(saveRunningActivityConfig).toHaveBeenCalledWith({
+            description: 'Inbox zero',
+            category: 'break/admin',
+            startDateTime: '2026-04-09T14:00:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'unsched-42'
         });
     });
 
@@ -165,6 +189,13 @@ describe('startTimer', () => {
 
         expect(result.runningActivity.category).toBeNull();
     });
+
+    test('defaults provenance to a plain timer when not started from a task', async () => {
+        const result = await startTimer({ description: 'No source task' });
+
+        expect(result.runningActivity.source).toBe('timer');
+        expect(result.runningActivity.sourceTaskId).toBeNull();
+    });
 });
 
 describe('stopTimer', () => {
@@ -193,6 +224,25 @@ describe('stopTimer', () => {
         expect(result.activity.startDateTime).toBe('2026-04-09T10:00:00.000Z');
         expect(result.activity.endDateTime).toBe('2026-04-09T11:30:00.000Z');
         expect(result.activity.duration).toBe(90);
+    });
+
+    test('consumes a linked unscheduled task and preserves auto provenance when timer stops', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({
+            description: 'Inbox cleanup',
+            category: 'break/admin',
+            source: 'auto',
+            sourceTaskId: 'unsched-99'
+        });
+        jest.clearAllMocks();
+
+        jest.setSystemTime(new Date('2026-04-09T10:12:00.000Z'));
+        const result = await stopTimer();
+
+        expect(result.success).toBe(true);
+        expect(result.activity.source).toBe('auto');
+        expect(result.activity.sourceTaskId).toBe('unsched-99');
+        expect(consumeUnscheduledTask).toHaveBeenCalledWith('unsched-99');
     });
 
     test('persists the created activity', async () => {
@@ -256,14 +306,15 @@ describe('stopTimer', () => {
         expect(result.reason).toMatch(/no timer/i);
     });
 
-    test('handles zero-duration timer', async () => {
+    test('rounds sub-minute completed timers up to one minute', async () => {
         jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
         await startTimer({ description: 'Quick' });
 
         const result = await stopTimer();
 
         expect(result.success).toBe(true);
-        expect(result.activity.duration).toBe(0);
+        expect(result.activity.duration).toBe(1);
+        expect(result.activity.endDateTime).toBe('2026-04-09T10:01:00.000Z');
     });
 });
 
@@ -290,7 +341,7 @@ describe('stopTimerAt', () => {
         expect(result.activity.duration).toBe(45);
     });
 
-    test('clamps to zero duration when endDateTime is before startDateTime', async () => {
+    test('clamps invalid timer end times to a one-minute completed activity', async () => {
         jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
         await startTimer({ description: 'Late start' });
 
@@ -298,9 +349,9 @@ describe('stopTimerAt', () => {
         const result = await stopTimerAt('2026-04-09T10:00:00.000Z');
 
         expect(result.success).toBe(true);
-        expect(result.activity.duration).toBe(0);
+        expect(result.activity.duration).toBe(1);
         expect(result.activity.startDateTime).toBe('2026-04-09T10:30:00.000Z');
-        expect(result.activity.endDateTime).toBe('2026-04-09T10:30:00.000Z');
+        expect(result.activity.endDateTime).toBe('2026-04-09T10:31:00.000Z');
     });
 
     test('returns failure when no timer is running', async () => {
@@ -335,7 +386,9 @@ describe('updateRunningActivity', () => {
         expect(saveRunningActivityConfig).toHaveBeenCalledWith({
             description: 'Updated',
             category: null,
-            startDateTime: '2026-04-09T10:00:00.000Z'
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'timer',
+            sourceTaskId: null
         });
     });
 
@@ -404,7 +457,9 @@ describe('startTimerReplacingCurrent', () => {
             runningActivity: {
                 description: 'First timer',
                 category: null,
-                startDateTime: '2026-04-09T10:00:00.000Z'
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                source: 'timer',
+                sourceTaskId: null
             },
             stoppedActivity: null
         });
@@ -428,7 +483,9 @@ describe('startTimerReplacingCurrent', () => {
         expect(result.runningActivity).toEqual({
             description: 'Next timer',
             category: null,
-            startDateTime: '2026-04-09T10:00:00.000Z'
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'timer',
+            sourceTaskId: null
         });
     });
 

--- a/__tests__/activity-timer.test.js
+++ b/__tests__/activity-timer.test.js
@@ -1,0 +1,379 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/storage.js', () => ({
+    putActivity: jest.fn(() => Promise.resolve()),
+    deleteActivity: jest.fn(() => Promise.resolve()),
+    putConfig: jest.fn(() => Promise.resolve()),
+    loadConfig: jest.fn(() => Promise.resolve(null)),
+    deleteConfig: jest.fn(() => Promise.resolve())
+}));
+
+import {
+    loadRunningActivity,
+    getRunningActivity,
+    startTimer,
+    stopTimer,
+    stopTimerAt,
+    updateRunningActivity,
+    resetActivityState,
+    getActivityState
+} from '../public/js/activities/manager.js';
+import { putConfig, loadConfig, deleteConfig, putActivity } from '../public/js/storage.js';
+
+const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
+
+describe('Timer state primitives', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+    });
+
+    describe('getRunningActivity', () => {
+        test('returns null when no timer is running', () => {
+            expect(getRunningActivity()).toBeNull();
+        });
+
+        test('returns a clone, not the internal reference', async () => {
+            await startTimer({ description: 'Test' });
+
+            const first = getRunningActivity();
+            const second = getRunningActivity();
+
+            expect(first).toEqual(second);
+            expect(first).not.toBe(second);
+        });
+    });
+
+    describe('loadRunningActivity', () => {
+        test('loads running activity from PouchDB config doc', async () => {
+            loadConfig.mockResolvedValueOnce({
+                id: RUNNING_ACTIVITY_CONFIG_ID,
+                description: 'Working on feature',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z'
+            });
+
+            await loadRunningActivity();
+
+            const running = getRunningActivity();
+            expect(running).not.toBeNull();
+            expect(running.description).toBe('Working on feature');
+            expect(running.category).toBe('work/deep');
+            expect(running.startDateTime).toBe('2026-04-09T10:00:00.000Z');
+        });
+
+        test('sets null when no config doc exists', async () => {
+            loadConfig.mockResolvedValueOnce(null);
+
+            await loadRunningActivity();
+
+            expect(getRunningActivity()).toBeNull();
+        });
+    });
+
+    describe('resetActivityState', () => {
+        test('clears running timer state', async () => {
+            await startTimer({ description: 'Active timer' });
+            expect(getRunningActivity()).not.toBeNull();
+
+            resetActivityState();
+
+            expect(getRunningActivity()).toBeNull();
+        });
+    });
+});
+
+describe('startTimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T14:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('creates a running activity with correct fields', async () => {
+        const result = await startTimer({
+            description: 'Deep work session',
+            category: 'work/deep'
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.runningActivity.description).toBe('Deep work session');
+        expect(result.runningActivity.category).toBe('work/deep');
+        expect(result.runningActivity.startDateTime).toBe('2026-04-09T14:00:00.000Z');
+    });
+
+    test('persists config doc to PouchDB', async () => {
+        await startTimer({ description: 'Test', category: null });
+
+        expect(putConfig).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: RUNNING_ACTIVITY_CONFIG_ID,
+                description: 'Test',
+                category: null,
+                startDateTime: '2026-04-09T14:00:00.000Z'
+            })
+        );
+    });
+
+    test('updates in-memory cache', async () => {
+        await startTimer({ description: 'Cached' });
+
+        const running = getRunningActivity();
+        expect(running.description).toBe('Cached');
+    });
+
+    test('trims description whitespace', async () => {
+        const result = await startTimer({ description: '  padded  ' });
+
+        expect(result.runningActivity.description).toBe('padded');
+    });
+
+    test('rejects empty description', async () => {
+        const result = await startTimer({ description: '' });
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/description/i);
+        expect(putConfig).not.toHaveBeenCalled();
+    });
+
+    test('rejects when timer is already running', async () => {
+        await startTimer({ description: 'First' });
+        jest.clearAllMocks();
+
+        const result = await startTimer({ description: 'Second' });
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/already running/i);
+        expect(putConfig).not.toHaveBeenCalled();
+    });
+
+    test('defaults category to null when not provided', async () => {
+        const result = await startTimer({ description: 'No cat' });
+
+        expect(result.runningActivity.category).toBeNull();
+    });
+});
+
+describe('stopTimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('creates an activity from the running timer', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Working', category: 'work/deep' });
+
+        jest.setSystemTime(new Date('2026-04-09T11:30:00.000Z'));
+        const result = await stopTimer();
+
+        expect(result.success).toBe(true);
+        expect(result.activity.description).toBe('Working');
+        expect(result.activity.category).toBe('work/deep');
+        expect(result.activity.source).toBe('timer');
+        expect(result.activity.sourceTaskId).toBeNull();
+        expect(result.activity.startDateTime).toBe('2026-04-09T10:00:00.000Z');
+        expect(result.activity.endDateTime).toBe('2026-04-09T11:30:00.000Z');
+        expect(result.activity.duration).toBe(90);
+    });
+
+    test('persists the created activity', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Persist me' });
+        jest.clearAllMocks();
+
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+        await stopTimer();
+
+        expect(putActivity).toHaveBeenCalledWith(
+            expect.objectContaining({
+                description: 'Persist me',
+                duration: 30,
+                source: 'timer'
+            })
+        );
+    });
+
+    test('deletes the config doc', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Test' });
+        jest.clearAllMocks();
+
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+        await stopTimer();
+
+        expect(deleteConfig).toHaveBeenCalledWith(RUNNING_ACTIVITY_CONFIG_ID);
+    });
+
+    test('clears the in-memory cache', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Test' });
+
+        jest.setSystemTime(new Date('2026-04-09T10:05:00.000Z'));
+        await stopTimer();
+
+        expect(getRunningActivity()).toBeNull();
+    });
+
+    test('adds the created activity to state', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Stateful timer' });
+
+        jest.setSystemTime(new Date('2026-04-09T10:05:00.000Z'));
+        await stopTimer();
+
+        expect(getActivityState()).toEqual([
+            expect.objectContaining({
+                description: 'Stateful timer',
+                duration: 5,
+                source: 'timer'
+            })
+        ]);
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await stopTimer();
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/no timer/i);
+    });
+
+    test('handles zero-duration timer', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Quick' });
+
+        const result = await stopTimer();
+
+        expect(result.success).toBe(true);
+        expect(result.activity.duration).toBe(0);
+    });
+});
+
+describe('stopTimerAt', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('stops timer at a specific endDateTime', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Working' });
+
+        jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        const result = await stopTimerAt('2026-04-09T10:45:00.000Z');
+
+        expect(result.success).toBe(true);
+        expect(result.activity.endDateTime).toBe('2026-04-09T10:45:00.000Z');
+        expect(result.activity.duration).toBe(45);
+    });
+
+    test('clamps to zero duration when endDateTime is before startDateTime', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+        await startTimer({ description: 'Late start' });
+
+        jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        const result = await stopTimerAt('2026-04-09T10:00:00.000Z');
+
+        expect(result.success).toBe(true);
+        expect(result.activity.duration).toBe(0);
+        expect(result.activity.startDateTime).toBe('2026-04-09T10:30:00.000Z');
+        expect(result.activity.endDateTime).toBe('2026-04-09T10:30:00.000Z');
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await stopTimerAt('2026-04-09T10:00:00.000Z');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/no timer/i);
+    });
+});
+
+describe('updateRunningActivity', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('updates description on running timer', async () => {
+        await startTimer({ description: 'Original' });
+        jest.clearAllMocks();
+
+        const result = await updateRunningActivity({ description: 'Updated' });
+
+        expect(result.success).toBe(true);
+        expect(result.runningActivity.description).toBe('Updated');
+        expect(getRunningActivity().description).toBe('Updated');
+        expect(putConfig).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: RUNNING_ACTIVITY_CONFIG_ID,
+                description: 'Updated'
+            })
+        );
+    });
+
+    test('updates category on running timer', async () => {
+        await startTimer({ description: 'Test', category: 'work/deep' });
+
+        const result = await updateRunningActivity({ category: 'work/meetings' });
+
+        expect(result.runningActivity.category).toBe('work/meetings');
+    });
+
+    test('updates startDateTime for backdating', async () => {
+        await startTimer({ description: 'Forgot to start' });
+
+        const result = await updateRunningActivity({
+            startDateTime: '2026-04-09T09:30:00.000Z'
+        });
+
+        expect(result.runningActivity.startDateTime).toBe('2026-04-09T09:30:00.000Z');
+    });
+
+    test('trims updated description whitespace', async () => {
+        await startTimer({ description: 'Original' });
+
+        const result = await updateRunningActivity({ description: '  Updated  ' });
+
+        expect(result.success).toBe(true);
+        expect(result.runningActivity.description).toBe('Updated');
+    });
+
+    test('rejects empty description', async () => {
+        await startTimer({ description: 'Valid' });
+
+        const result = await updateRunningActivity({ description: '' });
+
+        expect(result.success).toBe(false);
+        expect(getRunningActivity().description).toBe('Valid');
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await updateRunningActivity({ description: 'No timer' });
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/no timer/i);
+    });
+});

--- a/__tests__/activity-timer.test.js
+++ b/__tests__/activity-timer.test.js
@@ -16,10 +16,6 @@ jest.mock('../public/js/activities/running-activity-repository.js', () => ({
     deleteRunningActivityConfig: jest.fn(() => Promise.resolve())
 }));
 
-jest.mock('../public/js/tasks/manager.js', () => ({
-    consumeUnscheduledTask: jest.fn(() => ({ success: true }))
-}));
-
 import {
     loadRunningActivity,
     getRunningActivity,
@@ -37,7 +33,6 @@ import {
     saveRunningActivityConfig,
     deleteRunningActivityConfig
 } from '../public/js/activities/running-activity-repository.js';
-import { consumeUnscheduledTask } from '../public/js/tasks/manager.js';
 
 describe('Timer state primitives', () => {
     beforeEach(() => {
@@ -226,7 +221,7 @@ describe('stopTimer', () => {
         expect(result.activity.duration).toBe(90);
     });
 
-    test('consumes a linked unscheduled task and preserves auto provenance when timer stops', async () => {
+    test('preserves linked source task provenance when timer stops', async () => {
         jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
         await startTimer({
             description: 'Inbox cleanup',
@@ -242,7 +237,6 @@ describe('stopTimer', () => {
         expect(result.success).toBe(true);
         expect(result.activity.source).toBe('auto');
         expect(result.activity.sourceTaskId).toBe('unsched-99');
-        expect(consumeUnscheduledTask).toHaveBeenCalledWith('unsched-99');
     });
 
     test('persists the created activity', async () => {

--- a/__tests__/app-coordinator.test.js
+++ b/__tests__/app-coordinator.test.js
@@ -24,9 +24,24 @@ jest.mock('../public/js/activities/manager.js', () => ({
         id: 'activity-from-task',
         docType: 'activity',
         description: task.description,
+        startDateTime: task.startDateTime,
+        endDateTime: task.endDateTime,
         source: 'auto',
         sourceTaskId: task.id
-    }))
+    })),
+    getRunningActivity: jest.fn(() => null),
+    stopTimerAt: jest.fn(() =>
+        Promise.resolve({
+            success: true,
+            activity: {
+                id: 'activity-timer-stop',
+                docType: 'activity',
+                description: 'Stopped timer',
+                source: 'timer',
+                sourceTaskId: null
+            }
+        })
+    )
 }));
 
 jest.mock('../public/js/settings-manager.js', () => ({
@@ -49,7 +64,12 @@ jest.mock('../public/js/tasks/manager.js', () => ({
 }));
 
 import * as appCoordinator from '../public/js/app-coordinator.js';
-import { addActivity, createActivityFromTask } from '../public/js/activities/manager.js';
+import {
+    addActivity,
+    createActivityFromTask,
+    getRunningActivity,
+    stopTimerAt
+} from '../public/js/activities/manager.js';
 import { refreshUI, updateStartTimeField } from '../public/js/dom-renderer.js';
 import { isActivitiesEnabled } from '../public/js/settings-manager.js';
 import { triggerConfettiAnimation } from '../public/js/tasks/scheduled-renderer.js';
@@ -203,6 +223,120 @@ describe('app-coordinator', () => {
         expect(triggerConfettiAnimation).toHaveBeenCalledWith('task-10');
         expect(createActivityFromTask).not.toHaveBeenCalled();
         expect(addActivity).not.toHaveBeenCalled();
+    });
+
+    test('onTaskCompleted stops a running timer when the auto-log overlaps it', async () => {
+        isActivitiesEnabled.mockReturnValue(true);
+        getRunningActivity.mockReturnValue({
+            description: 'Running timer',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T09:45:00.000Z'
+        });
+        addActivity.mockResolvedValueOnce({
+            success: true,
+            activity: {
+                id: 'activity-from-task',
+                docType: 'activity',
+                description: 'Write notes',
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                endDateTime: '2026-04-09T10:30:00.000Z',
+                source: 'auto',
+                sourceTaskId: 'task-overlap'
+            }
+        });
+        createActivityFromTask.mockReturnValue({
+            id: 'activity-from-task',
+            docType: 'activity',
+            description: 'Write notes',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            endDateTime: '2026-04-09T10:30:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'task-overlap'
+        });
+
+        appCoordinator.onTaskCompleted({
+            task: { id: 'task-overlap', type: 'scheduled', description: 'Write notes' }
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(stopTimerAt).toHaveBeenCalledWith('2026-04-09T10:00:00.000Z');
+        expect(refreshUI).toHaveBeenCalledTimes(3);
+    });
+
+    test('onTaskCompleted leaves a running timer alone when the auto-log does not overlap it', async () => {
+        isActivitiesEnabled.mockReturnValue(true);
+        getRunningActivity.mockReturnValue({
+            description: 'Running timer',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T11:30:00.000Z'
+        });
+        addActivity.mockResolvedValueOnce({
+            success: true,
+            activity: {
+                id: 'activity-from-task',
+                docType: 'activity',
+                description: 'Write notes',
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                endDateTime: '2026-04-09T10:30:00.000Z',
+                source: 'auto',
+                sourceTaskId: 'task-no-overlap'
+            }
+        });
+        createActivityFromTask.mockReturnValue({
+            id: 'activity-from-task',
+            docType: 'activity',
+            description: 'Write notes',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            endDateTime: '2026-04-09T10:30:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'task-no-overlap'
+        });
+
+        appCoordinator.onTaskCompleted({
+            task: { id: 'task-no-overlap', type: 'scheduled', description: 'Write notes' }
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(stopTimerAt).not.toHaveBeenCalled();
+        expect(refreshUI).toHaveBeenCalledTimes(2);
+    });
+
+    test('onTaskCompleted does not stop a timer when the ranges only touch at the boundary', async () => {
+        isActivitiesEnabled.mockReturnValue(true);
+        getRunningActivity.mockReturnValue({
+            description: 'Running timer',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T10:30:00.000Z'
+        });
+        addActivity.mockResolvedValueOnce({
+            success: true,
+            activity: {
+                id: 'activity-from-task',
+                docType: 'activity',
+                description: 'Write notes',
+                startDateTime: '2026-04-09T10:00:00.000Z',
+                endDateTime: '2026-04-09T10:30:00.000Z',
+                source: 'auto',
+                sourceTaskId: 'task-touching'
+            }
+        });
+        createActivityFromTask.mockReturnValue({
+            id: 'activity-from-task',
+            docType: 'activity',
+            description: 'Write notes',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            endDateTime: '2026-04-09T10:30:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'task-touching'
+        });
+
+        appCoordinator.onTaskCompleted({
+            task: { id: 'task-touching', type: 'scheduled', description: 'Write notes' }
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(stopTimerAt).not.toHaveBeenCalled();
+        expect(refreshUI).toHaveBeenCalledTimes(2);
     });
 
     test('onTaskCompleted ignores missing task payloads', () => {

--- a/__tests__/app-lifecycle.test.js
+++ b/__tests__/app-lifecycle.test.js
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createRoomSessionLifecycle } from '../public/js/app-lifecycle.js';
+
+describe('app room/session lifecycle', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-21T23:59:58'));
+        document.body.innerHTML = '<div id="sync-status-text"></div>';
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    function createLifecycle(overrides = {}) {
+        const deps = {
+            loadAppState: jest.fn(async () => {}),
+            refreshUI: jest.fn(),
+            getActivitiesEnabled: jest.fn(() => true),
+            syncRestoredRunningTimer: jest.fn(),
+            getTaskState: jest.fn(() => []),
+            refreshActiveTaskColor: jest.fn(),
+            refreshCurrentGapHighlight: jest.fn(),
+            refreshStartTimeField: jest.fn(),
+            getRunningActivity: jest.fn(() => null),
+            stopTimerAt: jest.fn(async () => ({ success: true })),
+            syncTimerFormState: jest.fn(),
+            refreshTaskDisplays: jest.fn(),
+            onSyncStatusChange: jest.fn(() => jest.fn()),
+            updateSyncStatusUI: jest.fn(),
+            triggerSync: jest.fn(async () => {}),
+            logger: {
+                error: jest.fn()
+            },
+            ...overrides
+        };
+
+        return {
+            deps,
+            lifecycle: createRoomSessionLifecycle(deps)
+        };
+    }
+
+    test('dedupes overlapping storage refreshes and re-syncs restored timer state', async () => {
+        let resolveLoadAppState;
+        const pendingLoadAppState = new Promise((resolve) => {
+            resolveLoadAppState = resolve;
+        });
+        const { deps, lifecycle } = createLifecycle({
+            loadAppState: jest.fn(() => pendingLoadAppState)
+        });
+
+        const firstRefresh = lifecycle.refreshFromStorage();
+        const secondRefresh = lifecycle.refreshFromStorage();
+
+        expect(deps.loadAppState).toHaveBeenCalledTimes(1);
+
+        resolveLoadAppState();
+        await firstRefresh;
+        await secondRefresh;
+
+        expect(deps.refreshUI).toHaveBeenCalledTimes(1);
+        expect(deps.syncRestoredRunningTimer).toHaveBeenCalledWith(true);
+        expect(deps.refreshActiveTaskColor).toHaveBeenCalledWith([]);
+        expect(deps.refreshCurrentGapHighlight).toHaveBeenCalledTimes(1);
+    });
+
+    test('wires sync status updates and refreshes after sync completion', async () => {
+        let syncStatusCallback;
+        const unsubscribe = jest.fn();
+        const { deps, lifecycle } = createLifecycle({
+            onSyncStatusChange: jest.fn((callback) => {
+                syncStatusCallback = callback;
+                return unsubscribe;
+            })
+        });
+
+        const abortController = new AbortController();
+        lifecycle.start({ signal: abortController.signal });
+
+        deps.loadAppState.mockClear();
+        syncStatusCallback('synced');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.updateSyncStatusUI).toHaveBeenCalledWith('synced');
+        expect(deps.loadAppState).toHaveBeenCalledTimes(1);
+
+        lifecycle.stop();
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    test('refreshes from storage on visibility changes and triggers sync on focus', async () => {
+        const { deps, lifecycle } = createLifecycle();
+        const abortController = new AbortController();
+
+        lifecycle.start({ signal: abortController.signal });
+
+        deps.loadAppState.mockClear();
+        Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+        document.dispatchEvent(new Event('visibilitychange'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.loadAppState).toHaveBeenCalledTimes(1);
+
+        window.dispatchEvent(new Event('focus'));
+        await Promise.resolve();
+
+        expect(deps.triggerSync).toHaveBeenCalledWith({ respectCooldown: true });
+    });
+
+    test('runs the clock tick loop and stops a running timer at midnight', async () => {
+        const currentTime = new Date('2026-04-21T23:59:59');
+        jest.setSystemTime(currentTime);
+        const expectedBoundary = new Date('2026-04-22T00:00:00');
+        expectedBoundary.setHours(0, 0, 0, 0);
+
+        const { deps, lifecycle } = createLifecycle({
+            getRunningActivity: jest.fn(() => ({
+                description: 'Running timer',
+                startDateTime: '2026-04-21T23:30:00.000Z'
+            }))
+        });
+        const abortController = new AbortController();
+
+        lifecycle.start({ signal: abortController.signal });
+
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.stopTimerAt).toHaveBeenCalledWith(expectedBoundary.toISOString());
+        expect(deps.syncTimerFormState).toHaveBeenCalledTimes(1);
+        expect(deps.refreshTaskDisplays).toHaveBeenCalledTimes(1);
+        expect(deps.refreshStartTimeField).toHaveBeenCalledTimes(1);
+    });
+});

--- a/__tests__/app-lifecycle.test.js
+++ b/__tests__/app-lifecycle.test.js
@@ -128,14 +128,22 @@ describe('app room/session lifecycle', () => {
         const abortController = new AbortController();
 
         lifecycle.start({ signal: abortController.signal });
+        deps.loadAppState.mockClear();
+        deps.refreshUI.mockClear();
+        deps.syncRestoredRunningTimer.mockClear();
+        deps.syncTimerFormState.mockClear();
+        deps.refreshTaskDisplays.mockClear();
 
         jest.advanceTimersByTime(1000);
         await Promise.resolve();
         await Promise.resolve();
 
         expect(deps.stopTimerAt).toHaveBeenCalledWith(expectedBoundary.toISOString());
-        expect(deps.syncTimerFormState).toHaveBeenCalledTimes(1);
-        expect(deps.refreshTaskDisplays).toHaveBeenCalledTimes(1);
+        expect(deps.loadAppState).toHaveBeenCalledTimes(1);
+        expect(deps.refreshUI).toHaveBeenCalledTimes(1);
+        expect(deps.syncRestoredRunningTimer).toHaveBeenCalledWith(true);
+        expect(deps.syncTimerFormState).not.toHaveBeenCalled();
+        expect(deps.refreshTaskDisplays).not.toHaveBeenCalled();
         expect(deps.refreshStartTimeField).toHaveBeenCalledTimes(1);
     });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -375,6 +375,22 @@ describe('App.js Callback Functions', () => {
             expect(mockSyncTimerFormState).toHaveBeenCalled();
         });
 
+        test('when a timer is restored on boot, app selects activity mode before syncing timer UI', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+            mockLoadRunningActivity.mockResolvedValue({
+                description: 'Persisted timer',
+                startDateTime: '2026-04-09T09:00:00.000Z'
+            });
+            mockGetRunningActivity.mockReturnValue({
+                description: 'Persisted timer',
+                startDateTime: '2026-04-09T09:00:00.000Z'
+            });
+
+            await setupAppWithTasks([]);
+
+            expect(document.getElementById('activity').checked).toBe(true);
+        });
+
         test('activity mode submits through the activity handler and uses activity UI state', async () => {
             mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -41,9 +41,19 @@ jest.mock('../public/js/sync-manager.js', () => ({
 }));
 jest.mock('../public/js/activities/manager.js', () => ({
     loadActivitiesState: jest.fn(() => Promise.resolve([])),
+    loadRunningActivity: jest.fn(() => Promise.resolve(null)),
+    getRunningActivity: jest.fn(() => null),
     getActivityState: jest.fn(() => []),
     getTodaysActivities: jest.fn(() => [])
 }));
+jest.mock('../public/js/activities/ui-handlers.js', () => {
+    const actual = jest.requireActual('../public/js/activities/ui-handlers.js');
+    return {
+        ...actual,
+        initializeTimerUI: jest.fn(),
+        syncTimerFormState: jest.fn()
+    };
+});
 jest.mock('../public/js/activities/renderer.js', () => ({
     renderActivities: jest.fn()
 }));
@@ -70,9 +80,15 @@ import {
 } from '../public/js/sync-manager.js';
 import {
     loadActivitiesState as mockLoadActivitiesStateInternal,
+    loadRunningActivity as mockLoadRunningActivityInternal,
+    getRunningActivity as mockGetRunningActivityInternal,
     getActivityState as mockGetActivityStateInternal,
     getTodaysActivities as mockGetTodaysActivitiesInternal
 } from '../public/js/activities/manager.js';
+import {
+    initializeTimerUI as mockInitializeTimerUIInternal,
+    syncTimerFormState as mockSyncTimerFormStateInternal
+} from '../public/js/activities/ui-handlers.js';
 import { renderActivities as mockRenderActivitiesInternal } from '../public/js/activities/renderer.js';
 import {
     handleAddActivity as mockHandleAddActivityInternal,
@@ -94,8 +110,12 @@ const mockLoadConfig = jest.mocked(mockLoadConfigInternal);
 const mockOnSyncStatusChange = jest.mocked(mockOnSyncStatusChangeInternal);
 const mockTriggerSync = jest.mocked(mockTriggerSyncInternal);
 const mockLoadActivitiesState = jest.mocked(mockLoadActivitiesStateInternal);
+const mockLoadRunningActivity = jest.mocked(mockLoadRunningActivityInternal);
+const mockGetRunningActivity = jest.mocked(mockGetRunningActivityInternal);
 const mockGetActivityState = jest.mocked(mockGetActivityStateInternal);
 const mockGetTodaysActivities = jest.mocked(mockGetTodaysActivitiesInternal);
+const mockInitializeTimerUI = jest.mocked(mockInitializeTimerUIInternal);
+const mockSyncTimerFormState = jest.mocked(mockSyncTimerFormStateInternal);
 const mockRenderActivities = jest.mocked(mockRenderActivitiesInternal);
 const mockHandleAddActivity = jest.mocked(mockHandleAddActivityInternal);
 const mockHandleEditActivity = jest.mocked(mockHandleEditActivityInternal);
@@ -168,8 +188,12 @@ describe('App.js Callback Functions', () => {
         mockLoadConfig.mockResolvedValue(null);
         mockPutConfig.mockResolvedValue(undefined);
         mockLoadActivitiesState.mockResolvedValue([]);
+        mockLoadRunningActivity.mockResolvedValue(null);
+        mockGetRunningActivity.mockReturnValue(null);
         mockGetActivityState.mockReturnValue([]);
         mockRenderActivities.mockClear();
+        mockInitializeTimerUI.mockClear();
+        mockSyncTimerFormState.mockClear();
         mockHandleAddActivity.mockClear();
         mockHandleEditActivity.mockClear();
         mockHandleDeleteActivity.mockClear();
@@ -326,6 +350,26 @@ describe('App.js Callback Functions', () => {
             expect(
                 document.getElementById('activities-container')?.classList.contains('hidden')
             ).toBe(false);
+        });
+
+        test('when a timer is restored on boot, app loads it and initializes timer UI', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+            mockLoadRunningActivity.mockResolvedValue({
+                description: 'Persisted timer',
+                startDateTime: '2026-04-09T09:00:00.000Z'
+            });
+            mockGetRunningActivity.mockReturnValue({
+                description: 'Persisted timer',
+                startDateTime: '2026-04-09T09:00:00.000Z'
+            });
+
+            await setupAppWithTasks([]);
+
+            expect(mockLoadRunningActivity).toHaveBeenCalled();
+            expect(mockInitializeTimerUI).toHaveBeenCalledWith({
+                refreshUI: expect.any(Function)
+            });
+            expect(mockSyncTimerFormState).toHaveBeenCalled();
         });
 
         test('activity mode submits through the activity handler and uses activity UI state', async () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -46,13 +46,15 @@ jest.mock('../public/js/activities/manager.js', () => ({
     getActivityState: jest.fn(() => []),
     getTodaysActivities: jest.fn(() => [])
 }));
+jest.mock('../public/js/activities/timer-ui.js', () => ({
+    hideTimerDisplay: jest.fn(),
+    disposeTimerUI: jest.fn(),
+    initializeTimerUI: jest.fn(),
+    syncTimerFormState: jest.fn()
+}));
 jest.mock('../public/js/activities/ui-handlers.js', () => {
     const actual = jest.requireActual('../public/js/activities/ui-handlers.js');
-    return {
-        ...actual,
-        initializeTimerUI: jest.fn(),
-        syncTimerFormState: jest.fn()
-    };
+    return actual;
 });
 jest.mock('../public/js/activities/renderer.js', () => ({
     renderActivities: jest.fn()
@@ -88,7 +90,7 @@ import {
 import {
     initializeTimerUI as mockInitializeTimerUIInternal,
     syncTimerFormState as mockSyncTimerFormStateInternal
-} from '../public/js/activities/ui-handlers.js';
+} from '../public/js/activities/timer-ui.js';
 import { renderActivities as mockRenderActivitiesInternal } from '../public/js/activities/renderer.js';
 import {
     handleAddActivity as mockHandleAddActivityInternal,

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -528,6 +528,9 @@ describe('App.js Callback Functions', () => {
             activityList
                 .querySelector('.btn-delete-activity')
                 .dispatchEvent(new Event('click', { bubbles: true }));
+            activityList
+                .querySelector('.btn-delete-activity')
+                .dispatchEvent(new Event('click', { bubbles: true }));
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(mockHandleSaveActivityEdit).toHaveBeenCalledWith(
@@ -623,6 +626,9 @@ describe('App.js Callback Functions', () => {
             `;
             activityList
                 .querySelector('.btn-save-activity-edit span')
+                .dispatchEvent(new Event('click', { bubbles: true }));
+            activityList
+                .querySelector('.btn-delete-activity span')
                 .dispatchEvent(new Event('click', { bubbles: true }));
             activityList
                 .querySelector('.btn-delete-activity span')

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -183,6 +183,7 @@ describe('App.js Callback Functions', () => {
     beforeEach(async () => {
         // Reset DOM and app state
         document.body.innerHTML = '';
+        window.alert = jest.fn();
         clearLocalStorage();
         jest.clearAllMocks();
         resetEventDelegation();
@@ -617,6 +618,9 @@ describe('App.js Callback Functions', () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(mockHandleAddActivity).not.toHaveBeenCalled();
+            expect(window.alert).toHaveBeenCalledWith(
+                'Alert: Activity description cannot be empty.'
+            );
             expect(document.activeElement).toBe(descriptionInput);
             expect(activityRadio.checked).toBe(true);
             expect(addTaskButton.textContent).toContain('Log Activity');

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -44,7 +44,8 @@ jest.mock('../public/js/activities/manager.js', () => ({
     loadRunningActivity: jest.fn(() => Promise.resolve(null)),
     getRunningActivity: jest.fn(() => null),
     getActivityState: jest.fn(() => []),
-    getTodaysActivities: jest.fn(() => [])
+    getTodaysActivities: jest.fn(() => []),
+    getSuggestedActivityStartTime: jest.fn(() => null)
 }));
 jest.mock('../public/js/activities/timer-ui.js', () => ({
     hideTimerDisplay: jest.fn(),

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -430,6 +430,31 @@ describe('App.js Callback Functions', () => {
             expect(descriptionInput.getAttribute('placeholder')).toBe('What did you work on?');
         });
 
+        test('activity mode keeps the activity button label when time inputs change', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityRadio = document.getElementById('activity');
+            const startTimeInput = document.querySelector('#task-form input[name="start-time"]');
+            const durationHoursInput = document.querySelector(
+                '#task-form input[name="duration-hours"]'
+            );
+            const addTaskButton = document.getElementById('add-task-btn');
+            const overlapWarning = document.getElementById('overlap-warning');
+
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+            startTimeInput.value = '10:00';
+            startTimeInput.dispatchEvent(new Event('input', { bubbles: true }));
+            durationHoursInput.value = '1';
+            durationHoursInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+            expect(addTaskButton.textContent).toContain('Log Activity');
+            expect(overlapWarning.textContent).toBe('');
+        });
+
         test('activity list delegates inline activity save and delete controls to the activity handlers', async () => {
             mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
 
@@ -499,6 +524,39 @@ describe('App.js Callback Functions', () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(mockHandleSaveActivityEdit).not.toHaveBeenCalled();
+        });
+
+        test('pressing Enter in an activity inline edit form saves the edit', async () => {
+            mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+
+            await setupAppWithTasks([]);
+
+            const activityList = document.getElementById('activity-list');
+            activityList.innerHTML = `
+                <form class="activity-inline-edit-form" data-activity-id="activity-43" data-activity-date="2026-04-07">
+                    <input name="description" value="Updated activity" />
+                    <input name="start-time" value="09:00" />
+                    <input name="duration-hours" value="1" />
+                    <input name="duration-minutes" value="0" />
+                    <select name="category"></select>
+                    <button type="submit" class="btn-save-activity-edit">Save</button>
+                </form>
+            `;
+
+            activityList.querySelector('input[name="description"]').dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    key: 'Enter',
+                    code: 'Enter',
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockHandleSaveActivityEdit).toHaveBeenCalledWith(
+                'activity-43',
+                expect.any(HTMLFormElement)
+            );
         });
 
         test('activity actions can resolve ids from the ancestor activity element', async () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -42,6 +42,7 @@ jest.mock('../public/js/sync-manager.js', () => ({
 jest.mock('../public/js/activities/manager.js', () => ({
     loadActivitiesState: jest.fn(() => Promise.resolve([])),
     loadRunningActivity: jest.fn(() => Promise.resolve(null)),
+    stopTimerAt: jest.fn(() => Promise.resolve({ success: true })),
     getRunningActivity: jest.fn(() => null),
     getActivityState: jest.fn(() => []),
     getTodaysActivities: jest.fn(() => []),
@@ -86,6 +87,7 @@ import {
 import {
     loadActivitiesState as mockLoadActivitiesStateInternal,
     loadRunningActivity as mockLoadRunningActivityInternal,
+    stopTimerAt as mockStopTimerAtInternal,
     getRunningActivity as mockGetRunningActivityInternal,
     getActivityState as mockGetActivityStateInternal,
     getTodaysActivities as mockGetTodaysActivitiesInternal
@@ -116,6 +118,7 @@ const mockOnSyncStatusChange = jest.mocked(mockOnSyncStatusChangeInternal);
 const mockTriggerSync = jest.mocked(mockTriggerSyncInternal);
 const mockLoadActivitiesState = jest.mocked(mockLoadActivitiesStateInternal);
 const mockLoadRunningActivity = jest.mocked(mockLoadRunningActivityInternal);
+const mockStopTimerAt = jest.mocked(mockStopTimerAtInternal);
 const mockGetRunningActivity = jest.mocked(mockGetRunningActivityInternal);
 const mockGetActivityState = jest.mocked(mockGetActivityStateInternal);
 const mockGetTodaysActivities = jest.mocked(mockGetTodaysActivitiesInternal);
@@ -393,6 +396,37 @@ describe('App.js Callback Functions', () => {
             await setupAppWithTasks([]);
 
             expect(document.getElementById('activity').checked).toBe(true);
+        });
+
+        test('stops a running timer at midnight boundary', async () => {
+            jest.useFakeTimers();
+            try {
+                jest.setSystemTime(new Date('2026-04-09T23:59:59'));
+                mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+                mockLoadRunningActivity.mockResolvedValue({
+                    description: 'Late timer',
+                    startDateTime: '2026-04-09T23:00:00.000Z'
+                });
+                mockGetRunningActivity.mockReturnValue({
+                    description: 'Late timer',
+                    startDateTime: '2026-04-09T23:00:00.000Z'
+                });
+                mockStopTimerAt.mockResolvedValue({ success: true });
+
+                const setupPromise = setupAppWithTasks([]);
+                await Promise.resolve();
+                await jest.runOnlyPendingTimersAsync();
+                await setupPromise;
+
+                await jest.advanceTimersByTimeAsync(1000);
+
+                const expectedMidnight = new Date('2026-04-10T00:00:00');
+
+                expect(mockStopTimerAt).toHaveBeenCalledWith(expectedMidnight.toISOString());
+                expect(mockSyncTimerFormState).toHaveBeenCalled();
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         test('activity mode submits through the activity handler and uses activity UI state', async () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1705,6 +1705,41 @@ describe('App.js Callback Functions', () => {
                 expect(mockSaveTasks).not.toHaveBeenCalled();
             });
 
+            test('should re-sync the timer ui when a running timer changes after sync completes', async () => {
+                const initialTasks = [
+                    createTaskWithDateTime({
+                        description: 'Local Task',
+                        startTime: '09:00',
+                        duration: 60
+                    })
+                ];
+
+                mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+                await setupAppWithTasks(initialTasks);
+
+                const syncStatusCallback = mockOnSyncStatusChange.mock.calls.at(-1)?.[0];
+                expect(syncStatusCallback).toEqual(expect.any(Function));
+
+                mockSyncTimerFormState.mockClear();
+                mockLoadConfig.mockResolvedValue({ activitiesEnabled: true });
+                mockLoadRunningActivity.mockImplementation(async () => {
+                    mockGetRunningActivity.mockReturnValue({
+                        description: 'Synced timer',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    });
+                    return {
+                        description: 'Synced timer',
+                        startDateTime: '2026-04-09T10:00:00.000Z'
+                    };
+                });
+
+                syncStatusCallback('synced');
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                expect(document.getElementById('activity').checked).toBe(true);
+                expect(mockSyncTimerFormState).toHaveBeenCalledTimes(1);
+            });
+
             test('should refresh tasks from storage when the tab becomes visible again', async () => {
                 const initialTasks = [
                     createTaskWithDateTime({

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -45,6 +45,7 @@ jest.mock('../public/js/activities/manager.js', () => ({
     getRunningActivity: jest.fn(() => null),
     getActivityState: jest.fn(() => []),
     getTodaysActivities: jest.fn(() => []),
+    getLiveTodayActivitySummary: jest.fn(() => null),
     getSuggestedActivityStartTime: jest.fn(() => null)
 }));
 jest.mock('../public/js/activities/timer-ui.js', () => ({
@@ -58,7 +59,8 @@ jest.mock('../public/js/activities/ui-handlers.js', () => {
     return actual;
 });
 jest.mock('../public/js/activities/renderer.js', () => ({
-    renderActivities: jest.fn()
+    renderActivities: jest.fn(),
+    renderActivitySummaryOnly: jest.fn()
 }));
 jest.mock('../public/js/activities/handlers.js', () => ({
     handleAddActivity: jest.fn(() => Promise.resolve()),
@@ -371,7 +373,8 @@ describe('App.js Callback Functions', () => {
 
             expect(mockLoadRunningActivity).toHaveBeenCalled();
             expect(mockInitializeTimerUI).toHaveBeenCalledWith({
-                refreshUI: expect.any(Function)
+                refreshUI: expect.any(Function),
+                refreshActivitySummary: expect.any(Function)
             });
             expect(mockSyncTimerFormState).toHaveBeenCalled();
         });

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -53,30 +53,45 @@ describe('DOM Handler Interaction Tests', () => {
                     <div class="form-group">
                         <input type="text" name="description" placeholder="Task description" required />
                     </div>
+                    <div id="category-dropdown-row">
+                        <span id="category-color-indicator"></span>
+                        <select name="category" id="category-select">
+                            <option value="">No category</option>
+                        </select>
+                    </div>
                     <div class="task-type-toggle">
                         <input type="radio" id="scheduled" name="task-type" value="scheduled" checked />
                         <label for="scheduled">Scheduled</label>
                         <input type="radio" id="unscheduled" name="task-type" value="unscheduled" />
                         <label for="unscheduled">Unscheduled</label>
-                    </div>
-                    <div id="time-inputs">
-                        <div class="form-group">
-                            <input type="time" name="start-time" required />
-                        </div>
-                        <div class="form-group">
-                            <input type="number" name="duration-hours" min="0" value="1" />
-                            <input type="number" name="duration-minutes" min="0" max="59" value="00" />
+                        <div id="activity-toggle-option">
+                            <input type="radio" id="activity" name="task-type" value="activity" />
+                            <label for="activity">Activity</label>
                         </div>
                     </div>
-                    <div id="priority-input" style="display: none;">
-                        <select name="priority">
-                            <option value="medium">Medium</option>
-                            <option value="high">High</option>
-                            <option value="low">Low</option>
-                        </select>
-                        <input type="number" name="est-duration" placeholder="Est. minutes" />
+                    <div id="task-form-main-row">
+                        <div>
+                            <div id="time-inputs">
+                                <div class="form-group">
+                                    <input type="time" name="start-time" required />
+                                </div>
+                                <div class="form-group">
+                                    <input type="number" name="duration-hours" min="0" value="1" />
+                                    <input type="number" name="duration-minutes" min="0" max="59" value="00" />
+                                </div>
+                            </div>
+                            <div id="priority-input" style="display: none;">
+                                <select name="priority">
+                                    <option value="medium">Medium</option>
+                                    <option value="high">High</option>
+                                    <option value="low">Low</option>
+                                </select>
+                                <input type="number" name="est-duration" placeholder="Est. minutes" />
+                            </div>
+                        </div>
+                        <button type="submit" id="add-task-btn">Add Task</button>
+                        <button id="start-timer-btn" type="button" class="hidden">Start Timer</button>
                     </div>
-                    <button type="submit">Add Task</button>
                 </form>
                 <div id="scheduled-task-list" class="task-list"></div>
                 <div id="unscheduled-task-list" class="unscheduled-task-list"></div>
@@ -1200,6 +1215,42 @@ describe('DOM Handler Interaction Tests', () => {
                 taskForm.dispatchEvent(new Event('submit'));
                 taskForm.dispatchEvent(new Event('submit'));
             }).not.toThrow();
+        });
+
+        test('switching to activity keeps the category color indicator visible', () => {
+            const activityRadio = document.getElementById('activity');
+            const scheduledRadio = document.getElementById('scheduled');
+            const categoryIndicator = document.getElementById('category-color-indicator');
+
+            if (!(activityRadio instanceof HTMLInputElement)) {
+                throw new Error('Activity radio not found');
+            }
+
+            scheduledRadio.checked = true;
+            scheduledRadio.dispatchEvent(new Event('change', { bubbles: true }));
+            expect(categoryIndicator.classList.contains('hidden')).toBe(false);
+
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+            expect(categoryIndicator.classList.contains('hidden')).toBe(false);
+        });
+
+        test('switching task type toggles activity mode on the shared production row', () => {
+            const taskForm = document.getElementById('task-form');
+            const activityRadio = document.getElementById('activity');
+            const scheduledRadio = document.getElementById('scheduled');
+            const startTimerButton = document.getElementById('start-timer-btn');
+
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+            expect(taskForm.classList.contains('task-form--activity')).toBe(true);
+            expect(startTimerButton.classList.contains('hidden')).toBe(false);
+
+            scheduledRadio.checked = true;
+            scheduledRadio.dispatchEvent(new Event('change', { bubbles: true }));
+            expect(taskForm.classList.contains('task-form--activity')).toBe(false);
+            expect(startTimerButton.classList.contains('hidden')).toBe(true);
         });
     });
 

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -921,6 +921,7 @@ describe('DOM Handler Interaction Tests', () => {
                 onEditUnscheduledTask: jest.fn(),
                 onDeleteUnscheduledTask: jest.fn(),
                 onScheduleUnscheduledTask: jest.fn(),
+                onStartTimerFromUnscheduledTask: jest.fn(),
                 onSaveUnscheduledTaskEdit: jest.fn(),
                 onCancelUnscheduledTaskEdit: jest.fn()
             };
@@ -935,6 +936,7 @@ describe('DOM Handler Interaction Tests', () => {
                             <i class="fa-regular ${isCompleted ? 'fa-check-square' : 'fa-square'}"></i>
                         </label>
                         <span>Test Task</span>
+                        <button class="btn-start-unscheduled-timer" data-task-id="${taskId}" ${isCompleted ? 'disabled' : ''}>Start Timer</button>
                         <button class="btn-schedule-task" data-task-id="${taskId}" ${isCompleted ? 'disabled' : ''}>Schedule</button>
                         <button class="btn-edit-unscheduled" data-task-id="${taskId}">Edit</button>
                         <button class="btn-delete-unscheduled" data-task-id="${taskId}">Delete</button>
@@ -979,6 +981,17 @@ describe('DOM Handler Interaction Tests', () => {
                 'Test Task',
                 '1h'
             );
+        });
+
+        test('start timer button calls onStartTimerFromUnscheduledTask', () => {
+            setupUnscheduledTask('unsched-1');
+
+            const startTimerBtn = document.querySelector('.btn-start-unscheduled-timer');
+            startTimerBtn.dispatchEvent(new Event('click', { bubbles: true }));
+
+            expect(
+                mockUnscheduledTaskCallbacks.onStartTimerFromUnscheduledTask
+            ).toHaveBeenCalledWith('unsched-1');
         });
 
         test('schedule button does not call callback for completed task', () => {

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -18,11 +18,13 @@ import {
 } from '../public/js/dom-renderer.js';
 import { getTaskFormElement, focusTaskDescriptionInput } from '../public/js/tasks/form-utils.js';
 import { showAlert, askConfirmation } from '../public/js/modal-manager.js';
+import { resetActivityState, updateActivityState } from '../public/js/activities/manager.js';
 import {
     convertTo12HourTime,
     timeToDateTime,
     calculateEndDateTime,
-    extractDateFromDateTime
+    extractDateFromDateTime,
+    extractTimeFromDateTime
 } from '../public/js/utils.js';
 
 // Mock storage.js before importing task-manager
@@ -34,7 +36,7 @@ jest.mock('../public/js/storage.js', () => ({
     deleteTask: jest.fn(),
     loadTasks: jest.fn(() => [])
 }));
-import { updateTaskState } from '../public/js/tasks/manager.js';
+import { getSuggestedStartTime, updateTaskState } from '../public/js/tasks/manager.js';
 
 describe('DOM Handler Interaction Tests', () => {
     let mockAppCallbacks;
@@ -141,6 +143,7 @@ describe('DOM Handler Interaction Tests', () => {
     afterEach(() => {
         jest.clearAllMocks();
         resetEventDelegation();
+        resetActivityState();
         document.body.innerHTML = '';
     });
 
@@ -1252,6 +1255,71 @@ describe('DOM Handler Interaction Tests', () => {
             expect(taskForm.classList.contains('task-form--activity')).toBe(false);
             expect(startTimerButton.classList.contains('hidden')).toBe(true);
         });
+
+        test('switching to activity replaces the generic default with the latest activity end time', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-07T12:00:00.000Z'));
+
+            updateActivityState([
+                {
+                    id: 'activity-1',
+                    description: 'Standup',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T09:30:00.000Z',
+                    duration: 30,
+                    source: 'manual'
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Focus',
+                    startDateTime: '2026-04-07T10:00:00.000Z',
+                    endDateTime: '2026-04-07T11:15:00.000Z',
+                    duration: 75,
+                    source: 'auto',
+                    sourceTaskId: 'sched-2'
+                }
+            ]);
+
+            const startTimeInput = document.querySelector('input[name="start-time"]');
+            const activityRadio = document.getElementById('activity');
+
+            updateStartTimeField(getSuggestedStartTime(), true);
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+            expect(startTimeInput.value).toBe(
+                extractTimeFromDateTime(new Date('2026-04-07T11:15:00.000Z'))
+            );
+
+            jest.useRealTimers();
+        });
+
+        test('switching to activity preserves a user-edited start-time draft', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-07T12:00:00.000Z'));
+
+            updateActivityState([
+                {
+                    id: 'activity-3',
+                    description: 'Review',
+                    startDateTime: '2026-04-07T12:00:00.000Z',
+                    endDateTime: '2026-04-07T12:45:00.000Z',
+                    duration: 45,
+                    source: 'manual'
+                }
+            ]);
+
+            const startTimeInput = document.querySelector('input[name="start-time"]');
+            const activityRadio = document.getElementById('activity');
+
+            startTimeInput.value = '10:00';
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+            expect(startTimeInput.value).toBe('10:00');
+
+            jest.useRealTimers();
+        });
     });
 
     describe('refreshUI', () => {
@@ -1304,6 +1372,46 @@ describe('DOM Handler Interaction Tests', () => {
 
             // refreshUI should render the task
             expect(() => refreshUI()).not.toThrow();
+        });
+
+        test('uses the latest activity end time when refreshing in activity mode', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-04-07T12:00:00.000Z'));
+
+            const scheduledCallbacks = { onCompleteTask: jest.fn() };
+            const unscheduledCallbacks = { onScheduleUnscheduledTask: jest.fn() };
+
+            renderTasks([], scheduledCallbacks);
+            renderUnscheduledTasks([], unscheduledCallbacks);
+
+            updateActivityState([
+                {
+                    id: 'activity-1',
+                    description: 'Deep work',
+                    startDateTime: '2026-04-07T10:00:00.000Z',
+                    endDateTime: '2026-04-07T11:32:00.000Z',
+                    duration: 92,
+                    source: 'manual'
+                }
+            ]);
+
+            const { initializeTaskTypeToggle } = require('../public/js/dom-renderer.js');
+            initializeTaskTypeToggle();
+
+            const activityRadio = document.getElementById('activity');
+            const startTimeInput = document.querySelector('input[name="start-time"]');
+
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+            updateStartTimeField(getSuggestedStartTime(), true);
+            refreshUI();
+
+            expect(startTimeInput.value).toBe(
+                extractTimeFromDateTime(new Date('2026-04-07T11:32:00.000Z'))
+            );
+
+            jest.useRealTimers();
         });
     });
 });

--- a/__tests__/form-utils.test.js
+++ b/__tests__/form-utils.test.js
@@ -1211,6 +1211,39 @@ describe('Form Utils Tests', () => {
             expect(warningElement.textContent).toBe('');
             expect(buttonElement.innerHTML).toContain('Add Task');
         });
+
+        test('skips overlap warning updates when shouldWarn returns false', () => {
+            const tasks = makeTasks(['Meeting', '10:00', 60]);
+
+            setupOverlapWarning(
+                startTimeInput,
+                hoursInput,
+                minutesInput,
+                warningElement,
+                buttonElement,
+                () => tasks,
+                {
+                    defaultButtonHTML,
+                    defaultButtonClasses,
+                    overlapButtonHTML,
+                    overlapButtonClasses,
+                    shouldWarn: () => false
+                }
+            );
+
+            buttonElement.innerHTML = '<i class="fa-regular fa-clock mr-2"></i>Log Activity';
+            buttonElement.className =
+                'bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300';
+            buttonElement.dataset.defaultButtonHtml = buttonElement.innerHTML;
+            buttonElement.dataset.defaultButtonClasses = buttonElement.className;
+
+            startTimeInput.value = '10:30';
+            startTimeInput.dispatchEvent(new Event('input'));
+
+            expect(warningElement.textContent).toBe('');
+            expect(buttonElement.innerHTML).toContain('Log Activity');
+            expect(buttonElement.className).toContain('from-sky-500');
+        });
     });
 
     describe('resetTaskFormPreviewState', () => {

--- a/__tests__/layout-mockups.test.js
+++ b/__tests__/layout-mockups.test.js
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+describe('layout mockups page', () => {
+    test('comparison grid gives each mockup enough width to render cleanly', () => {
+        const html = fs.readFileSync(
+            path.join(process.cwd(), 'public', 'layout-mockups.html'),
+            'utf8'
+        );
+
+        expect(html).toContain('grid-template-columns: repeat(2, minmax(0, 1fr));');
+        expect(html).toContain('.option.featured-row {');
+        expect(html).toContain('grid-column: 1 / -1;');
+    });
+});

--- a/__tests__/room-manager.test.js
+++ b/__tests__/room-manager.test.js
@@ -51,9 +51,27 @@ describe('Room Manager', () => {
             expect(code.length).toBeGreaterThan(0);
         });
 
-        test('generates unique codes', () => {
-            const codes = new Set(Array.from({ length: 20 }, () => generateRoomCode()));
-            expect(codes.size).toBe(20);
+        test('generates room codes in the expected format', () => {
+            const code = generateRoomCode();
+            expect(code).toMatch(/^[a-z]{3}-\d{3}$/);
+        });
+
+        test('produces different codes when randomness changes', () => {
+            const randomSpy = jest.spyOn(Math, 'random');
+            randomSpy
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(0.999)
+                .mockReturnValueOnce(0.999);
+
+            const firstCode = generateRoomCode();
+            const secondCode = generateRoomCode();
+
+            expect(firstCode).toBe('fox-100');
+            expect(secondCode).toBe('yak-999');
+            expect(firstCode).not.toBe(secondCode);
+
+            randomSpy.mockRestore();
         });
     });
 

--- a/__tests__/running-activity-repository.test.js
+++ b/__tests__/running-activity-repository.test.js
@@ -32,7 +32,28 @@ describe('running activity repository', () => {
         await expect(loadRunningActivityConfig()).resolves.toEqual({
             description: 'Focus',
             category: 'work/deep',
-            startDateTime: '2026-04-09T10:00:00.000Z'
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'timer',
+            sourceTaskId: null
+        });
+    });
+
+    test('loads optional provenance fields for task-linked timers', async () => {
+        loadConfig.mockResolvedValueOnce({
+            id: 'config-running-activity',
+            description: 'Inbox zero',
+            category: 'break/admin',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'unsched-7'
+        });
+
+        await expect(loadRunningActivityConfig()).resolves.toEqual({
+            description: 'Inbox zero',
+            category: 'break/admin',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'unsched-7'
         });
     });
 
@@ -44,14 +65,37 @@ describe('running activity repository', () => {
         await saveRunningActivityConfig({
             description: 'Focus',
             category: null,
-            startDateTime: '2026-04-09T10:00:00.000Z'
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'timer',
+            sourceTaskId: null
         });
 
         expect(putConfig).toHaveBeenCalledWith({
             id: 'config-running-activity',
             description: 'Focus',
             category: null,
-            startDateTime: '2026-04-09T10:00:00.000Z'
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'timer',
+            sourceTaskId: null
+        });
+    });
+
+    test('saves linked source task provenance for promoted unscheduled timers', async () => {
+        await saveRunningActivityConfig({
+            description: 'Email triage',
+            category: 'break/admin',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'unsched-7'
+        });
+
+        expect(putConfig).toHaveBeenCalledWith({
+            id: 'config-running-activity',
+            description: 'Email triage',
+            category: 'break/admin',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'unsched-7'
         });
     });
 

--- a/__tests__/running-activity-repository.test.js
+++ b/__tests__/running-activity-repository.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/storage.js', () => ({
+    putConfig: jest.fn(() => Promise.resolve()),
+    loadConfig: jest.fn(() => Promise.resolve(null)),
+    deleteConfig: jest.fn(() => Promise.resolve())
+}));
+
+import {
+    loadRunningActivityConfig,
+    saveRunningActivityConfig,
+    deleteRunningActivityConfig
+} from '../public/js/activities/running-activity-repository.js';
+import { putConfig, loadConfig, deleteConfig } from '../public/js/storage.js';
+
+describe('running activity repository', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('loads normalized running activity state from config storage', async () => {
+        loadConfig.mockResolvedValueOnce({
+            id: 'config-running-activity',
+            description: 'Focus',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            ignored: true
+        });
+
+        await expect(loadRunningActivityConfig()).resolves.toEqual({
+            description: 'Focus',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T10:00:00.000Z'
+        });
+    });
+
+    test('returns null when no running activity config exists', async () => {
+        await expect(loadRunningActivityConfig()).resolves.toBeNull();
+    });
+
+    test('saves running activity state under the dedicated config id', async () => {
+        await saveRunningActivityConfig({
+            description: 'Focus',
+            category: null,
+            startDateTime: '2026-04-09T10:00:00.000Z'
+        });
+
+        expect(putConfig).toHaveBeenCalledWith({
+            id: 'config-running-activity',
+            description: 'Focus',
+            category: null,
+            startDateTime: '2026-04-09T10:00:00.000Z'
+        });
+    });
+
+    test('deletes running activity state by dedicated config id', async () => {
+        await deleteRunningActivityConfig();
+
+        expect(deleteConfig).toHaveBeenCalledWith('config-running-activity');
+    });
+});

--- a/__tests__/settings-renderer.test.js
+++ b/__tests__/settings-renderer.test.js
@@ -543,6 +543,7 @@ describe('settings-renderer', () => {
             form.querySelector('[name="group-label"]').value = 'Fitness';
             form.querySelector('[name="group-family"]').value = 'rose';
             await submitForm(form);
+            await waitForCondition(() => onTaxonomyChanged.mock.calls.length > 0);
 
             expect(onTaxonomyChanged).toHaveBeenCalled();
         });

--- a/__tests__/storage-config.test.js
+++ b/__tests__/storage-config.test.js
@@ -23,6 +23,7 @@ import {
     destroyStorage,
     putConfig,
     loadConfig,
+    deleteConfig,
     saveTasks,
     putTask,
     getDb
@@ -105,5 +106,42 @@ describe('Storage - config docs', () => {
         const loaded = await loadConfig('config-categories');
         expect(loaded).not.toBeNull();
         expect(loaded.categories).toEqual(['survive']);
+    });
+
+    describe('deleteConfig', () => {
+        test('deletes a config document by ID', async () => {
+            await initStorage(uniqueRoomCode(), { adapter: 'memory' });
+            await putConfig({ id: 'config-test-delete', someSetting: true });
+
+            const before = await loadConfig('config-test-delete');
+            expect(before).not.toBeNull();
+            expect(before.someSetting).toBe(true);
+
+            await deleteConfig('config-test-delete');
+
+            const after = await loadConfig('config-test-delete');
+            expect(after).toBeNull();
+        });
+
+        test('succeeds silently when config does not exist', async () => {
+            await initStorage(uniqueRoomCode(), { adapter: 'memory' });
+
+            await expect(deleteConfig('config-nonexistent')).resolves.toBeUndefined();
+        });
+
+        test('does not affect other config documents', async () => {
+            await initStorage(uniqueRoomCode(), { adapter: 'memory' });
+            await putConfig({ id: 'config-keep', value: 'keep' });
+            await putConfig({ id: 'config-remove', value: 'remove' });
+
+            await deleteConfig('config-remove');
+
+            const kept = await loadConfig('config-keep');
+            expect(kept).not.toBeNull();
+            expect(kept.value).toBe('keep');
+
+            const removed = await loadConfig('config-remove');
+            expect(removed).toBeNull();
+        });
     });
 });

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -23,8 +23,12 @@ jest.mock('../public/js/sync-manager.js', () => ({
 import {
     initStorage,
     putTask,
+    putActivity,
+    putConfig,
     deleteTask,
     loadTasks,
+    loadActivities,
+    loadConfig,
     saveTasks,
     getDb,
     destroyStorage
@@ -215,6 +219,60 @@ describe('Storage - PouchDB', () => {
             await saveTasks([]);
             const tasks = await loadTasks();
             expect(tasks).toEqual([]);
+        });
+
+        test('clearing all tasks preserves activity and config docs', async () => {
+            await initStorage(uniqueRoomCode(), { adapter: 'memory' });
+            await putTask({
+                id: 'sched-1',
+                type: 'scheduled',
+                description: 'Scheduled task',
+                status: 'incomplete'
+            });
+            await putTask({
+                id: 'unsched-1',
+                type: 'unscheduled',
+                description: 'Unscheduled task',
+                status: 'incomplete',
+                priority: 'medium'
+            });
+            await putActivity({
+                id: 'activity-1',
+                docType: 'activity',
+                description: 'Preserved activity',
+                category: null,
+                startDateTime: '2026-04-11T09:00:00.000Z',
+                endDateTime: '2026-04-11T09:30:00.000Z',
+                duration: 30,
+                source: 'manual',
+                sourceTaskId: null
+            });
+            await putConfig({
+                id: 'config-categories',
+                groups: [],
+                categories: []
+            });
+
+            await saveTasks([]);
+
+            const tasks = await loadTasks();
+            const activities = await loadActivities();
+            const categoriesConfig = await loadConfig('config-categories');
+
+            expect(tasks).toEqual([]);
+            expect(activities).toEqual([
+                expect.objectContaining({
+                    id: 'activity-1',
+                    docType: 'activity',
+                    description: 'Preserved activity'
+                })
+            ]);
+            expect(categoriesConfig).toEqual(
+                expect.objectContaining({
+                    id: 'config-categories',
+                    docType: 'config'
+                })
+            );
         });
     });
 });

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -27,7 +27,8 @@ import {
     getTaskById,
     getTaskIndex,
     setTaskInlineEditing,
-    resetAllInlineEditingFlags
+    resetAllInlineEditingFlags,
+    consumeUnscheduledTask
 } from '../public/js/tasks/manager.js';
 import { isValidTaskData } from '../public/js/tasks/validators.js';
 import { checkOverlap, tasksOverlap } from '../public/js/reschedule-engine.js';
@@ -2423,6 +2424,37 @@ describe('Task Management Functions (task-manager.js)', () => {
             updateTaskState([]);
             const result = deleteUnscheduledTask('nonexistent');
             expect(result.success).toBe(false);
+        });
+    });
+
+    describe('consumeUnscheduledTask', () => {
+        test('removes an incomplete unscheduled task without confirmation', () => {
+            const task = {
+                id: 'unsched-linked',
+                type: 'unscheduled',
+                description: 'Linked task',
+                priority: 'medium',
+                estDuration: 30,
+                status: 'incomplete',
+                confirmingDelete: false
+            };
+            updateTaskState([task]);
+
+            const result = consumeUnscheduledTask('unsched-linked');
+
+            expect(result.success).toBe(true);
+            expect(result.task).toEqual(expect.objectContaining({ id: 'unsched-linked' }));
+            expect(getTaskState()).toEqual([]);
+            expect(mockDeleteTaskFromStorage).toHaveBeenCalledWith('unsched-linked');
+        });
+
+        test('returns failure for missing unscheduled tasks', () => {
+            updateTaskState([]);
+
+            const result = consumeUnscheduledTask('missing-unsched');
+
+            expect(result.success).toBe(false);
+            expect(result.reason).toBe('Unscheduled task not found.');
         });
     });
 

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -44,6 +44,7 @@ function setupDOM() {
         <button id="settings-gear-btn" type="button"><i class="fa-solid fa-gear"></i></button>
       </div>
       <form id="task-form">
+        <div id="task-form-fields">
         <div class="form-group">
           <input type="text" name="description" placeholder="Task description" required />
         </div>
@@ -81,6 +82,15 @@ function setupDOM() {
           <input type="number" name="est-duration" placeholder="Est. minutes" />
         </div>
         <button type="submit" id="add-task-btn">Add Task</button>
+        </div>
+        <div id="timer-display" class="hidden">
+          <input id="timer-description" />
+          <select id="timer-category"></select>
+          <input id="timer-start-time" type="time" />
+          <div id="timer-elapsed"></div>
+          <button id="timer-stop-btn" type="button">Stop</button>
+        </div>
+        <button id="start-timer-btn" type="button" class="hidden">Start Timer</button>
       </form>
       <span id="overlap-warning"></span>
       <div id="scheduled-task-list" class="task-list"></div>

--- a/__tests__/unscheduled-task-handlers.test.js
+++ b/__tests__/unscheduled-task-handlers.test.js
@@ -4,6 +4,7 @@
 
 import {
     handleScheduleUnscheduledTask,
+    handleStartTimerFromUnscheduledTask,
     handleEditUnscheduledTask,
     handleDeleteUnscheduledTask,
     handleConfirmScheduleTask,
@@ -60,6 +61,14 @@ jest.mock('../public/js/toast-manager.js', () => ({
     showToast: jest.fn()
 }));
 
+jest.mock('../public/js/activities/handlers.js', () => ({
+    handleStartTimer: jest.fn(() => Promise.resolve({ success: true }))
+}));
+
+jest.mock('../public/js/activities/timer-ui.js', () => ({
+    syncTimerFormState: jest.fn()
+}));
+
 jest.mock('../public/js/app-coordinator.js', () => ({
     onTaskEdited: jest.fn(),
     onTaskDeleted: jest.fn(),
@@ -84,10 +93,12 @@ jest.mock('../public/js/tasks/form-utils.js', () => ({
 }));
 
 import { refreshUI } from '../public/js/dom-renderer.js';
-import { showAlert, showScheduleModal } from '../public/js/modal-manager.js';
+import { showAlert, showScheduleModal, askConfirmation } from '../public/js/modal-manager.js';
 import { showToast } from '../public/js/toast-manager.js';
 import { getUnscheduledTaskInlineFormData } from '../public/js/tasks/form-utils.js';
 import { onTaskEdited, onTaskDeleted, onTaskScheduled } from '../public/js/app-coordinator.js';
+import { handleStartTimer } from '../public/js/activities/handlers.js';
+import { syncTimerFormState } from '../public/js/activities/timer-ui.js';
 
 function createUnscheduledTask(overrides = {}) {
     return {
@@ -121,6 +132,7 @@ describe('Unscheduled Task Handlers', () => {
         test('returns object with all expected callback properties', () => {
             const callbacks = createUnscheduledTaskCallbacks();
             expect(callbacks).toHaveProperty('onScheduleUnscheduledTask');
+            expect(callbacks).toHaveProperty('onStartTimerFromUnscheduledTask');
             expect(callbacks).toHaveProperty('onEditUnscheduledTask');
             expect(callbacks).toHaveProperty('onDeleteUnscheduledTask');
             expect(callbacks).toHaveProperty('onConfirmScheduleTask');
@@ -159,6 +171,76 @@ describe('Unscheduled Task Handlers', () => {
         });
     });
 
+    describe('handleStartTimerFromUnscheduledTask', () => {
+        test('starts a linked timer from an incomplete unscheduled task, switches to activity mode, and refreshes UI', async () => {
+            const task = createUnscheduledTask({
+                id: 'unsched-linked',
+                description: 'Email triage',
+                category: 'break/admin'
+            });
+            updateTaskState([task]);
+            document.body.innerHTML += `
+                <input id="activity" type="radio" name="task-type" />
+            `;
+            const activityRadio = document.getElementById('activity');
+            const onActivityModeChange = jest.fn();
+            activityRadio.addEventListener('change', onActivityModeChange);
+
+            await handleStartTimerFromUnscheduledTask(task.id);
+
+            expect(handleStartTimer).toHaveBeenCalledWith({
+                description: 'Email triage',
+                category: 'break/admin',
+                source: 'auto',
+                sourceTaskId: 'unsched-linked'
+            });
+            expect(activityRadio.checked).toBe(true);
+            expect(onActivityModeChange).toHaveBeenCalledTimes(1);
+            expect(syncTimerFormState).toHaveBeenCalledTimes(1);
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('shows alert instead of starting a timer for a completed unscheduled task', async () => {
+            const task = createUnscheduledTask({
+                id: 'unsched-complete',
+                status: 'completed'
+            });
+            updateTaskState([task]);
+
+            await handleStartTimerFromUnscheduledTask(task.id);
+
+            expect(handleStartTimer).not.toHaveBeenCalled();
+            expect(showAlert).toHaveBeenCalledWith(
+                'This task is already completed and cannot be started as a timer.',
+                'indigo'
+            );
+        });
+
+        test('does not refresh UI when linked timer start fails', async () => {
+            const task = createUnscheduledTask({
+                id: 'unsched-fail',
+                description: 'Email triage'
+            });
+            updateTaskState([task]);
+            handleStartTimer.mockResolvedValueOnce({
+                success: false,
+                reason: 'Could not start timer.'
+            });
+
+            await handleStartTimerFromUnscheduledTask(task.id);
+
+            expect(handleStartTimer).toHaveBeenCalled();
+            expect(refreshUI).not.toHaveBeenCalled();
+        });
+
+        test('ignores missing unscheduled tasks when starting a linked timer', async () => {
+            await handleStartTimerFromUnscheduledTask('missing-unsched');
+
+            expect(handleStartTimer).not.toHaveBeenCalled();
+            expect(refreshUI).not.toHaveBeenCalled();
+        });
+    });
+
     describe('handleEditUnscheduledTask', () => {
         test('toggles editing mode on', () => {
             const task = createUnscheduledTask();
@@ -189,6 +271,12 @@ describe('Unscheduled Task Handlers', () => {
 
             expect(getTaskById(task1.id).isEditingInline).toBe(false);
             expect(getTaskById(task2.id).isEditingInline).toBe(true);
+        });
+
+        test('shows alert when asked to edit a missing unscheduled task', () => {
+            handleEditUnscheduledTask('missing-unsched');
+
+            expect(showAlert).toHaveBeenCalledWith('Could not find the task to edit.', 'teal');
         });
     });
 
@@ -248,6 +336,39 @@ describe('Unscheduled Task Handlers', () => {
             });
             expect(refreshUI).not.toHaveBeenCalled();
         });
+
+        test('shows alert and refreshes when overlap confirmation is declined', async () => {
+            jest.spyOn(taskManager, 'scheduleUnscheduledTask').mockReturnValueOnce({
+                success: false,
+                requiresConfirmation: true,
+                reason: 'Scheduling will overlap other tasks. Reschedule them?',
+                context: {
+                    unscheduledTaskId: 'unsched-overlap',
+                    scheduledTaskData: { description: 'Overlap task', startTime: '09:00' }
+                }
+            });
+            askConfirmation.mockResolvedValueOnce(false);
+
+            await handleConfirmScheduleTask('unsched-overlap', '09:00', 30);
+
+            expect(showAlert).toHaveBeenCalledWith(
+                'Task not scheduled to avoid overlap.',
+                'indigo'
+            );
+            expect(refreshUI).toHaveBeenCalled();
+        });
+
+        test('shows alert and refreshes when scheduling fails without confirmation flow', async () => {
+            jest.spyOn(taskManager, 'scheduleUnscheduledTask').mockReturnValueOnce({
+                success: false,
+                reason: 'Unscheduled task not found.'
+            });
+
+            await handleConfirmScheduleTask('missing-unsched', '09:00', 30);
+
+            expect(showAlert).toHaveBeenCalledWith('Unscheduled task not found.', 'indigo');
+            expect(refreshUI).toHaveBeenCalled();
+        });
     });
 
     describe('handleSaveUnscheduledTaskEdit', () => {
@@ -274,6 +395,41 @@ describe('Unscheduled Task Handlers', () => {
                 })
             });
             expect(refreshUI).not.toHaveBeenCalled();
+        });
+
+        test('returns early when inline form extraction fails', async () => {
+            const task = createUnscheduledTask({
+                id: 'unsched-inline-missing',
+                isEditingInline: true
+            });
+            updateTaskState([task]);
+            getUnscheduledTaskInlineFormData.mockReturnValue(null);
+
+            await handleSaveUnscheduledTaskEdit(task.id);
+
+            expect(onTaskEdited).not.toHaveBeenCalled();
+        });
+
+        test('shows alert when unscheduled inline save fails validation', async () => {
+            const task = createUnscheduledTask({
+                id: 'unsched-inline-invalid',
+                isEditingInline: true
+            });
+            updateTaskState([task]);
+            getUnscheduledTaskInlineFormData.mockReturnValue({
+                description: '',
+                priority: 'high',
+                estDuration: 45
+            });
+            jest.spyOn(taskManager, 'updateUnscheduledTask').mockReturnValueOnce({
+                success: false,
+                reason: 'Task description is required.'
+            });
+
+            await handleSaveUnscheduledTaskEdit(task.id);
+
+            expect(showAlert).toHaveBeenCalledWith('Task description is required.', 'indigo');
+            expect(onTaskEdited).not.toHaveBeenCalled();
         });
     });
 

--- a/__tests__/unscheduled-task-renderer.test.js
+++ b/__tests__/unscheduled-task-renderer.test.js
@@ -2,409 +2,81 @@
  * @jest-environment jsdom
  */
 
-jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
-    renderCategoryBadge: jest.fn((categoryKey) =>
-        categoryKey ? `<span class="category-badge">${categoryKey}</span>` : ''
-    )
+jest.mock('../public/js/activities/manager.js', () => ({
+    getRunningActivity: jest.fn(() => null)
 }));
 
-import {
-    getUnscheduledTaskListElement,
-    getPriorityClasses,
-    renderUnscheduledTasks
-} from '../public/js/tasks/unscheduled-renderer.js';
+import { renderUnscheduledTasks } from '../public/js/tasks/unscheduled-renderer.js';
+import { getRunningActivity } from '../public/js/activities/manager.js';
 
-describe('Unscheduled Task Renderer Tests', () => {
+describe('unscheduled task renderer', () => {
     beforeEach(() => {
-        document.body.innerHTML = `
-            <div id="unscheduled-task-list"></div>
-        `;
+        jest.clearAllMocks();
+        document.body.innerHTML = '<div id="unscheduled-task-list"></div>';
     });
 
-    afterEach(() => {
-        document.body.innerHTML = '';
+    test('renders a start timer action for incomplete unscheduled tasks', () => {
+        renderUnscheduledTasks(
+            [
+                {
+                    id: 'unsched-1',
+                    type: 'unscheduled',
+                    description: 'Inbox zero',
+                    priority: 'medium',
+                    estDuration: 30,
+                    status: 'incomplete'
+                }
+            ],
+            {},
+            jest.fn()
+        );
+
+        const startTimerButton = document.querySelector('.btn-start-unscheduled-timer');
+        expect(startTimerButton).not.toBeNull();
+        expect(startTimerButton.getAttribute('title')).toBe('Start timer from task');
+        expect(startTimerButton.querySelector('.fa-stopwatch')).not.toBeNull();
+        expect(startTimerButton.hasAttribute('disabled')).toBe(false);
     });
 
-    describe('getUnscheduledTaskListElement', () => {
-        test('returns the unscheduled task list element when it exists', () => {
-            const element = getUnscheduledTaskListElement();
-            expect(element).toBeInstanceOf(HTMLElement);
-            expect(element?.id).toBe('unscheduled-task-list');
+    test('renders the linked source task with a subdued in-progress badge and fully disabled while its timer runs', () => {
+        getRunningActivity.mockReturnValue({
+            description: 'Inbox zero',
+            category: 'break/admin',
+            startDateTime: '2026-04-14T12:00:00.000Z',
+            source: 'auto',
+            sourceTaskId: 'unsched-2'
         });
 
-        test('returns null when element does not exist', () => {
-            document.body.innerHTML = '';
-            const element = getUnscheduledTaskListElement();
-            expect(element).toBeNull();
-        });
-    });
-
-    describe('getPriorityClasses', () => {
-        test('returns high priority classes', () => {
-            const classes = getPriorityClasses('high');
-            expect(classes.border).toBe('border-rose-400');
-            expect(classes.bg).toBe('bg-rose-400 bg-opacity-20');
-            expect(classes.text).toBe('text-rose-300');
-            expect(classes.icon).toBe('fa-solid fa-arrow-up');
-            expect(classes.focusRing).toBe('rose-400');
-        });
-
-        test('returns medium priority classes', () => {
-            const classes = getPriorityClasses('medium');
-            expect(classes.border).toBe('border-amber-400');
-            expect(classes.bg).toBe('bg-amber-400 bg-opacity-20');
-            expect(classes.text).toBe('text-amber-300');
-            expect(classes.icon).toBe('fa-solid fa-equals');
-            expect(classes.focusRing).toBe('amber-300');
-        });
-
-        test('returns low priority classes', () => {
-            const classes = getPriorityClasses('low');
-            expect(classes.border).toBe('border-emerald-400');
-            expect(classes.bg).toBe('bg-emerald-400 bg-opacity-20');
-            expect(classes.text).toBe('text-emerald-300');
-            expect(classes.icon).toBe('fa-solid fa-arrow-down');
-            expect(classes.focusRing).toBe('emerald-400');
-        });
-
-        test('defaults to medium for unknown priority', () => {
-            const classes = getPriorityClasses('unknown');
-            expect(classes.border).toBe('border-amber-400');
-        });
-
-        test('includes checkbox class', () => {
-            const classes = getPriorityClasses('high');
-            expect(classes.checkbox).toBe('text-teal-700');
-        });
-    });
-
-    describe('renderUnscheduledTasks', () => {
-        let mockEventCallbacks;
-        let mockSetGlobalCallbacks;
-
-        beforeEach(() => {
-            mockEventCallbacks = {
-                onCompleteTask: jest.fn(),
-                onEditTask: jest.fn(),
-                onDeleteTask: jest.fn()
-            };
-            mockSetGlobalCallbacks = jest.fn();
-        });
-
-        test('renders empty state message when no tasks', () => {
-            renderUnscheduledTasks([], mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const list = getUnscheduledTaskListElement();
-            expect(list.innerHTML).toContain('No unscheduled tasks yet');
-            expect(mockSetGlobalCallbacks).toHaveBeenCalledWith(mockEventCallbacks);
-        });
-
-        test('renders a single task correctly', () => {
-            const tasks = [
+        renderUnscheduledTasks(
+            [
                 {
-                    id: 'task-1',
-                    description: 'Test task',
-                    category: 'work/deep',
-                    priority: 'high',
-                    estDuration: 90,
-                    status: 'incomplete',
-                    type: 'unscheduled'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const list = getUnscheduledTaskListElement();
-            expect(list.children.length).toBe(1);
-
-            const taskCard = list.querySelector('[data-task-id="task-1"]');
-            expect(taskCard).not.toBeNull();
-            expect(taskCard.textContent).toContain('Test task');
-            expect(taskCard.textContent).toContain('High Priority');
-            expect(taskCard.textContent).toContain('1h 30m');
-            expect(taskCard.querySelector('.category-badge')).not.toBeNull();
-        });
-
-        test('renders multiple tasks', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task 1',
-                    priority: 'high',
-                    estDuration: 60,
-                    status: 'incomplete'
-                },
-                {
-                    id: 'task-2',
-                    description: 'Task 2',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'incomplete'
-                },
-                {
-                    id: 'task-3',
-                    description: 'Task 3',
-                    priority: 'low',
-                    estDuration: 15,
-                    status: 'completed'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const list = getUnscheduledTaskListElement();
-            expect(list.children.length).toBe(3);
-        });
-
-        test('renders completed task with strikethrough', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Completed task',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'completed'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const taskCard = document.querySelector('[data-task-id="task-1"]');
-            expect(taskCard.innerHTML).toContain('line-through');
-            expect(taskCard.innerHTML).toContain('fa-check-square');
-        });
-
-        test('renders incomplete task without strikethrough', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Incomplete task',
+                    id: 'unsched-2',
+                    type: 'unscheduled',
+                    description: 'Inbox zero',
                     priority: 'medium',
                     estDuration: 30,
                     status: 'incomplete'
                 }
-            ];
+            ],
+            {},
+            jest.fn()
+        );
 
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const taskCard = document.querySelector('[data-task-id="task-1"]');
-            expect(taskCard.innerHTML).toContain('fa-square');
-            expect(taskCard.querySelector('.line-through')).toBeNull();
-        });
-
-        test('renders task with confirming delete state', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task to delete',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'incomplete',
-                    confirmingDelete: true
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const taskCard = document.querySelector('[data-task-id="task-1"]');
-            expect(taskCard.innerHTML).toContain('fa-check-circle');
-            expect(taskCard.innerHTML).toContain('text-rose-400');
-        });
-
-        test('includes schedule button for tasks', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task to schedule',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'incomplete'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const scheduleBtn = document.querySelector('.btn-schedule-task');
-            expect(scheduleBtn).not.toBeNull();
-            expect(scheduleBtn.dataset.taskId).toBe('task-1');
-        });
-
-        test('disables schedule button for completed tasks', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Completed task',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'completed'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const scheduleBtn = document.querySelector('.btn-schedule-task');
-            expect(scheduleBtn.hasAttribute('disabled')).toBe(true);
-        });
-
-        test('includes edit and delete buttons', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'incomplete'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const editBtn = document.querySelector('.btn-edit-unscheduled');
-            const deleteBtn = document.querySelector('.btn-delete-unscheduled');
-
-            expect(editBtn).not.toBeNull();
-            expect(deleteBtn).not.toBeNull();
-            expect(editBtn.dataset.taskId).toBe('task-1');
-            expect(deleteBtn.dataset.taskId).toBe('task-1');
-        });
-
-        test('sets data attributes on task card', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Test task',
-                    priority: 'high',
-                    estDuration: 90,
-                    status: 'incomplete'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const taskCard = document.querySelector('[data-task-id="task-1"]');
-            expect(taskCard.dataset.taskName).toBe('Test task');
-            expect(taskCard.dataset.taskEstDuration).toBe('1h 30m');
-        });
-
-        test('includes inline edit form (hidden by default)', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task',
-                    priority: 'medium',
-                    estDuration: 60,
-                    status: 'incomplete'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const editForm = document.querySelector('.inline-edit-unscheduled-form');
-            expect(editForm).not.toBeNull();
-            expect(editForm.classList.contains('hidden')).toBe(true);
-        });
-
-        test('shows inline edit form for task with isEditingInline', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Editing task',
-                    priority: 'high',
-                    estDuration: 60,
-                    status: 'incomplete',
-                    isEditingInline: true
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const viewPart = document.querySelector('.task-display-view');
-            const editForm = document.querySelector('.inline-edit-unscheduled-form');
-
-            expect(viewPart.classList.contains('hidden')).toBe(true);
-            expect(editForm.classList.contains('hidden')).toBe(false);
-        });
-
-        test('does not throw when list element not found', () => {
-            document.body.innerHTML = '';
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'incomplete'
-                }
-            ];
-
-            expect(() => {
-                renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-            }).not.toThrow();
-        });
-
-        test('inline edit form has correct priority radio buttons', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task',
-                    priority: 'high',
-                    estDuration: 60,
-                    status: 'incomplete'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const highRadio = document.querySelector(
-                'input[name="inline-edit-priority"][value="high"]'
-            );
-            const medRadio = document.querySelector(
-                'input[name="inline-edit-priority"][value="medium"]'
-            );
-            const lowRadio = document.querySelector(
-                'input[name="inline-edit-priority"][value="low"]'
-            );
-
-            expect(highRadio).not.toBeNull();
-            expect(medRadio).not.toBeNull();
-            expect(lowRadio).not.toBeNull();
-            expect(highRadio.checked).toBe(true);
-        });
-
-        test('renders duration in hours and minutes format', () => {
-            const tasks = [
-                {
-                    id: 'task-1',
-                    description: 'Task 1',
-                    priority: 'medium',
-                    estDuration: 90,
-                    status: 'incomplete'
-                },
-                {
-                    id: 'task-2',
-                    description: 'Task 2',
-                    priority: 'medium',
-                    estDuration: 30,
-                    status: 'incomplete'
-                },
-                {
-                    id: 'task-3',
-                    description: 'Task 3',
-                    priority: 'medium',
-                    estDuration: 120,
-                    status: 'incomplete'
-                }
-            ];
-
-            renderUnscheduledTasks(tasks, mockEventCallbacks, mockSetGlobalCallbacks);
-
-            const task1 = document.querySelector('[data-task-id="task-1"]');
-            const task2 = document.querySelector('[data-task-id="task-2"]');
-            const task3 = document.querySelector('[data-task-id="task-3"]');
-
-            expect(task1.textContent).toContain('1h 30m');
-            expect(task2.textContent).toContain('30m');
-            expect(task3.textContent).toContain('2h');
-        });
+        const taskCard = document.querySelector('[data-task-id="unsched-2"]');
+        expect(taskCard.className).toContain('opacity-70');
+        expect(taskCard.className).toContain('pointer-events-none');
+        const inProgressBadge = taskCard.querySelector('.unscheduled-in-progress-badge');
+        expect(inProgressBadge).not.toBeNull();
+        expect(inProgressBadge.textContent).toContain('In progress');
+        expect(inProgressBadge.className).toContain('bg-slate-700/70');
+        expect(inProgressBadge.className).toContain('text-sky-200');
+        expect(
+            document.querySelector('.btn-start-unscheduled-timer').hasAttribute('disabled')
+        ).toBe(true);
+        expect(document.querySelector('.btn-schedule-task').hasAttribute('disabled')).toBe(true);
+        expect(document.querySelector('.btn-edit-unscheduled').hasAttribute('disabled')).toBe(true);
+        expect(document.querySelector('.btn-delete-unscheduled').hasAttribute('disabled')).toBe(
+            true
+        );
     });
 });

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -499,6 +499,7 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 **Phase 6: Polish and E2E**
 
 - Add E2E coverage for activity flows
+- Add a one-time "What's new?" prompt on initial app load after Activities ships, highlighting activity logging, timer capture, and insights
 - Finalize activity accent color
 - Add transitions and micro-interactions
 - Adapt timeline UX for mobile

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -2,9 +2,9 @@
 
 ## Pyramid Summary
 
-- **~2w:** Add activity tracking to Fortudo so planning and actual time spent live in one app: synced Activities enablement, shared task/activity taxonomy, manual and automatic activity logging, and insights built around plan-vs-actual review.
-- **~8w:** The foundation is now in place: `task`, `activity`, and `config` documents coexist safely in one room database; taxonomy and settings are PouchDB-backed; and boot/sync validation exists. The remaining work is activity CRUD, auto-logging, and insights UI layered on top of that shared local-first data model.
-- **~32w:** Fortudo evolves from a planning-only tool into a lightweight planning-and-tracking system. Tasks and activities share taxonomy, settings sync at the room level, the coordinator remains the post-mutation seam for cross-cutting behavior like auto-logging, and insights center on reviewing planned versus actual time without splitting that workflow into a separate app.
+- **~2w:** Add activity tracking to Fortudo so planning and actual time spent live in one app: synced Activities enablement, shared task/activity taxonomy, manual logging, automatic logging from completed tasks, a live start/stop timer, and insights built around plan-vs-actual review.
+- **~8w:** Activities can be logged three ways: manually after the fact, auto-logged when scheduled tasks complete, or captured in real time via a live timer (PouchDB config doc, syncs across devices). The foundation supports `task`, `activity`, and `config` documents in one room database with taxonomy, settings, and timer state all PouchDB-backed. Insights UI layers on top for plan-vs-actual review.
+- **~32w:** Fortudo evolves from a planning-only tool into a lightweight planning-and-tracking system. Tasks and activities share taxonomy, settings sync at the room level, the coordinator remains the post-mutation seam for cross-cutting behavior like auto-logging and timer auto-stop, and insights center on reviewing planned versus actual time without splitting that workflow into a separate app.
 
 ---
 
@@ -21,7 +21,7 @@ Fortudo handles the planning side of daily time management by scheduling tasks i
 - **ID conventions:** `sched-{timestamp}` for scheduled, `unsched-{timestamp}` for unscheduled.
 - **Module architecture:** `app.js` now focuses on boot, storage wiring, room lifecycle, and top-level event setup. Feature handlers live under `tasks/`. Successful task mutations are reported through `app-coordinator.js` as semantic post-mutation events. Render-time callback threading still exists through `dom-renderer.js`.
 - **Sync:** Bidirectional CouchDB replication via `sync-manager.js` with debounced sync and status callbacks. Room-switch sync handoff is now session-aware so in-flight sync from one room does not mutate the next room.
-- **UI:** Dark Tailwind theme. Teal = scheduled, indigo = unscheduled, amber = warnings, rose = destructive. Modals remain for real confirmations. Toasts now handle non-blocking feedback. Max width `3xl`.
+- **UI:** Dark Tailwind theme. Teal = scheduled, indigo = unscheduled, sky = activity, amber = warnings, rose = destructive. Modals remain for real confirmations. Toasts now handle non-blocking feedback. Max width `3xl`.
 
 ### Tracks Architecture
 
@@ -51,7 +51,7 @@ Fortudo handles the planning side of daily time management by scheduling tasks i
     startDateTime: String,        // ISO datetime
     endDateTime: String,          // ISO datetime
     duration: Number,             // minutes, matching Fortudo task duration units
-    source: 'auto' | 'manual',    // future: 'habit' is possible later
+    source: 'auto' | 'manual' | 'timer',  // future: 'habit' is possible later
     sourceTaskId: String | null   // source task link when source = 'auto'
 }
 ```
@@ -101,6 +101,22 @@ Stored in PouchDB so task taxonomy syncs across devices sharing a room.
 
 Taxonomy now treats standalone groups and child categories as first-class records. Keys remain hierarchical using `/`, so insights can still aggregate by top-level group while the task form dropdown stays grouped for easy scanning.
 
+**Config document - Running Activity Timer:**
+
+Ephemeral config doc representing a live timer. Created on timer start, deleted on timer stop. Syncs across devices sharing a room.
+
+```js
+{
+    docType: 'config',
+    id: 'config-running-activity',
+    description: String,
+    category: String | null,
+    startDateTime: String  // ISO datetime, real wall-clock time
+}
+```
+
+When the timer stops, this config doc is deleted and a normal activity document is created with `source: 'timer'`, computed `endDateTime` and `duration`.
+
 Shared field names between tasks and activities: `description`, `startDateTime`, `endDateTime`, `duration`, `category`.
 
 ### Storage Layer Changes
@@ -112,6 +128,7 @@ Shared field names between tasks and activities: `description`, `startDateTime`,
 - `deleteActivity(id)` - same pattern as `deleteTask`
 - `loadConfig(configId)` - loads a single config document by ID
 - `putConfig(config)` - upserts a config document
+- `deleteConfig(configId)` - deletes a config document (used by timer stop)
 
 **Modified functions:**
 
@@ -140,7 +157,6 @@ export function onScheduledTasksCleared() { ... }
 export function onCompletedTasksCleared() { ... }
 export function onAllTasksCleared() { ... }
 
-// Phase 4 additions:
 export function onActivityCreated({ activity }) { ... }
 export function onActivityEdited({ activity }) { ... }
 export function onActivityDeleted({ activity }) { ... }
@@ -160,9 +176,9 @@ handleCompleteTask -> completeTask -> coordinator.onTaskCompleted({ task })
 
 The current implementation uses object payloads such as `coordinator.onTaskCompleted({ task })` rather than primitive arguments.
 
-Pre-Activities, most coordinator events still resolve to `refreshUI()`, with scheduled-task completion confetti as the one distinct cross-cutting side effect. That is acceptable. The value of the coordinator at this stage is the semantic boundary, not a large present-day behavior surface.
+Most coordinator events resolve to `refreshUI()`, which re-renders task lists and the activity log. Scheduled-task completion adds confetti and, when Activities are enabled, fires auto-logging as a fire-and-forget async chain (`.then()/.catch()`) to keep `onTaskCompleted` synchronous. Auto-log failures surface an amber warning toast rather than blocking the completion flow.
 
-As Activities land, new cross-cutting behavior should attach to these semantic events rather than being re-threaded through each handler. That keeps handlers thin and preserves the coordinator as the single post-mutation boundary.
+Cross-cutting behavior attaches to these semantic events rather than being threaded through each handler. That keeps handlers thin and preserves the coordinator as the single post-mutation boundary.
 
 If the coordinator later grows unwieldy with habits, rollover, or richer activity logic, it can evolve into an event bus pattern. There is no need to force that now.
 
@@ -183,11 +199,13 @@ public/js/
 |   |-- clear-handler.js          # clear tasks handler
 |   `-- form-utils.js             # task form extraction, validation
 |-- activities/
-|   |-- manager.js                # activity state management, CRUD, auto-logging
-|   |-- renderer.js               # renders activity log list
-|   |-- insights-renderer.js      # insights dashboard, timeline, charts
-|   |-- handlers.js               # activity event handlers
-|   `-- form-utils.js             # activity form extraction
+|   |-- manager.js                # activity state management, CRUD, createActivityFromTask, live timer
+|   |-- renderer.js               # renders activity log list with inline editing
+|   |-- handlers.js               # activity add/edit/delete handlers
+|   |-- form-utils.js             # activity form extraction (add + edit)
+|   |-- ui-handlers.js            # activity UI orchestration (form routing, list clicks, edit state, timer display)
+|   |-- smoke-hooks.js            # testability hooks for forcing activity failures in preview/smoke
+|   `-- insights-renderer.js      # (Phase 5) insights dashboard, timeline, charts
 |-- app.js                        # boot sequence, DOM setup, storage + room wiring
 |-- app-coordinator.js            # runtime post-mutation orchestration
 |-- storage.js                    # PouchDB persistence layer
@@ -230,11 +248,46 @@ When Activities are disabled: no activity-related DOM, no category dropdown on t
 
 ### UI: Activity Logging
 
-**Auto-logging:** When a scheduled task is completed and Activities are enabled, `createActivityFromTask(task)` creates an activity document copying `description`, `startDateTime`, `endDateTime`, `duration`, and `category`, with `source: 'auto'` and `sourceTaskId`. Silent, no notification.
+**Auto-logging:** When a scheduled task is completed and Activities are enabled, `createActivityFromTask(task)` creates an activity document copying `description`, `startDateTime`, `endDateTime`, `duration`, and `category`, with `source: 'auto'` and `sourceTaskId`. Auto-logging fires as fire-and-forget async work inside the synchronous `onTaskCompleted` coordinator event. On success, `onActivityCreated` triggers a UI refresh showing the new activity. On failure, an amber warning toast surfaces the issue without blocking the completion flow.
 
-**Manual logging:** Third mode on the existing task form, alongside Scheduled and Unscheduled. Accent color is still TBD. Candidates: cyan, sky, or orange.
+**Manual logging:** Third mode on the existing task form, alongside Scheduled and Unscheduled. Accent color: sky.
 
 Fields: description, category dropdown grouped by group, start time, duration (hours/minutes). No priority and no rescheduling logic.
+
+### UI: Live Activity Timer
+
+Bridges the gap between Fortudo's retrospective logging and the real-time start/stop model from [tracks](https://github.com/iconix/tracks). The timer lets you capture what you're doing now with real timestamps, instead of reconstructing it after the fact.
+
+**Activity tab states:** The activity tab in the three-way form toggle has two visual states depending on whether a timer is running:
+
+- **No timer running:** The manual entry form as shipped in Phase 4 (description, category, start time, duration), with two side-by-side action buttons: "Log Activity" and "Start Timer."
+- **Timer running:** The form transforms into a timer display showing the activity description (editable), category dropdown (editable), start time (editable, for backdating), live elapsed counter (`HH:MM:SS` via `setInterval`), and a "Stop" button. Switching to scheduled or unscheduled tabs works normally regardless of timer state. Switching back to the activity tab shows the timer display. All other operations (adding/editing/deleting tasks and activities, completing tasks, auto-logging) continue to work while the timer runs.
+
+**Starting a timer:** Fill in description and optionally category on the activity form, click "Start Timer." Start time defaults to now. The form transforms to the timer display.
+
+**Stopping a timer:** Click "Stop." The running-activity config doc is deleted, a normal activity document is created with computed `endDateTime` and `duration`, and the form reverts to the manual entry state. The new activity appears in the activity log.
+
+**Backdating:** The start time on the timer display is editable via a time picker. Use case: you forgot to start the timer 20 minutes ago.
+
+**Boot restoration:** If a `config-running-activity` doc exists on load, the timer state is silently restored and the elapsed counter resumes from the persisted `startDateTime`. The user stays on whichever tab they land on, but the activity tab gets a brief UI highlight (pulse, badge, or similar) to signal that a timer is running. Navigating to the activity tab shows the timer display.
+
+**Stop triggers:**
+
+1. **Explicit stop** -- user clicks "Stop" button
+2. **Stop-on-start** -- starting a new timer auto-stops the running one (no confirmation). The stopped timer's `endDateTime` is set to now, its activity is created, then the new timer starts. Sequential execution to avoid two config docs existing simultaneously.
+3. **Task completion with overlap** -- when auto-logging fires in `onTaskCompleted`, if the auto-logged activity's time range overlaps with the running timer's active range (`startDateTime` through now), the timer is stopped with `endDateTime` set to the auto-log's `startDateTime`. If no overlap, the timer keeps running. **Guard:** if the early-completion time adjustment shifts the auto-log's `startDateTime` to before the timer's own `startDateTime`, clamp the timer's `endDateTime` to its `startDateTime` (producing a zero-duration activity) rather than creating a negative duration. The zero-duration activity is still saved per the "always create" edge case decision.
+
+**Early task completion adjustment:** When `createActivityFromTask` runs and the task's planned `startDateTime` is in the future, the auto-log times are adjusted: `endDateTime` = now, `startDateTime` = now minus the task's `duration`. This ensures auto-logged activities reflect when the work actually happened rather than when it was planned.
+
+**Unscheduled tasks and the timer:** Completing an unscheduled task does not affect a running timer (unscheduled completions are lightweight and often happen mid-flow). Users who want to track unscheduled work can: start a timer for it, schedule it first then complete for auto-logging, or manually log it after the fact.
+
+**Timer state management** in `activities/manager.js`:
+
+- `startTimer({ description, category })` -- writes config doc, returns running state
+- `stopTimer()` -- reads config doc, computes duration, creates activity, deletes config doc
+- `getRunningActivity()` -- synchronous read from in-memory cache (same pattern as `isActivitiesEnabled()`)
+- `updateRunningActivity({ description, category, startDateTime })` -- updates config doc (for backdating or mid-timer changes)
+- `loadRunningActivity()` -- called during boot, populates in-memory cache
 
 **Category dropdown visual:** Since `<option>` elements cannot be styled with colors consistently cross-browser, the dropdown should stay text-only and grouped by group. A small colored dot or badge can render next to the currently selected category outside the `<select>`.
 
@@ -254,8 +307,8 @@ Accessed via a tab toggle in the header ("Tasks" / "Insights"). The toggle switc
 2. **Activity Log**
    - Chronological list of today's activities
    - Each entry shows description, category badge, time range, and duration
-   - Manual entries are editable and deletable
-   - Auto entries link to their source task
+   - All entries (manual and auto-logged) are editable and deletable via inline editing
+   - Auto entries show a source task link with provenance metadata; editing creates a modified copy retaining `sourceTaskId`
 
 3. **Data Issues**
    - Highlights overlapping activities, end-before-start, and duplicate auto-logged entries
@@ -288,22 +341,25 @@ Accessed via a tab toggle in the header ("Tasks" / "Insights"). The toggle switc
 
 **TDD approach:** Red/green for all new code. Write failing tests first, implement until they pass, then refactor.
 
-**Unit tests needed:**
+**Unit tests (covered through Phase 4):**
 
-- `activities/manager.js` - addActivity, createActivityFromTask, CRUD
-- `activities/handlers.js` - activity handler tests following existing patterns
+- `activities/manager.js` - addActivity, editActivity, removeActivity, createActivityFromTask, CRUD, state management
+- `activities/handlers.js` - add/edit/save/delete handlers, resolveActivityPayload routing
+- `activities/form-utils.js` - extractActivityFormData (add form), extractActivityEditFormData (inline edit), shared field extraction
+- `activities/renderer.js` - renderActivities, renderActivityItem, renderInlineEditActivityItem, source link rendering
+- `activities/smoke-hooks.js` - consumeActivitySmokeFailure, queueActivitySmokeFailure, host gating
+- `app-coordinator.js` (integration) - activity creation/editing/deletion coordination, auto-logging flow
 - `taxonomy/taxonomy-store.js` - seeding, normalization, config-doc persistence
 - `taxonomy/taxonomy-selectors.js` - option helpers, resolution, badge rendering
 - `taxonomy/taxonomy-mutations.js` - taxonomy CRUD and task-reference safety checks
 - `settings-manager.js` - boot loading, PouchDB-backed toggle persistence, legacy migration, failure handling
-- `storage.js` - new activity/config functions, `saveTasks` scoping, migration
-- `app-coordinator.js` - activity-related coordination logic
+- `storage.js` - activity/config functions, `saveTasks` scoping, migration
 
-**Existing tests:** The `tasks/` reorganization, toast system, coordinator hardening, and current orchestration boundary are already covered. New work should extend from that baseline rather than re-proving the foundation.
+**Existing tests:** The `tasks/` reorganization, toast system, coordinator hardening, and orchestration boundary are already covered. Phase 4 extended that baseline with activity-specific unit and integration tests.
 
 **E2E tests:** Add activity tracking E2E coverage once the UI exists.
 
-**Existing smoke coverage:** `scripts/playwright_preview_smoke.py` now covers both storage-level merge-readiness and a seeded phase-3 UI confidence pass, including legacy migration, cross-type isolation, room isolation, synced-preview behavior, taxonomy/settings rendering, group-vs-child task assignment, reload persistence, and referenced-delete safety.
+**Existing smoke coverage:** `scripts/playwright_preview_smoke.py` covers storage-level merge-readiness and seeded UI confidence passes, including legacy migration, cross-type isolation, room isolation, synced-preview behavior, taxonomy/settings rendering, group-vs-child task assignment, reload persistence, and referenced-delete safety. `activities/smoke-hooks.js` provides testability hooks for injecting activity failures in preview/smoke environments (localhost and preview hosts only).
 
 ### Sync Considerations
 
@@ -313,9 +369,11 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 
 ## Open Questions
 
-- **Activity accent color:** cyan, sky, or orange (leaning blue/sky). Try visually during implementation.
+- **Activity accent color:** Currently sky in the implementation. Still open to experimenting with cyan and orange.
 - **Charts:** Hand-rolled HTML/CSS/SVG for v1. If that looks too plain, evaluate either a lightweight library such as uPlot or Frappe Charts, or Chart.js for full interactivity.
 - **Legacy settings migration cleanup:** remove the one-time `fortudo-activities-enabled` migration path after a later release, once it is acceptable to stop supporting users skipping directly from pre-3.9 builds.
+- **Unscheduled task hint:** When Activities are enabled, surface a hint near unscheduled tasks that they won't auto-log on completion. Exact placement and wording TBD.
+- **Timer display compactness:** How compact should the timer display be? One-line minimal bar vs. showing all editable fields (description, category, start time) inline.
 
 ### Phase 4 Design Decisions (resolved)
 
@@ -323,11 +381,23 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 
 2. **Third form mode routing.** `extractActivityFormData()` lives in `activities/form-utils.js` (separate from tasks). Submit routes through `activities/handlers.js`, not the task `add-handler.js`. `dom-renderer.js` gains a three-way mode toggle but delegates to the appropriate module. Manual activity creation flows through `coordinator.onActivityCreated({ activity })`, keeping the coordinator as the consistent post-mutation boundary.
 
-3. **Auto-logging: scheduled tasks only.** Unscheduled tasks lack real start/end times; synthesizing timestamps from estimated duration produces misleading plan-vs-actual data. Users who want to track unscheduled work can either schedule it first (giving it real times, then completing auto-logs naturally) or manually log it.
+3. **Auto-logging: scheduled tasks only.** Unscheduled tasks lack real start/end times; synthesizing timestamps from estimated duration produces misleading plan-vs-actual data. Users who want to track unscheduled work can: start a timer for it (Phase 4.5), schedule it first (giving it real times, then completing auto-logs naturally), or manually log it.
 
-4. **Phase 4 file boundary.** Phase 4 ships: `activities/manager.js`, `activities/handlers.js`, `activities/form-utils.js`, `activities/renderer.js`. Phase 5 ships: `activities/insights-renderer.js`.
+4. **Phase 4 file boundary.** Phase 4 ships: `activities/manager.js`, `activities/handlers.js`, `activities/form-utils.js`, `activities/renderer.js`, `activities/ui-handlers.js`, `activities/smoke-hooks.js`. Phase 5 ships: `activities/insights-renderer.js`.
 
 5. **`isActivitiesEnabled()` stays synchronous.** Boot-time `loadSettings()` populates an in-memory cache from the PouchDB config doc. `isActivitiesEnabled()` remains a synchronous read. Same pattern as `loadTaxonomy()`. No call sites become async.
+
+### Phase 4.5 Design Decisions (resolved)
+
+1. **Timer state as PouchDB config doc, not activity doc.** A running timer is ephemeral coordinator state, not a first-class activity. It becomes an activity only when stopped. This keeps the activity schema clean (no `status: 'running'` partial documents) and avoids confusing insights queries. The config doc syncs across devices and survives page reloads.
+
+2. **No new files.** Timer logic extends `activities/manager.js` (state, start/stop/update) and `activities/ui-handlers.js` (timer display, elapsed counter, form transitions). The timer is a feature of activity management, not a separate module.
+
+3. **Overlap check uses real time ranges, not assumptions.** The auto-log's time range may be shifted (early completion adjustment), may be in the past (task was earlier), or may be in the future (planned for later). The overlap check compares the running timer's active range (`startDateTime` through now) against the auto-log's actual time range. Only true overlaps trigger a timer stop.
+
+4. **Unscheduled task completion does not affect the timer.** Unscheduled tasks are lightweight items often completed mid-flow. No auto-logging, no timer stop. Users track unscheduled work via the timer, schedule-then-complete, or manual logging.
+
+5. **Side-by-side action buttons.** The activity form shows "Log Activity" and "Start Timer" side by side. This keeps the start-new-activity flow to one action when a timer is already running (type, click "Start Timer," old timer auto-stops).
 
 ## Implementation Phases
 
@@ -380,17 +450,34 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 - Load settings during boot via `loadSettings()` before feature-gated UI checks
 - Add failure-path handling so migration does not drop legacy state on failed persistence and toggle writes revert UI state with a toast
 
-### Next Planned Work
+### Completed Activity Logging Work
 
 **Phase 4: Activity logging**
 
-- Add `activities/manager.js` with CRUD and `createActivityFromTask` (scheduled tasks only)
-- Add `activities/form-utils.js` for activity form extraction (separate from task form-utils)
-- Add `activities/handlers.js` with submit handler routing through `coordinator.onActivityCreated`
-- Add third form mode ("Activity") on the main task form via three-way toggle in `dom-renderer.js`
-- Wire auto-logging into scheduled task completion via `coordinator.onTaskCompleted`
-- Add `activities/renderer.js` with chronological today's-activities list (edit/delete for manual, source link for auto)
-- Add empty states for activity views
+- Added `activities/manager.js` with CRUD, `createActivityFromTask` (scheduled tasks only), and state management with clone/normalize pattern
+- Added `activities/form-utils.js` for activity form extraction (add + inline edit), separate from task form-utils
+- Added `activities/handlers.js` with submit handler routing through `coordinator.onActivityCreated`, using `resolveActivityPayload` to accept both data objects and HTMLFormElements
+- Added `activities/renderer.js` with chronological today's-activities list, inline editing for all entries, source task links for auto-logged entries
+- Added `activities/ui-handlers.js` for activity UI orchestration: form routing (`handleActivityAwareFormSubmit`), list click delegation, edit state management, feature-flag-aware show/hide
+- Added `activities/smoke-hooks.js` for testability hooks (force activity failures in preview/smoke environments)
+- Added third form mode ("Activity") via data-driven `TASK_FORM_MODE_CONFIG` three-way toggle in `dom-renderer.js`
+- Wired auto-logging into scheduled task completion as fire-and-forget async in `coordinator.onTaskCompleted`
+- Added empty states for activity views
+- Both manual and auto-logged activities are editable; auto entries retain provenance metadata (`sourceTaskId`) through edits
+
+### Next Planned Work
+
+**Phase 4.5: Live activity timer**
+
+- Add timer state management to `activities/manager.js`: `startTimer`, `stopTimer`, `getRunningActivity`, `updateRunningActivity`, `loadRunningActivity`
+- Add `config-running-activity` PouchDB config doc persistence with in-memory cache
+- Add timer display UI to `activities/ui-handlers.js`: elapsed counter, stop button, editable fields (description, category, start time), form-to-timer and timer-to-form transitions
+- Add side-by-side "Log Activity" / "Start Timer" buttons on the activity form
+- Add stop-on-start behavior (starting a new timer auto-stops the running one)
+- Add early task completion time adjustment in `createActivityFromTask` (shift auto-log window to end at now when task was scheduled in the future)
+- Extend `onTaskCompleted` auto-log chain in coordinator: overlap detection with running timer, auto-stop at auto-log's `startDateTime` when ranges intersect
+- Add boot restoration of running timer from persisted config doc
+- Verify `deleteConfig` exists in `storage.js` or add it
 
 **Phase 4.7: Category editing parity**
 

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -500,6 +500,7 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 
 - Add E2E coverage for activity flows
 - Add a one-time "What's new?" prompt on initial app load after Activities ships, highlighting activity logging, timer capture, and insights
+- Rename orchestration modules to clarify responsibilities, e.g. distinguish the room/session lifecycle coordinator from the post-mutation coordinator (`app-lifecycle.js` / `app-coordinator.js`)
 - Finalize activity accent color
 - Add transitions and micro-interactions
 - Adapt timeline UX for mobile

--- a/docs/plans/2026-04-09-fortudo-activities-phase4.5.md
+++ b/docs/plans/2026-04-09-fortudo-activities-phase4.5.md
@@ -1,0 +1,2060 @@
+# Phase 4.5: Live Activity Timer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a live start/stop timer to the activity tab so users can capture activities in real time rather than logging retroactively.
+
+**Architecture:** Timer state is a PouchDB config document (`config-running-activity`) with an in-memory cache, following the same pattern as `settings-manager.js`. Timer functions extend `activities/manager.js`. Handler functions in `handlers.js` orchestrate stop-on-start and coordinator notifications. The coordinator's `onTaskCompleted` gains overlap detection to auto-stop running timers when auto-logged activities conflict. The activity tab shows a timer display (with editable fields and elapsed counter) when a timer is running, replacing the manual entry form. No new JS files; all logic extends existing modules.
+
+**Tech Stack:** Vanilla JS with ES modules, PouchDB, Tailwind CSS, Jest 30 + jsdom for testing.
+
+**Design doc:** `docs/plans/2026-03-16-fortudo-activities-design.md` — see "UI: Live Activity Timer" and "Phase 4.5 Design Decisions"
+
+---
+
+## File Map
+
+**Modified:**
+| File | Changes |
+|------|---------|
+| `public/js/storage.js` | Add `deleteConfig` export |
+| `public/js/activities/manager.js` | Add 6 timer functions, update `resetActivityState`, update `createActivityFromTask` for early completion, relax `addActivity` duration validation |
+| `public/js/activities/handlers.js` | Add `handleStartTimer`, `handleStopTimer` |
+| `public/js/activities/ui-handlers.js` | Add timer display rendering, elapsed counter, form/timer transitions, `initializeTimerUI`, update `handleActivityAwareFormSubmit` guard, update `syncActivitiesUI` |
+| `public/js/app-coordinator.js` | Extend `onTaskCompleted` with overlap detection + auto-stop |
+| `public/js/dom-renderer.js` | Update `initializeTaskTypeToggle` for Start Timer button visibility |
+| `public/js/app.js` | Boot restoration: `loadRunningActivity`, timer display init, activity tab highlight |
+| `public/index.html` | Add `#task-form-fields` wrapper div, `#timer-display` container, `#start-timer-btn` button |
+| `__tests__/test-utils.js` | Update `setupDOM` with timer HTML elements |
+
+**New:**
+| File | Purpose |
+|------|---------|
+| `__tests__/activity-timer.test.js` | Timer state management + timer handler tests |
+
+**Modified (tests):**
+| File | Changes |
+|------|---------|
+| `__tests__/storage-config.test.js` | Add `deleteConfig` tests |
+| `__tests__/activity-manager.test.js` | Add early completion tests, duration validation edge case |
+| `__tests__/app-coordinator.test.js` | Add overlap detection + auto-stop tests |
+| `__tests__/activity-app-integration.test.js` | Add timer lifecycle integration tests |
+
+---
+
+## Chunk 1: Storage Foundation
+
+### Task 1: Add `deleteConfig` to storage.js
+
+**Files:**
+- Modify: `public/js/storage.js`
+- Test: `__tests__/storage-config.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `__tests__/storage-config.test.js`, add a new `describe('deleteConfig')` block. This file uses real PouchDB with the memory adapter (not mocks).
+
+```js
+const { deleteConfig } = require('../public/js/storage.js');
+
+// Add to existing imports if not already present
+
+describe('deleteConfig', () => {
+    test('deletes a config document by ID', async () => {
+        await putConfig({ id: 'config-test-delete', someSetting: true });
+        const before = await loadConfig('config-test-delete');
+        expect(before).not.toBeNull();
+        expect(before.someSetting).toBe(true);
+
+        await deleteConfig('config-test-delete');
+        const after = await loadConfig('config-test-delete');
+        expect(after).toBeNull();
+    });
+
+    test('succeeds silently when config does not exist', async () => {
+        await expect(deleteConfig('config-nonexistent')).resolves.not.toThrow();
+    });
+
+    test('does not affect other config documents', async () => {
+        await putConfig({ id: 'config-keep', value: 'keep' });
+        await putConfig({ id: 'config-remove', value: 'remove' });
+
+        await deleteConfig('config-remove');
+
+        const kept = await loadConfig('config-keep');
+        expect(kept).not.toBeNull();
+        expect(kept.value).toBe('keep');
+
+        const removed = await loadConfig('config-remove');
+        expect(removed).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/storage-config.test.js -t "deleteConfig" --verbose`
+Expected: FAIL — `deleteConfig` is not exported from storage.js
+
+- [ ] **Step 3: Implement `deleteConfig`**
+
+In `public/js/storage.js`, add the export near the existing `deleteTask` and `deleteActivity` functions. The internal `deleteTypedDoc` helper already handles the deletion pattern:
+
+```js
+export async function deleteConfig(configId) {
+    await deleteTypedDoc(configId, DOC_TYPES.CONFIG, 'config');
+}
+```
+
+Add `deleteConfig` to any barrel exports if the file has them.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/storage-config.test.js -t "deleteConfig" --verbose`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `npx jest --verbose`
+Expected: All existing tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/js/storage.js __tests__/storage-config.test.js
+git commit -m "feat: add deleteConfig to storage layer for timer state cleanup"
+```
+
+---
+
+## Chunk 2: Timer State Management
+
+### Task 2: Timer state primitives + `startTimer` in manager.js
+
+**Files:**
+- Modify: `public/js/activities/manager.js`
+- Create: `__tests__/activity-timer.test.js`
+
+- [ ] **Step 1: Write failing tests for load, get, reset, and startTimer**
+
+Create `__tests__/activity-timer.test.js`:
+
+```js
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/storage.js', () => ({
+    putActivity: jest.fn(() => Promise.resolve()),
+    deleteActivity: jest.fn(() => Promise.resolve()),
+    putConfig: jest.fn(() => Promise.resolve()),
+    loadConfig: jest.fn(() => Promise.resolve(null)),
+    deleteConfig: jest.fn(() => Promise.resolve()),
+}));
+
+const {
+    loadRunningActivity,
+    getRunningActivity,
+    startTimer,
+    resetActivityState,
+} = require('../public/js/activities/manager.js');
+
+const { putConfig, loadConfig } = require('../public/js/storage.js');
+
+const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
+
+describe('Timer state primitives', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+    });
+
+    describe('getRunningActivity', () => {
+        test('returns null when no timer is running', () => {
+            expect(getRunningActivity()).toBeNull();
+        });
+
+        test('returns a clone, not the internal reference', async () => {
+            await startTimer({ description: 'Test' });
+            const a = getRunningActivity();
+            const b = getRunningActivity();
+            expect(a).toEqual(b);
+            expect(a).not.toBe(b);
+        });
+    });
+
+    describe('loadRunningActivity', () => {
+        test('loads running activity from PouchDB config doc', async () => {
+            loadConfig.mockResolvedValueOnce({
+                id: RUNNING_ACTIVITY_CONFIG_ID,
+                description: 'Working on feature',
+                category: 'work/deep',
+                startDateTime: '2026-04-09T10:00:00.000Z',
+            });
+
+            await loadRunningActivity();
+
+            const running = getRunningActivity();
+            expect(running).not.toBeNull();
+            expect(running.description).toBe('Working on feature');
+            expect(running.category).toBe('work/deep');
+            expect(running.startDateTime).toBe('2026-04-09T10:00:00.000Z');
+        });
+
+        test('sets null when no config doc exists', async () => {
+            loadConfig.mockResolvedValueOnce(null);
+            await loadRunningActivity();
+            expect(getRunningActivity()).toBeNull();
+        });
+    });
+
+    describe('resetActivityState', () => {
+        test('clears running timer state', async () => {
+            await startTimer({ description: 'Active timer' });
+            expect(getRunningActivity()).not.toBeNull();
+
+            resetActivityState();
+            expect(getRunningActivity()).toBeNull();
+        });
+    });
+});
+
+describe('startTimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T14:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('creates a running activity with correct fields', async () => {
+        const result = await startTimer({ description: 'Deep work session', category: 'work/deep' });
+
+        expect(result.success).toBe(true);
+        expect(result.runningActivity.description).toBe('Deep work session');
+        expect(result.runningActivity.category).toBe('work/deep');
+        expect(result.runningActivity.startDateTime).toBe('2026-04-09T14:00:00.000Z');
+    });
+
+    test('persists config doc to PouchDB', async () => {
+        await startTimer({ description: 'Test', category: null });
+
+        expect(putConfig).toHaveBeenCalledWith(expect.objectContaining({
+            id: RUNNING_ACTIVITY_CONFIG_ID,
+            description: 'Test',
+            category: null,
+            startDateTime: '2026-04-09T14:00:00.000Z',
+        }));
+    });
+
+    test('updates in-memory cache', async () => {
+        await startTimer({ description: 'Cached' });
+        const running = getRunningActivity();
+        expect(running.description).toBe('Cached');
+    });
+
+    test('trims description whitespace', async () => {
+        const result = await startTimer({ description: '  padded  ' });
+        expect(result.runningActivity.description).toBe('padded');
+    });
+
+    test('rejects empty description', async () => {
+        const result = await startTimer({ description: '' });
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/description/i);
+        expect(putConfig).not.toHaveBeenCalled();
+    });
+
+    test('rejects when timer is already running', async () => {
+        await startTimer({ description: 'First' });
+        jest.clearAllMocks();
+
+        const result = await startTimer({ description: 'Second' });
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/already running/i);
+        expect(putConfig).not.toHaveBeenCalled();
+    });
+
+    test('defaults category to null when not provided', async () => {
+        const result = await startTimer({ description: 'No cat' });
+        expect(result.runningActivity.category).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-timer.test.js --verbose`
+Expected: FAIL — `loadRunningActivity`, `getRunningActivity`, `startTimer` not exported
+
+- [ ] **Step 3: Implement timer state primitives and startTimer**
+
+In `public/js/activities/manager.js`, add imports and timer state:
+
+```js
+// Add to existing imports from storage.js:
+import { putConfig, loadConfig, deleteConfig } from '../storage.js';
+// (putActivity and deleteActivity imports should already exist)
+
+const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
+
+let runningActivity = null;
+```
+
+Add the timer functions (before or after existing activity functions):
+
+```js
+// --- Timer state management ---
+
+export async function loadRunningActivity() {
+    const config = await loadConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    runningActivity = config ? {
+        description: config.description,
+        category: config.category || null,
+        startDateTime: config.startDateTime,
+    } : null;
+}
+
+export function getRunningActivity() {
+    return runningActivity ? { ...runningActivity } : null;
+}
+
+export async function startTimer({ description, category }) {
+    if (!description?.trim()) {
+        return { success: false, reason: 'Description is required to start a timer.' };
+    }
+
+    if (runningActivity) {
+        return { success: false, reason: 'A timer is already running. Stop it first.' };
+    }
+
+    const now = new Date().toISOString();
+    const timerState = {
+        description: description.trim(),
+        category: category || null,
+        startDateTime: now,
+    };
+
+    await putConfig({
+        id: RUNNING_ACTIVITY_CONFIG_ID,
+        ...timerState,
+    });
+
+    runningActivity = timerState;
+    return { success: true, runningActivity: { ...runningActivity } };
+}
+```
+
+Update `resetActivityState` to also clear the timer:
+
+```js
+export function resetActivityState() {
+    activities = [];
+    runningActivity = null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-timer.test.js --verbose`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Run full test suite for regressions**
+
+Run: `npx jest --verbose`
+Expected: All tests pass. The `resetActivityState` change should not break existing tests since it only adds a `null` assignment.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/js/activities/manager.js __tests__/activity-timer.test.js
+git commit -m "feat: add timer state primitives and startTimer to activity manager"
+```
+
+---
+
+### Task 3: `stopTimer`, `stopTimerAt`, `updateRunningActivity` + duration validation
+
+**Files:**
+- Modify: `public/js/activities/manager.js`
+- Modify: `__tests__/activity-timer.test.js`
+- Modify: `__tests__/activity-manager.test.js`
+
+- [ ] **Step 1: Write failing tests for stopTimer, stopTimerAt, and updateRunningActivity**
+
+Append to `__tests__/activity-timer.test.js`:
+
+```js
+const {
+    loadRunningActivity,
+    getRunningActivity,
+    startTimer,
+    stopTimer,
+    stopTimerAt,
+    updateRunningActivity,
+    resetActivityState,
+    getActivityState,
+} = require('../public/js/activities/manager.js');
+
+const { putConfig, loadConfig, deleteConfig, putActivity } = require('../public/js/storage.js');
+
+describe('stopTimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('creates an activity from the running timer', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Working', category: 'work/deep' });
+
+        jest.setSystemTime(new Date('2026-04-09T11:30:00.000Z'));
+        const result = await stopTimer();
+
+        expect(result.success).toBe(true);
+        expect(result.activity.description).toBe('Working');
+        expect(result.activity.category).toBe('work/deep');
+        expect(result.activity.source).toBe('timer');
+        expect(result.activity.sourceTaskId).toBeNull();
+        expect(result.activity.startDateTime).toBe('2026-04-09T10:00:00.000Z');
+        expect(result.activity.endDateTime).toBe('2026-04-09T11:30:00.000Z');
+        expect(result.activity.duration).toBe(90);
+    });
+
+    test('deletes the config doc', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Test' });
+        jest.clearAllMocks();
+
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+        await stopTimer();
+
+        expect(deleteConfig).toHaveBeenCalledWith(RUNNING_ACTIVITY_CONFIG_ID);
+    });
+
+    test('clears the in-memory cache', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Test' });
+
+        jest.setSystemTime(new Date('2026-04-09T10:05:00.000Z'));
+        await stopTimer();
+
+        expect(getRunningActivity()).toBeNull();
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await stopTimer();
+        expect(result.success).toBe(false);
+        expect(result.reason).toMatch(/no timer/i);
+    });
+
+    test('handles zero-duration timer (immediate stop)', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Quick' });
+
+        // Same time — 0 duration
+        const result = await stopTimer();
+        expect(result.success).toBe(true);
+        expect(result.activity.duration).toBe(0);
+    });
+});
+
+describe('stopTimerAt', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('stops timer at a specific endDateTime', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Working' });
+
+        jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        const result = await stopTimerAt('2026-04-09T10:45:00.000Z');
+
+        expect(result.success).toBe(true);
+        expect(result.activity.endDateTime).toBe('2026-04-09T10:45:00.000Z');
+        expect(result.activity.duration).toBe(45);
+    });
+
+    test('clamps to zero duration when endDateTime is before startDateTime', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+        await startTimer({ description: 'Late start' });
+
+        jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        // endDateTime before the timer's startDateTime
+        const result = await stopTimerAt('2026-04-09T10:00:00.000Z');
+
+        expect(result.success).toBe(true);
+        expect(result.activity.duration).toBe(0);
+        expect(result.activity.startDateTime).toBe('2026-04-09T10:30:00.000Z');
+        expect(result.activity.endDateTime).toBe('2026-04-09T10:30:00.000Z');
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await stopTimerAt('2026-04-09T10:00:00.000Z');
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('updateRunningActivity', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('updates description on running timer', async () => {
+        await startTimer({ description: 'Original' });
+        jest.clearAllMocks();
+
+        const result = await updateRunningActivity({ description: 'Updated' });
+
+        expect(result.success).toBe(true);
+        expect(result.runningActivity.description).toBe('Updated');
+        expect(getRunningActivity().description).toBe('Updated');
+        expect(putConfig).toHaveBeenCalledWith(expect.objectContaining({
+            id: RUNNING_ACTIVITY_CONFIG_ID,
+            description: 'Updated',
+        }));
+    });
+
+    test('updates category on running timer', async () => {
+        await startTimer({ description: 'Test', category: 'work/deep' });
+
+        const result = await updateRunningActivity({ category: 'work/meetings' });
+        expect(result.runningActivity.category).toBe('work/meetings');
+    });
+
+    test('updates startDateTime for backdating', async () => {
+        await startTimer({ description: 'Forgot to start' });
+
+        const result = await updateRunningActivity({
+            startDateTime: '2026-04-09T09:30:00.000Z',
+        });
+        expect(result.runningActivity.startDateTime).toBe('2026-04-09T09:30:00.000Z');
+    });
+
+    test('rejects empty description', async () => {
+        await startTimer({ description: 'Valid' });
+
+        const result = await updateRunningActivity({ description: '' });
+        expect(result.success).toBe(false);
+        expect(getRunningActivity().description).toBe('Valid');
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await updateRunningActivity({ description: 'No timer' });
+        expect(result.success).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Write failing test for zero-duration in addActivity**
+
+In `__tests__/activity-manager.test.js`, add:
+
+```js
+test('addActivity accepts zero duration', async () => {
+    const result = await addActivity({
+        description: 'Zero duration edge case',
+        startDateTime: '2026-04-09T10:00:00.000Z',
+        endDateTime: '2026-04-09T10:00:00.000Z',
+        duration: 0,
+        source: 'timer',
+        sourceTaskId: null,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.activity.duration).toBe(0);
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-timer.test.js __tests__/activity-manager.test.js --verbose`
+Expected: FAIL — `stopTimer`, `stopTimerAt`, `updateRunningActivity` not exported; zero-duration addActivity fails validation
+
+- [ ] **Step 4: Implement stopTimer, stopTimerAt, updateRunningActivity**
+
+In `public/js/activities/manager.js`, add after `startTimer`:
+
+```js
+export async function stopTimer() {
+    if (!runningActivity) {
+        return { success: false, reason: 'No timer is currently running.' };
+    }
+
+    const now = new Date();
+    const start = new Date(runningActivity.startDateTime);
+    const durationMinutes = Math.max(0, Math.round((now - start) / 60000));
+
+    const activityData = {
+        description: runningActivity.description,
+        category: runningActivity.category,
+        startDateTime: runningActivity.startDateTime,
+        endDateTime: now.toISOString(),
+        duration: durationMinutes,
+        source: 'timer',
+        sourceTaskId: null,
+    };
+
+    await deleteConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    runningActivity = null;
+
+    return addActivity(activityData);
+}
+
+export async function stopTimerAt(endDateTime) {
+    if (!runningActivity) {
+        return { success: false, reason: 'No timer is currently running.' };
+    }
+
+    const start = new Date(runningActivity.startDateTime);
+    const end = new Date(endDateTime);
+
+    // Guard: clamp to startDateTime if end is before start (zero-duration)
+    const effectiveEnd = end <= start ? start : end;
+    const durationMinutes = Math.max(0, Math.round((effectiveEnd - start) / 60000));
+
+    const activityData = {
+        description: runningActivity.description,
+        category: runningActivity.category,
+        startDateTime: runningActivity.startDateTime,
+        endDateTime: effectiveEnd.toISOString(),
+        duration: durationMinutes,
+        source: 'timer',
+        sourceTaskId: null,
+    };
+
+    await deleteConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    runningActivity = null;
+
+    return addActivity(activityData);
+}
+
+export async function updateRunningActivity(updates) {
+    if (!runningActivity) {
+        return { success: false, reason: 'No timer is currently running.' };
+    }
+
+    const merged = { ...runningActivity, ...updates };
+
+    if (!merged.description?.trim()) {
+        return { success: false, reason: 'Description cannot be empty.' };
+    }
+
+    runningActivity = {
+        description: merged.description.trim(),
+        category: merged.category || null,
+        startDateTime: merged.startDateTime,
+    };
+
+    await putConfig({
+        id: RUNNING_ACTIVITY_CONFIG_ID,
+        ...runningActivity,
+    });
+
+    return { success: true, runningActivity: { ...runningActivity } };
+}
+```
+
+- [ ] **Step 5: Relax `addActivity` duration validation**
+
+In `public/js/activities/manager.js`, find the `addActivity` function's duration validation. Change the check from rejecting `duration <= 0` (or falsy duration) to only rejecting negative duration:
+
+```js
+// Before (one of these patterns):
+// if (!activityData.duration || activityData.duration <= 0) {
+// if (activityData.duration <= 0) {
+
+// After:
+if (typeof activityData.duration !== 'number' || activityData.duration < 0) {
+```
+
+This allows zero-duration activities from the timer edge case while still rejecting negative or non-numeric values.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-timer.test.js __tests__/activity-manager.test.js --verbose`
+Expected: PASS (all tests)
+
+- [ ] **Step 7: Run full test suite for regressions**
+
+Run: `npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add public/js/activities/manager.js __tests__/activity-timer.test.js __tests__/activity-manager.test.js
+git commit -m "feat: add stopTimer, stopTimerAt, updateRunningActivity with zero-duration support"
+```
+
+---
+
+## Chunk 3: Timer Handlers
+
+### Task 4: `handleStartTimer` and `handleStopTimer` in handlers.js
+
+**Files:**
+- Modify: `public/js/activities/handlers.js`
+- Modify: `__tests__/activity-timer.test.js`
+
+- [ ] **Step 1: Write failing tests for timer handlers**
+
+Append to `__tests__/activity-timer.test.js`. These tests need the handlers module and mocked coordinator:
+
+```js
+jest.mock('../public/js/app-coordinator.js', () => ({
+    onActivityCreated: jest.fn(),
+    onActivityEdited: jest.fn(),
+    onActivityDeleted: jest.fn(),
+}));
+
+jest.mock('../public/js/toast-manager.js', () => ({
+    showToast: jest.fn(),
+}));
+
+// Mock showAlert on window
+beforeAll(() => {
+    window.showAlert = jest.fn();
+});
+
+const { handleStartTimer, handleStopTimer } = require('../public/js/activities/handlers.js');
+const { onActivityCreated } = require('../public/js/app-coordinator.js');
+const { showToast } = require('../public/js/toast-manager.js');
+
+describe('handleStartTimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('starts a timer and shows toast', async () => {
+        const result = await handleStartTimer({ description: 'Working', category: 'work/deep' });
+
+        expect(result.success).toBe(true);
+        expect(getRunningActivity()).not.toBeNull();
+        expect(showToast).toHaveBeenCalledWith('Timer started.', { theme: 'sky' });
+    });
+
+    test('stop-on-start: stops running timer before starting new one', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'First' });
+        jest.clearAllMocks();
+
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+        const result = await handleStartTimer({ description: 'Second' });
+
+        expect(result.success).toBe(true);
+        expect(getRunningActivity().description).toBe('Second');
+        // The stopped timer should have triggered onActivityCreated
+        expect(onActivityCreated).toHaveBeenCalledWith(
+            expect.objectContaining({
+                activity: expect.objectContaining({
+                    description: 'First',
+                    source: 'timer',
+                    duration: 30,
+                }),
+            })
+        );
+    });
+
+    test('rejects empty description', async () => {
+        const result = await handleStartTimer({ description: '' });
+        expect(result.success).toBe(false);
+        expect(getRunningActivity()).toBeNull();
+    });
+});
+
+describe('handleStopTimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resetActivityState();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('stops timer, creates activity, notifies coordinator', async () => {
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Working' });
+        jest.clearAllMocks();
+
+        jest.setSystemTime(new Date('2026-04-09T11:00:00.000Z'));
+        const result = await handleStopTimer();
+
+        expect(result.success).toBe(true);
+        expect(getRunningActivity()).toBeNull();
+        expect(onActivityCreated).toHaveBeenCalledWith(
+            expect.objectContaining({
+                activity: expect.objectContaining({
+                    description: 'Working',
+                    source: 'timer',
+                }),
+            })
+        );
+        expect(showToast).toHaveBeenCalledWith('Activity logged.', { theme: 'sky' });
+    });
+
+    test('returns failure when no timer is running', async () => {
+        const result = await handleStopTimer();
+        expect(result.success).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-timer.test.js -t "handleStartTimer|handleStopTimer" --verbose`
+Expected: FAIL — `handleStartTimer`, `handleStopTimer` not exported
+
+- [ ] **Step 3: Implement timer handlers**
+
+In `public/js/activities/handlers.js`, add imports:
+
+```js
+import { startTimer, stopTimer, getRunningActivity } from './manager.js';
+```
+
+Add the handler functions:
+
+```js
+export async function handleStartTimer({ description, category }) {
+    try {
+        // Stop-on-start: if a timer is already running, stop it first
+        const running = getRunningActivity();
+        if (running) {
+            const stopResult = await stopTimer();
+            if (stopResult?.success && stopResult.activity) {
+                onActivityCreated({ activity: stopResult.activity });
+            }
+        }
+
+        const result = await startTimer({ description, category });
+        if (!result.success) {
+            showAlert(result.reason, 'sky');
+            return result;
+        }
+
+        showToast('Timer started.', { theme: 'sky' });
+        return result;
+    } catch (error) {
+        logger.error('Failed to start timer:', error);
+        showAlert(`Failed to start timer: ${error.message}`, 'sky');
+        return { success: false, reason: error.message };
+    }
+}
+
+export async function handleStopTimer() {
+    try {
+        const result = await stopTimer();
+        if (!result.success) {
+            showAlert(result.reason, 'sky');
+            return result;
+        }
+
+        if (result.activity) {
+            onActivityCreated({ activity: result.activity });
+        }
+
+        showToast('Activity logged.', { theme: 'sky' });
+        return result;
+    } catch (error) {
+        logger.error('Failed to stop timer:', error);
+        showAlert(`Failed to stop timer: ${error.message}`, 'sky');
+        return { success: false, reason: error.message };
+    }
+}
+```
+
+Add `logger` to imports if not already present:
+```js
+import { logger } from '../utils.js';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-timer.test.js --verbose`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/js/activities/handlers.js __tests__/activity-timer.test.js
+git commit -m "feat: add handleStartTimer and handleStopTimer with stop-on-start orchestration"
+```
+
+---
+
+## Chunk 4: Auto-Logging Enhancements
+
+### Task 5: Early completion time adjustment in `createActivityFromTask`
+
+**Files:**
+- Modify: `public/js/activities/manager.js`
+- Modify: `__tests__/activity-manager.test.js`
+
+- [ ] **Step 1: Write failing tests for early completion adjustment**
+
+In `__tests__/activity-manager.test.js`, add to the `createActivityFromTask` describe block:
+
+```js
+describe('early completion adjustment', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T14:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('uses original times when task endDateTime is in the past', () => {
+        const task = {
+            id: 'sched-1',
+            description: 'Past task',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T13:00:00.000Z',
+            endDateTime: '2026-04-09T13:30:00.000Z',
+            duration: 30,
+        };
+
+        const activity = createActivityFromTask(task);
+        expect(activity.startDateTime).toBe('2026-04-09T13:00:00.000Z');
+        expect(activity.endDateTime).toBe('2026-04-09T13:30:00.000Z');
+        expect(activity.duration).toBe(30);
+    });
+
+    test('shifts time window when task startDateTime is in the future', () => {
+        // Task scheduled for 15:00-15:30 but completed now (14:00)
+        const task = {
+            id: 'sched-2',
+            description: 'Future task done early',
+            category: null,
+            startDateTime: '2026-04-09T15:00:00.000Z',
+            endDateTime: '2026-04-09T15:30:00.000Z',
+            duration: 30,
+        };
+
+        const activity = createActivityFromTask(task);
+        // endDateTime = now (14:00), startDateTime = now - 30min (13:30)
+        expect(activity.endDateTime).toBe('2026-04-09T14:00:00.000Z');
+        expect(activity.startDateTime).toBe('2026-04-09T13:30:00.000Z');
+        expect(activity.duration).toBe(30);
+    });
+
+    test('preserves source and sourceTaskId on adjusted activities', () => {
+        const task = {
+            id: 'sched-3',
+            description: 'Early',
+            startDateTime: '2026-04-09T16:00:00.000Z',
+            endDateTime: '2026-04-09T17:00:00.000Z',
+            duration: 60,
+        };
+
+        const activity = createActivityFromTask(task);
+        expect(activity.source).toBe('auto');
+        expect(activity.sourceTaskId).toBe('sched-3');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-manager.test.js -t "early completion" --verbose`
+Expected: FAIL — future-task test expects adjusted times but gets original times
+
+- [ ] **Step 3: Implement early completion adjustment**
+
+In `public/js/activities/manager.js`, update `createActivityFromTask`:
+
+```js
+export function createActivityFromTask(task) {
+    if (!task) return null;
+
+    const now = new Date();
+    let startDateTime = task.startDateTime;
+    let endDateTime = task.endDateTime;
+    const duration = task.duration;
+
+    // Early completion: if task was scheduled for the future, shift to end at now
+    if (new Date(startDateTime) > now) {
+        endDateTime = now.toISOString();
+        startDateTime = new Date(now.getTime() - duration * 60000).toISOString();
+    }
+
+    return {
+        description: task.description,
+        category: task.category || null,
+        startDateTime,
+        endDateTime,
+        duration,
+        source: 'auto',
+        sourceTaskId: task.id || null,
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-manager.test.js --verbose`
+Expected: PASS (all tests including existing ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/js/activities/manager.js __tests__/activity-manager.test.js
+git commit -m "feat: adjust auto-log times when completing tasks scheduled in the future"
+```
+
+---
+
+### Task 6: Overlap detection + auto-stop in `onTaskCompleted`
+
+**Files:**
+- Modify: `public/js/app-coordinator.js`
+- Modify: `__tests__/app-coordinator.test.js`
+
+- [ ] **Step 1: Write failing tests for overlap detection**
+
+In `__tests__/app-coordinator.test.js`, add the timer-related imports to the mock setup. The file already mocks `activities/manager.js`; add `getRunningActivity` and `stopTimerAt` to the mock:
+
+```js
+// Add to the existing jest.mock for activities/manager.js:
+getRunningActivity: jest.fn(() => null),
+stopTimerAt: jest.fn(() => Promise.resolve({ success: true, activity: { id: 'timer-act', description: 'Timer' } })),
+```
+
+Add a new describe block:
+
+```js
+const { getRunningActivity, stopTimerAt } = require('../public/js/activities/manager.js');
+
+describe('onTaskCompleted — timer overlap', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T14:00:00.000Z'));
+        isActivitiesEnabled.mockReturnValue(true);
+        addActivity.mockResolvedValue({ success: true, activity: { id: 'auto-act' } });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('auto-stops timer when auto-log overlaps with running timer', async () => {
+        getRunningActivity.mockReturnValue({
+            description: 'Timer task',
+            category: null,
+            startDateTime: '2026-04-09T13:00:00.000Z',
+        });
+
+        const task = {
+            id: 'sched-1', type: 'scheduled', description: 'Done task',
+            startDateTime: '2026-04-09T13:30:00.000Z',
+            endDateTime: '2026-04-09T14:00:00.000Z',
+            duration: 30,
+        };
+
+        onTaskCompleted({ task });
+
+        // Wait for the fire-and-forget chain
+        await jest.runAllTimersAsync();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(stopTimerAt).toHaveBeenCalledWith('2026-04-09T13:30:00.000Z');
+    });
+
+    test('does not stop timer when auto-log does not overlap', async () => {
+        getRunningActivity.mockReturnValue({
+            description: 'Timer task',
+            category: null,
+            startDateTime: '2026-04-09T13:45:00.000Z',
+        });
+
+        // Task was 10:00-10:30, timer started at 13:45 — no overlap
+        const task = {
+            id: 'sched-2', type: 'scheduled', description: 'Old task',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+            endDateTime: '2026-04-09T10:30:00.000Z',
+            duration: 30,
+        };
+
+        onTaskCompleted({ task });
+
+        await jest.runAllTimersAsync();
+        await Promise.resolve();
+
+        expect(stopTimerAt).not.toHaveBeenCalled();
+        expect(addActivity).toHaveBeenCalled();
+    });
+
+    test('does not check timer when no timer is running', async () => {
+        getRunningActivity.mockReturnValue(null);
+
+        const task = {
+            id: 'sched-3', type: 'scheduled', description: 'Normal',
+            startDateTime: '2026-04-09T13:00:00.000Z',
+            endDateTime: '2026-04-09T14:00:00.000Z',
+            duration: 60,
+        };
+
+        onTaskCompleted({ task });
+
+        await jest.runAllTimersAsync();
+        await Promise.resolve();
+
+        expect(stopTimerAt).not.toHaveBeenCalled();
+        expect(addActivity).toHaveBeenCalled();
+    });
+
+    test('sequences stop-then-auto-log when overlap exists', async () => {
+        getRunningActivity.mockReturnValue({
+            description: 'Timer',
+            category: null,
+            startDateTime: '2026-04-09T13:00:00.000Z',
+        });
+
+        const callOrder = [];
+        stopTimerAt.mockImplementation(() => {
+            callOrder.push('stopTimerAt');
+            return Promise.resolve({ success: true, activity: { id: 'timer-act' } });
+        });
+        addActivity.mockImplementation(() => {
+            callOrder.push('addActivity');
+            return Promise.resolve({ success: true, activity: { id: 'auto-act' } });
+        });
+
+        const task = {
+            id: 'sched-4', type: 'scheduled', description: 'Task',
+            startDateTime: '2026-04-09T13:30:00.000Z',
+            endDateTime: '2026-04-09T14:00:00.000Z',
+            duration: 30,
+        };
+
+        onTaskCompleted({ task });
+
+        await jest.runAllTimersAsync();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(callOrder).toEqual(['stopTimerAt', 'addActivity']);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/app-coordinator.test.js -t "timer overlap" --verbose`
+Expected: FAIL — `stopTimerAt` never called because the overlap logic doesn't exist yet
+
+- [ ] **Step 3: Implement overlap detection in `onTaskCompleted`**
+
+In `public/js/app-coordinator.js`, add imports:
+
+```js
+import { addActivity, createActivityFromTask, getRunningActivity, stopTimerAt } from './activities/manager.js';
+```
+
+Add the overlap helper (module-private):
+
+```js
+function timerOverlapsActivity(running, activity) {
+    const timerStart = new Date(running.startDateTime).getTime();
+    const now = Date.now();
+    const actStart = new Date(activity.startDateTime).getTime();
+    const actEnd = new Date(activity.endDateTime).getTime();
+    // Two ranges [timerStart, now] and [actStart, actEnd] overlap iff:
+    return timerStart < actEnd && actStart < now;
+}
+```
+
+Replace the auto-logging section of `onTaskCompleted` with the overlap-aware version:
+
+```js
+export function onTaskCompleted({ task }) {
+    if (!refreshWhenPresent(task)) { return; }
+    if (task.type !== 'scheduled') { return; }
+
+    triggerConfettiAnimation(task.id);
+
+    if (isActivitiesEnabled()) {
+        const activity = createActivityFromTask(task);
+        if (activity) {
+            const running = getRunningActivity();
+            const hasOverlap = running && timerOverlapsActivity(running, activity);
+
+            const timerStopPromise = hasOverlap
+                ? stopTimerAt(activity.startDateTime)
+                : Promise.resolve(null);
+
+            void timerStopPromise
+                .then((timerResult) => {
+                    if (timerResult?.success && timerResult.activity) {
+                        onActivityCreated({ activity: timerResult.activity });
+                    }
+                    // Now auto-log the completed task
+                    return consumeActivitySmokeFailure('auto-log')
+                        ? Promise.reject(new Error('Smoke forced activity auto-log failure.'))
+                        : addActivity(activity);
+                })
+                .then((result) => {
+                    if (result?.success && result.activity) {
+                        onActivityCreated({ activity: result.activity });
+                    }
+                })
+                .catch((error) => {
+                    logger.error('Failed to auto-log completed task as activity:', error);
+                    showToast('Task completed, but activity auto-log failed.', { theme: 'amber' });
+                });
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/app-coordinator.test.js --verbose`
+Expected: PASS (all tests including existing ones)
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/js/app-coordinator.js __tests__/app-coordinator.test.js
+git commit -m "feat: auto-stop running timer on task completion when time ranges overlap"
+```
+
+---
+
+## Chunk 5: HTML + Form Updates
+
+### Task 7: HTML structure updates + test-utils DOM
+
+**Files:**
+- Modify: `public/index.html`
+- Modify: `__tests__/test-utils.js`
+
+- [ ] **Step 1: Add `#task-form-fields` wrapper div to index.html**
+
+In `public/index.html`, find the `<form id="task-form">`. Inside that form, after the radio toggle `<div class="flex flex-col sm:flex-row sm:space-x-4 mb-2">` closing `</div>`, wrap all remaining form children (description input, `#time-inputs`, `#priority-input`, category elements, submit button) in a new div:
+
+```html
+<div id="task-form-fields">
+    <!-- All existing form inputs from description through submit button go here -->
+    <!-- Do NOT move the radio toggle div inside this wrapper -->
+</div>
+```
+
+- [ ] **Step 2: Add `#start-timer-btn` next to the submit button**
+
+Find the `<button id="add-task"` submit button. Wrap it and a new Start Timer button in a flex container:
+
+```html
+<div class="flex gap-2">
+    <button id="add-task" type="submit"
+        class="flex-1 py-2 sm:py-3 px-4 sm:px-6 bg-gradient-to-r from-teal-500 to-teal-400 text-white font-bold rounded-xl shadow-lg hover:shadow-teal-500/25 hover:scale-105 active:scale-95 transition-all duration-200">
+        <i class="fa-solid fa-plus mr-1"></i> Add Task
+    </button>
+    <button id="start-timer-btn" type="button"
+        class="hidden flex-1 py-2 sm:py-3 px-4 sm:px-6 bg-gradient-to-r from-sky-600 to-sky-500 text-white font-bold rounded-xl shadow-lg hover:shadow-sky-500/25 hover:scale-105 active:scale-95 transition-all duration-200">
+        <i class="fa-solid fa-play mr-1"></i> Start Timer
+    </button>
+</div>
+```
+
+Note: The existing `#add-task` button may not have a flex wrapper. If it is standalone, wrap both buttons in the `<div class="flex gap-2">`. If it already has a wrapper, add the new button inside.
+
+- [ ] **Step 3: Add `#timer-display` container**
+
+After the closing `</div>` of `#task-form-fields` but still inside the `<form>`, add:
+
+```html
+<div id="timer-display" class="hidden p-3 sm:p-4 bg-slate-800/50 rounded-xl border border-sky-500/30 space-y-3">
+    <div class="flex items-center justify-between">
+        <div id="timer-elapsed" class="text-sky-400 font-mono text-2xl sm:text-3xl tracking-wider">00:00:00</div>
+        <button id="timer-stop-btn" type="button"
+            class="py-2 px-4 sm:px-6 bg-gradient-to-r from-sky-500 to-sky-400 text-white font-bold rounded-xl shadow-lg hover:shadow-sky-500/25 hover:scale-105 active:scale-95 transition-all duration-200">
+            <i class="fa-solid fa-stop mr-1"></i> Stop
+        </button>
+    </div>
+    <div class="space-y-2">
+        <input id="timer-description" type="text" placeholder="What are you working on?"
+            class="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-slate-200 placeholder-slate-500 focus:border-sky-400 focus:ring-1 focus:ring-sky-400 focus:outline-none transition-colors" />
+        <div class="flex flex-col sm:flex-row gap-2">
+            <select id="timer-category"
+                class="flex-1 px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-400 focus:outline-none transition-colors">
+                <option value="">No category</option>
+            </select>
+            <div class="flex items-center gap-2">
+                <label class="text-slate-400 text-sm whitespace-nowrap">Started at</label>
+                <input id="timer-start-time" type="time"
+                    class="px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-400 focus:outline-none transition-colors" />
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+- [ ] **Step 4: Update `setupDOM` in test-utils.js**
+
+In `__tests__/test-utils.js`, find the `setupDOM()` function's HTML template. Add the same structural changes:
+
+1. Wrap the form inputs (below the radio toggle) in `<div id="task-form-fields">...</div>`
+2. Add `<button id="start-timer-btn" type="button" class="hidden">Start Timer</button>` next to the `#add-task` button
+3. Add the `#timer-display` div after `#task-form-fields`:
+
+```html
+<div id="timer-display" class="hidden">
+    <div id="timer-elapsed">00:00:00</div>
+    <button id="timer-stop-btn" type="button">Stop</button>
+    <input id="timer-description" type="text" />
+    <select id="timer-category"><option value="">No category</option></select>
+    <input id="timer-start-time" type="time" />
+</div>
+```
+
+The test-utils version can be simplified (no Tailwind classes needed for DOM structure tests).
+
+- [ ] **Step 5: Run full test suite to verify no regressions**
+
+Run: `npx jest --verbose`
+Expected: All tests pass. The HTML wrapper should not break existing DOM queries.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/index.html __tests__/test-utils.js
+git commit -m "feat: add timer display HTML structure and Start Timer button"
+```
+
+---
+
+### Task 8: Update `initializeTaskTypeToggle` for Start Timer button
+
+**Files:**
+- Modify: `public/js/dom-renderer.js`
+
+- [ ] **Step 1: Update `applyTaskFormMode` to show/hide Start Timer button**
+
+In `public/js/dom-renderer.js`, inside the `initializeTaskTypeToggle` function, find where DOM refs are collected. Add:
+
+```js
+const startTimerBtn = document.getElementById('start-timer-btn');
+```
+
+Inside the `applyTaskFormMode` function, after the existing submit button updates, add:
+
+```js
+// Show Start Timer button only in activity mode
+if (startTimerBtn) {
+    startTimerBtn.classList.toggle('hidden', mode !== 'activity');
+}
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/dom-renderer.js
+git commit -m "feat: show Start Timer button when activity form mode is selected"
+```
+
+---
+
+## Chunk 6: Timer Display UI
+
+### Task 9: Timer display rendering + elapsed counter in ui-handlers.js
+
+**Files:**
+- Modify: `public/js/activities/ui-handlers.js`
+- Modify: `__tests__/activity-app-integration.test.js`
+
+- [ ] **Step 1: Write failing tests for timer display functions**
+
+In `__tests__/activity-app-integration.test.js`, add a new describe block for timer display:
+
+```js
+const { showTimerDisplay, hideTimerDisplay } = require('../public/js/activities/ui-handlers.js');
+const { getRunningActivity } = require('../public/js/activities/manager.js');
+
+describe('Timer display rendering', () => {
+    beforeEach(() => {
+        setupDOM();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('showTimerDisplay hides form fields and shows timer', () => {
+        showTimerDisplay({
+            description: 'Working',
+            category: null,
+            startDateTime: '2026-04-09T10:00:00.000Z',
+        });
+
+        expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(false);
+    });
+
+    test('showTimerDisplay populates editable fields', () => {
+        showTimerDisplay({
+            description: 'Deep work',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T09:30:00.000Z',
+        });
+
+        expect(document.getElementById('timer-description').value).toBe('Deep work');
+        expect(document.getElementById('timer-start-time').value).toBe('09:30');
+    });
+
+    test('showTimerDisplay starts elapsed counter', () => {
+        showTimerDisplay({
+            description: 'Test',
+            startDateTime: '2026-04-09T09:00:00.000Z',
+        });
+
+        // At 10:00, elapsed from 09:00 = 1h 0m 0s
+        expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:00');
+
+        // Advance 30 seconds
+        jest.advanceTimersByTime(30000);
+        expect(document.getElementById('timer-elapsed').textContent).toBe('01:00:30');
+    });
+
+    test('hideTimerDisplay shows form fields and hides timer', () => {
+        showTimerDisplay({
+            description: 'Test',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+        });
+
+        hideTimerDisplay();
+
+        expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(true);
+    });
+
+    test('hideTimerDisplay stops the elapsed counter', () => {
+        showTimerDisplay({
+            description: 'Test',
+            startDateTime: '2026-04-09T10:00:00.000Z',
+        });
+
+        hideTimerDisplay();
+        const textAfterHide = document.getElementById('timer-elapsed').textContent;
+
+        jest.advanceTimersByTime(5000);
+        expect(document.getElementById('timer-elapsed').textContent).toBe(textAfterHide);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-app-integration.test.js -t "Timer display" --verbose`
+Expected: FAIL — `showTimerDisplay`, `hideTimerDisplay` not exported
+
+- [ ] **Step 3: Implement timer display functions**
+
+In `public/js/activities/ui-handlers.js`, add module state and display functions:
+
+```js
+let timerIntervalId = null;
+
+export function showTimerDisplay(runningActivity) {
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+    if (!formFields || !timerDisplay) return;
+
+    formFields.classList.add('hidden');
+    timerDisplay.classList.remove('hidden');
+
+    // Populate editable fields
+    const descInput = document.getElementById('timer-description');
+    const startInput = document.getElementById('timer-start-time');
+
+    if (descInput) descInput.value = runningActivity.description || '';
+    if (startInput && runningActivity.startDateTime) {
+        // Extract HH:MM in local time — input type="time" uses local time
+        const date = new Date(runningActivity.startDateTime);
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        startInput.value = `${hours}:${minutes}`;
+    }
+
+    // Populate timer category dropdown from taxonomy
+    const timerCat = document.getElementById('timer-category');
+    if (timerCat) {
+        // Re-use the same category options as the main form
+        const mainCatSelect = document.querySelector('#task-form select[name="category"]');
+        if (mainCatSelect) {
+            timerCat.innerHTML = mainCatSelect.innerHTML;
+        }
+        timerCat.value = runningActivity.category || '';
+    }
+
+    startElapsedCounter(runningActivity.startDateTime);
+}
+
+export function hideTimerDisplay() {
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+    if (!formFields || !timerDisplay) return;
+
+    stopElapsedCounter();
+    timerDisplay.classList.add('hidden');
+    formFields.classList.remove('hidden');
+}
+
+function startElapsedCounter(startDateTime) {
+    stopElapsedCounter();
+    const startMs = new Date(startDateTime).getTime();
+    const elapsedEl = document.getElementById('timer-elapsed');
+    if (!elapsedEl) return;
+
+    function update() {
+        const elapsed = Date.now() - startMs;
+        const h = Math.floor(elapsed / 3600000);
+        const m = Math.floor((elapsed % 3600000) / 60000);
+        const s = Math.floor((elapsed % 60000) / 1000);
+        elapsedEl.textContent =
+            `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    }
+
+    update();
+    timerIntervalId = setInterval(update, 1000);
+}
+
+function stopElapsedCounter() {
+    if (timerIntervalId) {
+        clearInterval(timerIntervalId);
+        timerIntervalId = null;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-app-integration.test.js -t "Timer display" --verbose`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/js/activities/ui-handlers.js __tests__/activity-app-integration.test.js
+git commit -m "feat: add timer display rendering with elapsed counter and editable fields"
+```
+
+---
+
+### Task 10: Timer interaction handlers + form/timer transitions
+
+**Files:**
+- Modify: `public/js/activities/ui-handlers.js`
+- Modify: `__tests__/activity-app-integration.test.js`
+
+- [ ] **Step 1: Write failing tests for timer interactions**
+
+Append to the timer display describe block in `__tests__/activity-app-integration.test.js`:
+
+```js
+const { initializeTimerUI, syncTimerFormState } = require('../public/js/activities/ui-handlers.js');
+const { handleStartTimer, handleStopTimer } = require('../public/js/activities/handlers.js');
+const { startTimer, resetActivityState, getRunningActivity } = require('../public/js/activities/manager.js');
+
+describe('syncTimerFormState', () => {
+    beforeEach(() => {
+        setupDOM();
+        resetActivityState();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('shows timer display when activity tab selected and timer running', async () => {
+        await startTimer({ description: 'Running' });
+        document.getElementById('activity').checked = true;
+
+        syncTimerFormState();
+
+        expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(false);
+    });
+
+    test('shows form fields when activity tab selected and no timer', () => {
+        document.getElementById('activity').checked = true;
+
+        syncTimerFormState();
+
+        expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(false);
+    });
+
+    test('shows form fields and hides timer when scheduled tab selected even with timer running', async () => {
+        await startTimer({ description: 'Running' });
+        document.getElementById('scheduled').checked = true;
+
+        syncTimerFormState();
+
+        expect(document.getElementById('task-form-fields').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('timer-display').classList.contains('hidden')).toBe(true);
+    });
+
+    test('hides Start Timer button on non-activity tabs', () => {
+        document.getElementById('scheduled').checked = true;
+
+        syncTimerFormState();
+
+        expect(document.getElementById('start-timer-btn').classList.contains('hidden')).toBe(true);
+    });
+});
+
+describe('handleActivityAwareFormSubmit with timer', () => {
+    test('prevents form submission when activity tab has running timer', async () => {
+        setupDOM();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+        await startTimer({ description: 'Running' });
+
+        document.getElementById('activity').checked = true;
+        const form = document.getElementById('task-form');
+
+        const mockHandleTaskSubmit = jest.fn();
+        handleActivityAwareFormSubmit(form, { handleTaskSubmit: mockHandleTaskSubmit });
+
+        // Neither task submit nor activity add should fire
+        expect(mockHandleTaskSubmit).not.toHaveBeenCalled();
+        jest.useRealTimers();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/activity-app-integration.test.js -t "syncTimerFormState|handleActivityAwareFormSubmit with timer" --verbose`
+Expected: FAIL — `syncTimerFormState` not exported, form submit guard not implemented
+
+- [ ] **Step 3: Implement syncTimerFormState**
+
+In `public/js/activities/ui-handlers.js`, add imports:
+
+```js
+import { getRunningActivity } from './manager.js';
+```
+
+Add the sync function:
+
+```js
+export function syncTimerFormState() {
+    const activityRadio = document.getElementById('activity');
+    const isActivityMode = activityRadio?.checked;
+    const running = getRunningActivity();
+
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+    const startTimerBtn = document.getElementById('start-timer-btn');
+
+    if (isActivityMode && running) {
+        showTimerDisplay(running);
+    } else {
+        hideTimerDisplay();
+        // Show Start Timer button only in activity mode when no timer
+        if (startTimerBtn) {
+            startTimerBtn.classList.toggle('hidden', !isActivityMode);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add timer guard to handleActivityAwareFormSubmit**
+
+In the existing `handleActivityAwareFormSubmit` function, add a guard at the top of the activity branch:
+
+```js
+if (taskType === 'activity') {
+    // Don't submit form when timer display is showing
+    if (getRunningActivity()) {
+        return;
+    }
+    // ... existing manual log flow
+}
+```
+
+- [ ] **Step 5: Implement initializeTimerUI**
+
+Add the initialization function that wires up timer-specific event listeners:
+
+```js
+export function initializeTimerUI(deps) {
+    // Sync timer/form state when radio toggle changes
+    const radios = document.querySelectorAll('input[name="task-type"]');
+    radios.forEach(radio => {
+        radio.addEventListener('change', () => syncTimerFormState());
+    });
+
+    // Start Timer button
+    const startTimerBtn = document.getElementById('start-timer-btn');
+    if (startTimerBtn) {
+        startTimerBtn.addEventListener('click', () => {
+            const descInput = document.querySelector('#task-form input[name="description"]');
+            const catSelect = document.querySelector('#task-form select[name="category"]');
+            const description = descInput?.value?.trim();
+            const category = catSelect?.value || null;
+
+            if (!description) {
+                if (window.showAlert) window.showAlert('Please enter a description before starting the timer.', 'sky');
+                return;
+            }
+
+            handleStartTimer({ description, category })
+                .then((result) => {
+                    if (result?.success) {
+                        syncTimerFormState();
+                        if (descInput) descInput.value = '';
+                        deps.refreshUI();
+                    }
+                });
+        });
+    }
+
+    // Stop Timer button
+    const stopTimerBtn = document.getElementById('timer-stop-btn');
+    if (stopTimerBtn) {
+        stopTimerBtn.addEventListener('click', () => {
+            handleStopTimer()
+                .then((result) => {
+                    if (result?.success) {
+                        syncTimerFormState();
+                        deps.refreshUI();
+                    }
+                });
+        });
+    }
+
+    // Timer description edit (debounced persistence)
+    const timerDesc = document.getElementById('timer-description');
+    if (timerDesc) {
+        timerDesc.addEventListener('change', () => {
+            updateRunningActivity({ description: timerDesc.value });
+        });
+    }
+
+    // Timer category edit
+    const timerCat = document.getElementById('timer-category');
+    if (timerCat) {
+        timerCat.addEventListener('change', () => {
+            updateRunningActivity({ category: timerCat.value || null });
+        });
+    }
+
+    // Timer start time edit (backdating)
+    const timerStartTime = document.getElementById('timer-start-time');
+    if (timerStartTime) {
+        timerStartTime.addEventListener('change', () => {
+            const running = getRunningActivity();
+            if (!running) return;
+            // Parse the time input as local time (matches how we display it)
+            const [hours, minutes] = timerStartTime.value.split(':').map(Number);
+            const newStart = new Date();
+            newStart.setHours(hours, minutes, 0, 0);
+            updateRunningActivity({ startDateTime: newStart.toISOString() });
+        });
+    }
+}
+```
+
+Add the needed imports:
+
+```js
+import { handleStartTimer, handleStopTimer } from './handlers.js';
+import { getRunningActivity, updateRunningActivity } from './manager.js';
+```
+
+- [ ] **Step 6: Update syncActivitiesUI to also call syncTimerFormState**
+
+In the existing `syncActivitiesUI(enabled)` function, add at the end:
+
+```js
+// Also sync timer display state when activities toggle changes
+if (!enabled) {
+    hideTimerDisplay();
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npx jest __tests__/activity-app-integration.test.js --verbose`
+Expected: PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add public/js/activities/ui-handlers.js __tests__/activity-app-integration.test.js
+git commit -m "feat: add timer interaction handlers with form/timer transitions and syncTimerFormState"
+```
+
+---
+
+## Chunk 7: Boot Restoration + Integration
+
+### Task 11: Boot restoration in app.js
+
+**Files:**
+- Modify: `public/js/app.js`
+
+- [ ] **Step 1: Add loadRunningActivity to loadAppState**
+
+In `public/js/app.js`, add import:
+
+```js
+import { loadRunningActivity, getRunningActivity } from './activities/manager.js';
+import { initializeTimerUI, syncTimerFormState } from './activities/ui-handlers.js';
+```
+
+Update `loadAppState`:
+
+```js
+async function loadAppState() {
+    await loadTasksIntoState();
+    if (isActivitiesEnabled()) {
+        await loadActivitiesState();
+        await loadRunningActivity();
+    }
+}
+```
+
+- [ ] **Step 2: Add timer UI initialization to boot sequence**
+
+In the `initAndBootApp` function, after the existing `initializeTaskTypeToggle()` call, add:
+
+```js
+initializeTimerUI({ refreshUI: refreshTaskDisplays });
+```
+
+- [ ] **Step 3: Add boot-time timer display restoration and tab highlight**
+
+After `refreshTaskDisplays()` (the initial render at the end of boot), add:
+
+```js
+// Restore timer display if a timer was running
+if (isActivitiesEnabled() && getRunningActivity()) {
+    syncTimerFormState();
+
+    // Brief highlight on activity tab to signal running timer
+    const activityToggle = document.getElementById('activity-toggle-option');
+    if (activityToggle) {
+        activityToggle.classList.add('ring-2', 'ring-sky-400/50');
+        setTimeout(() => {
+            activityToggle.classList.remove('ring-2', 'ring-sky-400/50');
+        }, 3000);
+    }
+}
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/js/app.js
+git commit -m "feat: restore running timer on boot with activity tab highlight"
+```
+
+---
+
+### Task 12: Timer lifecycle integration tests
+
+**Files:**
+- Modify: `__tests__/activity-app-integration.test.js`
+
+- [ ] **Step 1: Write integration tests for full timer lifecycle**
+
+Append to `__tests__/activity-app-integration.test.js`:
+
+```js
+describe('Timer lifecycle integration', () => {
+    beforeEach(() => {
+        setupDOM();
+        resetActivityState();
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-04-09T10:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('full start → work → stop lifecycle creates activity', async () => {
+        // Start timer
+        const startResult = await handleStartTimer({ description: 'Feature work', category: 'work/deep' });
+        expect(startResult.success).toBe(true);
+        expect(getRunningActivity()).not.toBeNull();
+
+        // Advance 45 minutes
+        jest.setSystemTime(new Date('2026-04-09T10:45:00.000Z'));
+
+        // Stop timer
+        const stopResult = await handleStopTimer();
+        expect(stopResult.success).toBe(true);
+        expect(getRunningActivity()).toBeNull();
+        expect(stopResult.activity.description).toBe('Feature work');
+        expect(stopResult.activity.category).toBe('work/deep');
+        expect(stopResult.activity.source).toBe('timer');
+        expect(stopResult.activity.duration).toBe(45);
+    });
+
+    test('stop-on-start creates activity for the first timer', async () => {
+        // Start first timer
+        await handleStartTimer({ description: 'First task' });
+
+        jest.setSystemTime(new Date('2026-04-09T10:30:00.000Z'));
+
+        // Start second timer (auto-stops first)
+        const result = await handleStartTimer({ description: 'Second task' });
+        expect(result.success).toBe(true);
+
+        // First timer's activity should have been created
+        expect(onActivityCreated).toHaveBeenCalledWith(
+            expect.objectContaining({
+                activity: expect.objectContaining({
+                    description: 'First task',
+                    duration: 30,
+                }),
+            })
+        );
+
+        // Second timer is now running
+        expect(getRunningActivity().description).toBe('Second task');
+    });
+
+    test('backdating updates the running timer start time', async () => {
+        await startTimer({ description: 'Started late' });
+
+        const result = await updateRunningActivity({
+            startDateTime: '2026-04-09T09:30:00.000Z',
+        });
+
+        expect(result.success).toBe(true);
+        expect(getRunningActivity().startDateTime).toBe('2026-04-09T09:30:00.000Z');
+    });
+
+    test('boot restoration recovers running timer from PouchDB', async () => {
+        // Simulate a config doc existing from a previous session
+        const { loadConfig } = require('../public/js/storage.js');
+        loadConfig.mockResolvedValueOnce({
+            id: 'config-running-activity',
+            description: 'Persisted timer',
+            category: 'work/deep',
+            startDateTime: '2026-04-09T09:00:00.000Z',
+        });
+
+        await loadRunningActivity();
+
+        const running = getRunningActivity();
+        expect(running).not.toBeNull();
+        expect(running.description).toBe('Persisted timer');
+        expect(running.startDateTime).toBe('2026-04-09T09:00:00.000Z');
+    });
+
+    test('resetActivityState clears both activities and timer', async () => {
+        await startTimer({ description: 'Active' });
+        expect(getRunningActivity()).not.toBeNull();
+
+        resetActivityState();
+
+        expect(getRunningActivity()).toBeNull();
+        expect(getActivityState()).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `npx jest __tests__/activity-app-integration.test.js --verbose`
+Expected: PASS (all tests)
+
+- [ ] **Step 3: Run full test suite with coverage**
+
+Run: `npx jest --coverage`
+Expected: All tests pass. Coverage thresholds (90/90/90/79) maintained.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add __tests__/activity-app-integration.test.js
+git commit -m "test: add timer lifecycle integration tests"
+```
+
+---
+
+## Summary
+
+12 tasks across 7 chunks:
+
+| Chunk | Tasks | What ships |
+|-------|-------|-----------|
+| 1. Storage Foundation | 1 | `deleteConfig` in storage.js |
+| 2. Timer State Management | 2-3 | Timer primitives, start/stop/update in manager.js |
+| 3. Timer Handlers | 4 | `handleStartTimer`/`handleStopTimer` with stop-on-start |
+| 4. Auto-Logging Enhancements | 5-6 | Early completion adjustment, overlap detection + auto-stop |
+| 5. HTML + Form Updates | 7-8 | Timer display HTML, Start Timer button, toggle awareness |
+| 6. Timer Display UI | 9-10 | Elapsed counter, editable fields, form/timer transitions |
+| 7. Boot + Integration | 11-12 | Boot restoration, tab highlight, lifecycle integration tests |
+
+Each chunk produces working, testable code. Chunks 1-4 are purely logic (no DOM). Chunks 5-7 add the UI.

--- a/docs/superpowers/specs/2026-04-15-activity-summary-parent-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-15-activity-summary-parent-expansion-design.md
@@ -1,0 +1,115 @@
+# Activity Summary Parent Expansion Design
+
+Date: 2026-04-15
+Branch: `feat/activities-phase4-5-timer`
+
+## Goal
+
+Change the activity category summary so the default view aggregates by taxonomy parent group, then allows a compact click-to-expand child breakdown for one selected parent group at a time.
+
+This is intended as a lightweight lead-in to richer activity insights without turning the summary into a full analytics panel.
+
+## Approved Interaction
+
+- Default state shows one summary line bar for today's activities grouped by taxonomy parent group.
+- The existing total duration remains visible.
+- The parent legend remains visible in the default state.
+- Parent bar segments and parent legend items are both valid click targets.
+- Clicking a parent group toggles expansion for that group.
+- Only one parent group is expanded at a time.
+- Clicking the already-expanded parent collapses the child breakdown.
+- Clicking a different parent swaps the child breakdown to that group.
+- Uncategorized appears in the default summary but is non-interactive.
+- Clicking uncategorized does nothing and does not affect the currently expanded parent group.
+
+## Expanded State Shape
+
+The expanded state follows the approved `A2` direction:
+
+- Keep the top parent-group summary bar unchanged.
+- Add a compact child-detail rail directly underneath, not a new card or full panel.
+- The child-detail rail includes:
+  - a small selected-group label
+  - a minimal child line bar
+  - a compact micro legend for the selected group's child categories that may wrap naturally within the rail width, but must remain part of the same lightweight rail rather than becoming a separate panel
+
+The intent is to preserve the top-level overview while adding child detail at low vertical cost.
+
+## Data Rules
+
+### Parent Summary
+
+Parent summary aggregation groups today's activities by:
+
+- taxonomy parent group for child-category activities
+- the group itself for activities logged directly against a parent group
+- a dedicated uncategorized bucket for uncategorized activities
+
+### Child Expansion
+
+Expanded child detail is calculated only for the selected parent group.
+
+Child items include:
+
+- child categories belonging to the selected parent that have non-zero activity today
+- a synthetic fallback bucket for activities logged directly to the parent group
+
+The synthetic bucket is required so the child detail rail sums to the same total as the selected parent in the default summary.
+
+Required label:
+
+- `Unspecified <Group Label>`
+
+Example:
+
+- parent `Work`
+- direct-to-group activity contributes to child bucket `Unspecified Work`
+
+Uncategorized never expands and has no child rail.
+
+## State Ownership
+
+Expanded/collapsed state is view state only.
+
+- Do not persist it to storage.
+- Keep it in the activity UI/rendering layer.
+- Resetting on refresh is acceptable.
+
+## Implementation Shape
+
+Keep this feature in the activity rendering/UI seam rather than introducing a new reporting module.
+
+Primary files:
+
+- `public/js/activities/renderer.js`
+- `public/js/activities/ui-handlers.js` if click state handling needs to move out of pure rendering
+
+Recommended internal helpers:
+
+- parent summary aggregation helper
+- selected-parent child aggregation helper
+- compact expanded-rail renderer
+
+The renderer should stay responsible for HTML generation, while the small piece of selected-parent state can live in the activity UI layer if needed for event handling.
+
+## Testing
+
+Add renderer/UI coverage for:
+
+- default parent-group aggregation
+- uncategorized bucket in default summary
+- clicking a parent expands its child rail
+- clicking the same parent collapses it
+- clicking a different parent swaps the expanded child rail
+- synthetic direct-to-parent bucket appears in child detail
+- zero-activity child categories are excluded from expanded detail
+- expanded child totals match the selected parent total
+- uncategorized does not expand
+
+## Non-Goals
+
+- no persistence of expansion state
+- no hover-only discovery model
+- no multi-parent simultaneous expansion
+- no full insights dashboard treatment
+- no percentages or heavier analytics UI in this change

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -70,6 +70,62 @@
     background: linear-gradient(180deg, rgba(94, 234, 212, 0.95), rgba(45, 212, 191, 0.8));
 }
 
+#activity-action-group {
+    display: contents;
+}
+
+#task-form.task-form--activity #time-inputs {
+    display: grid;
+    grid-template-columns: minmax(8.5rem, 1fr) auto;
+    align-items: center;
+    column-gap: 0.75rem;
+    padding-bottom: 0;
+}
+
+#task-form.task-form--activity #task-form-main-row {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+#task-form.task-form--activity #task-form-main-row > :first-child {
+    min-width: 0;
+    width: 100%;
+}
+
+#task-form.task-form--activity #time-inputs > :last-child {
+    flex: 0 0 auto;
+}
+
+#task-form.task-form--activity input[name='duration-hours'],
+#task-form.task-form--activity input[name='duration-minutes'] {
+    width: 4.5rem;
+}
+
+#task-form.task-form--activity #activity-action-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+}
+
+#task-form.task-form--activity #add-task-btn,
+#task-form.task-form--activity #start-timer-btn {
+    width: 100%;
+}
+
+@media (min-width: 640px) {
+    #task-form.task-form--activity #activity-action-group {
+        width: 100%;
+        flex-direction: row;
+        justify-content: flex-end;
+    }
+
+    #task-form.task-form--activity #add-task-btn,
+    #task-form.task-form--activity #start-timer-btn {
+        width: 10.75rem;
+    }
+}
+
 /* === Celebration Animation === */
 .celebration-container {
     position: absolute;

--- a/public/index.html
+++ b/public/index.html
@@ -163,37 +163,37 @@
                         </div>
                     </div>
 
-                    <div id="task-form-fields">
-                        <div class="mb-2 sm:mb-3">
-                            <input
-                                type="text"
-                                name="description"
-                                placeholder="Describe your task..."
-                                class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all scheduled-input text-sm sm:text-base"
-                                required
-                            />
-                        </div>
+                    <div class="mb-2 sm:mb-3">
+                        <input
+                            type="text"
+                            name="description"
+                            placeholder="Describe your task..."
+                            class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all scheduled-input text-sm sm:text-base"
+                            required
+                        />
+                    </div>
 
-                        <div id="category-dropdown-row" class="hidden mb-2 sm:mb-3">
-                            <div class="flex items-center gap-2">
-                                <span
-                                    id="category-color-indicator"
-                                    class="w-3 h-3 rounded-full bg-slate-500 shrink-0"
-                                ></span>
-                                <select
-                                    name="category"
-                                    id="category-select"
-                                    class="bg-slate-700 p-2 rounded-lg flex-1 border border-slate-600 focus:border-teal-400 focus:outline-none transition-all text-sm"
-                                >
-                                    <option value="">No category</option>
-                                </select>
-                            </div>
+                    <div id="category-dropdown-row" class="hidden mb-2 sm:mb-3">
+                        <div class="flex items-center gap-2">
+                            <span
+                                id="category-color-indicator"
+                                class="w-3 h-3 rounded-full bg-slate-500 shrink-0"
+                            ></span>
+                            <select
+                                name="category"
+                                id="category-select"
+                                class="bg-slate-700 p-2 rounded-lg flex-1 border border-slate-600 focus:border-teal-400 focus:outline-none transition-all text-sm"
+                            >
+                                <option value="">No category</option>
+                            </select>
                         </div>
+                    </div>
 
-                        <div
-                            class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center sm:pb-5"
-                        >
-                            <div class="flex-grow flex flex-col gap-2 sm:gap-4">
+                    <div
+                        id="task-form-main-row"
+                        class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center sm:pb-5"
+                    >
+                        <div class="flex-grow flex flex-col gap-2 sm:gap-4">
                             <div
                                 id="time-inputs"
                                 class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center w-full pb-5 sm:pb-0"
@@ -350,25 +350,24 @@
                                     </div>
                                 </div>
                             </div>
-                            </div>
+                        </div>
 
+                        <div id="activity-action-group">
                             <!-- Submit Button -->
-                            <div class="flex flex-col sm:flex-row gap-2">
-                                <button
-                                    type="submit"
-                                    id="add-task-btn"
-                                    class="shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center scheduled-button text-sm sm:text-base"
-                                >
-                                    <i class="fa-regular fa-plus mr-2"></i>Add Task
-                                </button>
-                                <button
-                                    type="button"
-                                    id="start-timer-btn"
-                                    class="hidden shrink-0 bg-slate-700 hover:bg-slate-600 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white border border-sky-400/30 transition-all duration-300 flex items-center justify-center text-sm sm:text-base"
-                                >
-                                    <i class="fa-solid fa-play mr-2"></i>Start Timer
-                                </button>
-                            </div>
+                            <button
+                                type="submit"
+                                id="add-task-btn"
+                                class="shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center scheduled-button text-sm sm:text-base"
+                            >
+                                <i class="fa-regular fa-plus mr-2"></i>Add Task
+                            </button>
+                            <button
+                                type="button"
+                                id="start-timer-btn"
+                                class="hidden shrink-0 bg-slate-700 hover:bg-slate-600 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white border border-sky-400/30 transition-all duration-300 flex items-center justify-center text-sm sm:text-base"
+                            >
+                                <i class="fa-solid fa-play mr-2"></i>Start Timer
+                            </button>
                         </div>
                     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -163,36 +163,37 @@
                         </div>
                     </div>
 
-                    <div class="mb-2 sm:mb-3">
-                        <input
-                            type="text"
-                            name="description"
-                            placeholder="Describe your task..."
-                            class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all scheduled-input text-sm sm:text-base"
-                            required
-                        />
-                    </div>
-
-                    <div id="category-dropdown-row" class="hidden mb-2 sm:mb-3">
-                        <div class="flex items-center gap-2">
-                            <span
-                                id="category-color-indicator"
-                                class="w-3 h-3 rounded-full bg-slate-500 shrink-0"
-                            ></span>
-                            <select
-                                name="category"
-                                id="category-select"
-                                class="bg-slate-700 p-2 rounded-lg flex-1 border border-slate-600 focus:border-teal-400 focus:outline-none transition-all text-sm"
-                            >
-                                <option value="">No category</option>
-                            </select>
+                    <div id="task-form-fields">
+                        <div class="mb-2 sm:mb-3">
+                            <input
+                                type="text"
+                                name="description"
+                                placeholder="Describe your task..."
+                                class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all scheduled-input text-sm sm:text-base"
+                                required
+                            />
                         </div>
-                    </div>
 
-                    <div
-                        class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center sm:pb-5"
-                    >
-                        <div class="flex-grow flex flex-col gap-2 sm:gap-4">
+                        <div id="category-dropdown-row" class="hidden mb-2 sm:mb-3">
+                            <div class="flex items-center gap-2">
+                                <span
+                                    id="category-color-indicator"
+                                    class="w-3 h-3 rounded-full bg-slate-500 shrink-0"
+                                ></span>
+                                <select
+                                    name="category"
+                                    id="category-select"
+                                    class="bg-slate-700 p-2 rounded-lg flex-1 border border-slate-600 focus:border-teal-400 focus:outline-none transition-all text-sm"
+                                >
+                                    <option value="">No category</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div
+                            class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center sm:pb-5"
+                        >
+                            <div class="flex-grow flex flex-col gap-2 sm:gap-4">
                             <div
                                 id="time-inputs"
                                 class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center w-full pb-5 sm:pb-0"
@@ -349,16 +350,70 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
+                            </div>
 
-                        <!-- Submit Button -->
-                        <button
-                            type="submit"
-                            id="add-task-btn"
-                            class="shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center scheduled-button text-sm sm:text-base"
-                        >
-                            <i class="fa-regular fa-plus mr-2"></i>Add Task
-                        </button>
+                            <!-- Submit Button -->
+                            <div class="flex flex-col sm:flex-row gap-2">
+                                <button
+                                    type="submit"
+                                    id="add-task-btn"
+                                    class="shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center scheduled-button text-sm sm:text-base"
+                                >
+                                    <i class="fa-regular fa-plus mr-2"></i>Add Task
+                                </button>
+                                <button
+                                    type="button"
+                                    id="start-timer-btn"
+                                    class="hidden shrink-0 bg-slate-700 hover:bg-slate-600 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white border border-sky-400/30 transition-all duration-300 flex items-center justify-center text-sm sm:text-base"
+                                >
+                                    <i class="fa-solid fa-play mr-2"></i>Start Timer
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div
+                        id="timer-display"
+                        class="hidden rounded-lg border border-sky-400/20 bg-slate-900/40 p-3 sm:p-4 space-y-3"
+                    >
+                        <div class="grid gap-3 sm:grid-cols-[minmax(0,2fr)_auto] sm:items-end">
+                            <input
+                                id="timer-description"
+                                type="text"
+                                class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm sm:text-base"
+                            />
+                            <div class="sm:text-right">
+                                <div class="text-xs uppercase tracking-[0.2em] text-sky-300/70">
+                                    Elapsed
+                                </div>
+                                <div
+                                    id="timer-elapsed"
+                                    class="text-2xl sm:text-3xl font-light text-sky-300"
+                                >
+                                    00:00:00
+                                </div>
+                            </div>
+                        </div>
+                        <div class="grid gap-3 sm:grid-cols-2">
+                            <select
+                                id="timer-category"
+                                class="bg-slate-700 p-2 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm"
+                            ></select>
+                            <input
+                                id="timer-start-time"
+                                type="time"
+                                class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm sm:text-base"
+                            />
+                        </div>
+                        <div class="flex justify-end">
+                            <button
+                                type="button"
+                                id="timer-stop-btn"
+                                class="shrink-0 bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center text-sm sm:text-base"
+                            >
+                                <i class="fa-solid fa-stop mr-2"></i>Stop
+                            </button>
+                        </div>
                     </div>
                     <span id="overlap-warning" class="block text-amber-400 text-xs mt-1"></span>
                 </form>

--- a/public/index.html
+++ b/public/index.html
@@ -406,7 +406,7 @@
                                 class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm sm:text-base"
                             />
                         </div>
-                        <div id="timer-action-group" class="flex justify-end gap-3">
+                        <div id="timer-action-group" class="flex flex-col gap-3 sm:flex-row sm:justify-end">
                             <button
                                 type="button"
                                 id="timer-stop-btn"

--- a/public/index.html
+++ b/public/index.html
@@ -163,41 +163,42 @@
                         </div>
                     </div>
 
-                    <div class="mb-2 sm:mb-3">
-                        <input
-                            type="text"
-                            name="description"
-                            placeholder="Describe your task..."
-                            class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all scheduled-input text-sm sm:text-base"
-                            required
-                        />
-                    </div>
-
-                    <div id="category-dropdown-row" class="hidden mb-2 sm:mb-3">
-                        <div class="flex items-center gap-2">
-                            <span
-                                id="category-color-indicator"
-                                class="w-3 h-3 rounded-full bg-slate-500 shrink-0"
-                            ></span>
-                            <select
-                                name="category"
-                                id="category-select"
-                                class="bg-slate-700 p-2 rounded-lg flex-1 border border-slate-600 focus:border-teal-400 focus:outline-none transition-all text-sm"
-                            >
-                                <option value="">No category</option>
-                            </select>
+                    <div id="task-form-fields">
+                        <div class="mb-2 sm:mb-3">
+                            <input
+                                type="text"
+                                name="description"
+                                placeholder="Describe your task..."
+                                class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-teal-400 focus:outline-none transition-all scheduled-input text-sm sm:text-base"
+                                required
+                            />
                         </div>
-                    </div>
 
-                    <div
-                        id="task-form-main-row"
-                        class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center sm:pb-5"
-                    >
-                        <div class="flex-grow flex flex-col gap-2 sm:gap-4">
-                            <div
-                                id="time-inputs"
-                                class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center w-full pb-5 sm:pb-0"
-                            >
+                        <div id="category-dropdown-row" class="hidden mb-2 sm:mb-3">
+                            <div class="flex items-center gap-2">
+                                <span
+                                    id="category-color-indicator"
+                                    class="w-3 h-3 rounded-full bg-slate-500 shrink-0"
+                                ></span>
+                                <select
+                                    name="category"
+                                    id="category-select"
+                                    class="bg-slate-700 p-2 rounded-lg flex-1 border border-slate-600 focus:border-teal-400 focus:outline-none transition-all text-sm"
+                                >
+                                    <option value="">No category</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div
+                            id="task-form-main-row"
+                            class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center sm:pb-5"
+                        >
+                            <div class="flex-grow flex flex-col gap-2 sm:gap-4">
+                                <div
+                                    id="time-inputs"
+                                    class="flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center w-full pb-5 sm:pb-0"
+                                >
                                 <!-- Start Time -->
                                 <div class="flex-1 min-w-0">
                                     <div class="relative">
@@ -247,10 +248,10 @@
                                 </div>
                             </div>
 
-                            <div
-                                id="priority-input"
-                                class="hidden flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center w-full"
-                            >
+                                <div
+                                    id="priority-input"
+                                    class="hidden flex flex-col sm:flex-row gap-2 sm:gap-4 items-stretch sm:items-center w-full"
+                                >
                                 <!-- Priority -->
                                 <div class="flex-1 min-w-0">
                                     <div class="flex items-center gap-1 sm:gap-2">
@@ -350,24 +351,25 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
+                            </div>
 
-                        <div id="activity-action-group">
-                            <!-- Submit Button -->
-                            <button
-                                type="submit"
-                                id="add-task-btn"
-                                class="shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center scheduled-button text-sm sm:text-base"
-                            >
-                                <i class="fa-regular fa-plus mr-2"></i>Add Task
-                            </button>
-                            <button
-                                type="button"
-                                id="start-timer-btn"
-                                class="hidden shrink-0 bg-slate-700 hover:bg-slate-600 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white border border-sky-400/30 transition-all duration-300 flex items-center justify-center text-sm sm:text-base"
-                            >
-                                <i class="fa-solid fa-play mr-2"></i>Start Timer
-                            </button>
+                            <div id="activity-action-group">
+                                <!-- Submit Button -->
+                                <button
+                                    type="submit"
+                                    id="add-task-btn"
+                                    class="shrink-0 bg-gradient-to-r from-teal-500 to-teal-400 hover:from-teal-400 hover:to-teal-300 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white transition-all duration-300 flex items-center justify-center scheduled-button text-sm sm:text-base"
+                                >
+                                    <i class="fa-regular fa-plus mr-2"></i>Add Task
+                                </button>
+                                <button
+                                    type="button"
+                                    id="start-timer-btn"
+                                    class="hidden shrink-0 bg-slate-700 hover:bg-slate-600 px-4 sm:px-5 py-2 sm:py-2.5 rounded-lg w-full sm:w-auto font-normal text-white border border-sky-400/30 transition-all duration-300 flex items-center justify-center text-sm sm:text-base"
+                                >
+                                    <i class="fa-solid fa-play mr-2"></i>Start Timer
+                                </button>
+                            </div>
                         </div>
                     </div>
 
@@ -404,7 +406,7 @@
                                 class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm sm:text-base"
                             />
                         </div>
-                        <div class="flex justify-end">
+                        <div id="timer-action-group" class="flex justify-end gap-3">
                             <button
                                 type="button"
                                 id="timer-stop-btn"

--- a/public/index.html
+++ b/public/index.html
@@ -406,6 +406,33 @@
                                 class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm sm:text-base"
                             />
                         </div>
+                        <div
+                            id="next-activity-strip"
+                            class="rounded-xl border border-dashed border-slate-700 bg-slate-800/40 p-3 space-y-3"
+                        >
+                            <div class="flex items-center justify-between gap-3">
+                                <div class="text-[11px] uppercase tracking-[0.22em] text-slate-400">
+                                    Next Activity
+                                </div>
+                                <div class="text-xs text-slate-500">
+                                    Starts immediately when you click
+                                    <span class="text-slate-300">Start Timer</span>
+                                </div>
+                            </div>
+                            <div class="grid gap-3 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto] sm:items-center">
+                                <input
+                                    id="next-activity-description"
+                                    type="text"
+                                    placeholder="What are you doing next?"
+                                    class="bg-slate-700 p-2 sm:p-2.5 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm sm:text-base"
+                                />
+                                <select
+                                    id="next-activity-category"
+                                    class="bg-slate-700 p-2 rounded-lg w-full border border-slate-600 focus:border-sky-400 focus:outline-none transition-all text-sm"
+                                ></select>
+                                <div id="next-activity-action-group" class="w-full sm:w-auto"></div>
+                            </div>
+                        </div>
                         <div id="timer-action-group" class="flex flex-col gap-3 sm:flex-row sm:justify-end">
                             <button
                                 type="button"

--- a/public/js/activities/app-wiring.js
+++ b/public/js/activities/app-wiring.js
@@ -1,0 +1,92 @@
+import {
+    handleActivityAwareFormSubmit,
+    handleActivityListClick,
+    handleActivityListSubmit,
+    handleActivityListKeydown,
+    handleActivityListInput,
+    refreshTodayActivitySummary
+} from './ui-handlers.js';
+import { initializeTimerUI, syncTimerFormState } from './timer-ui.js';
+import { getRunningActivity } from './manager.js';
+
+export function createActivityAppCallbacks({
+    getActivitiesEnabled,
+    refreshUI,
+    resetAllConfirmingDeleteFlags,
+    handleTaskSubmit,
+    focusTaskDescriptionInput,
+    resetTaskFormPreviewState,
+    initializeTaskTypeToggle
+}) {
+    return {
+        onTaskFormSubmit: async (formElement) => {
+            await handleActivityAwareFormSubmit(formElement, {
+                activitiesEnabled: getActivitiesEnabled(),
+                resetTaskFormPreviewState,
+                initializeTaskTypeToggle,
+                focusTaskDescriptionInput,
+                handleTaskSubmit
+            });
+        },
+        onGlobalClick: (event) => {
+            handleActivityListClick(event.target, {
+                refreshUI,
+                resetAllConfirmingDeleteFlags
+            });
+        }
+    };
+}
+
+export function initializeActivityUi({
+    signal,
+    refreshUI,
+    refreshTaskDisplays,
+    getActivitiesEnabled
+}) {
+    initializeTimerUI({
+        refreshUI: refreshTaskDisplays,
+        refreshActivitySummary: () => refreshTodayActivitySummary(getActivitiesEnabled())
+    });
+
+    const activityListElement = document.getElementById('activity-list');
+    if (!activityListElement) {
+        return;
+    }
+
+    activityListElement.addEventListener(
+        'submit',
+        (event) => {
+            handleActivityListSubmit(event, {
+                refreshUI
+            });
+        },
+        { signal }
+    );
+    activityListElement.addEventListener(
+        'keydown',
+        (event) => {
+            handleActivityListKeydown(event, {
+                refreshUI
+            });
+        },
+        { signal }
+    );
+    activityListElement.addEventListener('input', handleActivityListInput, { signal });
+}
+
+export function syncRestoredRunningTimer(activitiesEnabled) {
+    if (!activitiesEnabled) {
+        return;
+    }
+
+    const runningActivity = getRunningActivity();
+    if (runningActivity) {
+        const activityRadio = document.getElementById('activity');
+        if (activityRadio instanceof HTMLInputElement && !activityRadio.checked) {
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+    }
+
+    syncTimerFormState();
+}

--- a/public/js/activities/app-wiring.js
+++ b/public/js/activities/app-wiring.js
@@ -8,7 +8,6 @@ import {
 } from './ui-handlers.js';
 import { initializeTimerUI, syncTimerFormState } from './timer-ui.js';
 import { getRunningActivity } from './manager.js';
-import { logger } from '../utils.js';
 
 export function createActivityAppCallbacks({
     getActivitiesEnabled,
@@ -81,20 +80,6 @@ export function syncRestoredRunningTimer(activitiesEnabled) {
     }
 
     const runningActivity = getRunningActivity();
-    logger.info('timer-debug:sync-restored-running-timer', {
-        deviceNowIso: new Date().toISOString(),
-        timezoneOffsetMinutes: new Date().getTimezoneOffset(),
-        hasRunningActivity: !!runningActivity,
-        runningActivity: runningActivity
-            ? {
-                  description: runningActivity.description,
-                  category: runningActivity.category || null,
-                  startDateTime: runningActivity.startDateTime,
-                  source: runningActivity.source || 'timer',
-                  sourceTaskId: runningActivity.sourceTaskId || null
-              }
-            : null
-    });
     if (runningActivity) {
         const activityRadio = document.getElementById('activity');
         if (activityRadio instanceof HTMLInputElement && !activityRadio.checked) {

--- a/public/js/activities/app-wiring.js
+++ b/public/js/activities/app-wiring.js
@@ -8,6 +8,7 @@ import {
 } from './ui-handlers.js';
 import { initializeTimerUI, syncTimerFormState } from './timer-ui.js';
 import { getRunningActivity } from './manager.js';
+import { logger } from '../utils.js';
 
 export function createActivityAppCallbacks({
     getActivitiesEnabled,
@@ -80,6 +81,20 @@ export function syncRestoredRunningTimer(activitiesEnabled) {
     }
 
     const runningActivity = getRunningActivity();
+    logger.info('timer-debug:sync-restored-running-timer', {
+        deviceNowIso: new Date().toISOString(),
+        timezoneOffsetMinutes: new Date().getTimezoneOffset(),
+        hasRunningActivity: !!runningActivity,
+        runningActivity: runningActivity
+            ? {
+                  description: runningActivity.description,
+                  category: runningActivity.category || null,
+                  startDateTime: runningActivity.startDateTime,
+                  source: runningActivity.source || 'timer',
+                  sourceTaskId: runningActivity.sourceTaskId || null
+              }
+            : null
+    });
     if (runningActivity) {
         const activityRadio = document.getElementById('activity');
         if (activityRadio instanceof HTMLInputElement && !activityRadio.checked) {

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -1,7 +1,14 @@
 import { showAlert } from '../modal-manager.js';
 import { showToast } from '../toast-manager.js';
 import { extractActivityFormData, extractActivityEditFormData } from './form-utils.js';
-import { addActivity, editActivity, removeActivity } from './manager.js';
+import {
+    addActivity,
+    editActivity,
+    removeActivity,
+    startTimer,
+    stopTimer,
+    getRunningActivity
+} from './manager.js';
 import { consumeActivitySmokeFailure } from './smoke-hooks.js';
 import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
 
@@ -95,6 +102,65 @@ export async function handleDeleteActivity(activityId) {
 
     onActivityDeleted({ activity: result.activity });
     showToast('Activity deleted.', { theme: 'sky' });
+    return result;
+}
+
+export async function handleStartTimer(timerData) {
+    try {
+        const runningActivity = getRunningActivity();
+        if (runningActivity) {
+            const stopResult = await stopTimer();
+            if (!stopResult?.success) {
+                showAlert(stopResult?.reason || 'Could not stop timer.', 'sky');
+                return {
+                    success: false,
+                    reason: stopResult?.reason || 'Could not stop timer.'
+                };
+            }
+
+            if (stopResult.activity) {
+                onActivityCreated({ activity: stopResult.activity });
+            }
+        }
+
+        const result = await startTimer(timerData);
+        if (!result?.success) {
+            showAlert(result?.reason || 'Could not start timer.', 'sky');
+            return {
+                success: false,
+                reason: result?.reason || 'Could not start timer.'
+            };
+        }
+
+        showToast('Timer started.', { theme: 'sky' });
+        return result;
+    } catch {
+        showAlert('Could not start timer.', 'sky');
+        return { success: false, reason: 'Could not start timer.' };
+    }
+}
+
+export async function handleStopTimer() {
+    let result;
+    try {
+        result = await stopTimer();
+    } catch {
+        showAlert('Could not stop timer.', 'sky');
+        return { success: false, reason: 'Could not stop timer.' };
+    }
+
+    if (!result?.success) {
+        showAlert(result?.reason || 'Could not stop timer.', 'sky');
+        return {
+            success: false,
+            reason: result?.reason || 'Could not stop timer.'
+        };
+    }
+
+    if (result.activity) {
+        onActivityCreated({ activity: result.activity });
+    }
+    showToast('Timer stopped.', { theme: 'sky' });
     return result;
 }
 

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -8,8 +8,15 @@ import {
     startTimerReplacingCurrent,
     stopTimer
 } from './manager.js';
+import { consumeUnscheduledTask } from '../tasks/manager.js';
 import { consumeActivitySmokeFailure } from './smoke-hooks.js';
 import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
+
+function consumeSourceTaskIfPresent(activity) {
+    if (activity?.sourceTaskId) {
+        consumeUnscheduledTask(activity.sourceTaskId);
+    }
+}
 
 function resolveActivityPayload(activityDataOrForm) {
     if (!(activityDataOrForm instanceof HTMLFormElement)) {
@@ -108,6 +115,7 @@ export async function handleStartTimer(timerData) {
     try {
         const result = await startTimerReplacingCurrent(timerData);
         if (result?.stoppedActivity) {
+            consumeSourceTaskIfPresent(result.stoppedActivity);
             onActivityCreated({ activity: result.stoppedActivity });
         }
 
@@ -145,6 +153,7 @@ export async function handleStopTimer() {
     }
 
     if (result.activity) {
+        consumeSourceTaskIfPresent(result.activity);
         onActivityCreated({ activity: result.activity });
     }
     showToast('Timer stopped.', { theme: 'sky' });

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -5,9 +5,8 @@ import {
     addActivity,
     editActivity,
     removeActivity,
-    startTimer,
-    stopTimer,
-    getRunningActivity
+    startTimerReplacingCurrent,
+    stopTimer
 } from './manager.js';
 import { consumeActivitySmokeFailure } from './smoke-hooks.js';
 import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
@@ -107,23 +106,11 @@ export async function handleDeleteActivity(activityId) {
 
 export async function handleStartTimer(timerData) {
     try {
-        const runningActivity = getRunningActivity();
-        if (runningActivity) {
-            const stopResult = await stopTimer();
-            if (!stopResult?.success) {
-                showAlert(stopResult?.reason || 'Could not stop timer.', 'sky');
-                return {
-                    success: false,
-                    reason: stopResult?.reason || 'Could not stop timer.'
-                };
-            }
-
-            if (stopResult.activity) {
-                onActivityCreated({ activity: stopResult.activity });
-            }
+        const result = await startTimerReplacingCurrent(timerData);
+        if (result?.stoppedActivity) {
+            onActivityCreated({ activity: result.stoppedActivity });
         }
 
-        const result = await startTimer(timerData);
         if (!result?.success) {
             showAlert(result?.reason || 'Could not start timer.', 'sky');
             return {

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -3,7 +3,7 @@ import {
     loadActivities as loadActivitiesFromStorage,
     deleteActivity as deleteActivityFromStorage
 } from '../storage.js';
-import { extractDateFromDateTime, extractTimeFromDateTime, logger } from '../utils.js';
+import { extractDateFromDateTime, extractTimeFromDateTime } from '../utils.js';
 import {
     loadRunningActivityConfig,
     saveRunningActivityConfig,
@@ -13,14 +13,6 @@ import {
 /** @type {Array<Object>} */
 let activities = [];
 let runningActivity = null;
-
-function logTimerDebug(event, details = {}) {
-    logger.info(`timer-debug:${event}`, {
-        deviceNowIso: new Date().toISOString(),
-        timezoneOffsetMinutes: new Date().getTimezoneOffset(),
-        ...details
-    });
-}
 
 function cloneActivity(activity) {
     return activity ? { ...activity } : activity;
@@ -288,17 +280,6 @@ export function createActivityFromTask(task) {
 
 export async function loadRunningActivity() {
     runningActivity = await loadRunningActivityConfig();
-    logTimerDebug('load-running-activity', {
-        runningActivity: runningActivity
-            ? {
-                  description: runningActivity.description,
-                  category: runningActivity.category || null,
-                  startDateTime: runningActivity.startDateTime,
-                  source: runningActivity.source || 'timer',
-                  sourceTaskId: runningActivity.sourceTaskId || null
-              }
-            : null
-    });
     return getRunningActivity();
 }
 
@@ -332,9 +313,6 @@ export async function startTimer({
     await saveRunningActivityConfig(timerState);
 
     runningActivity = timerState;
-    logTimerDebug('start-timer', {
-        runningActivity: getRunningActivity()
-    });
     return { success: true, runningActivity: getRunningActivity() };
 }
 
@@ -392,10 +370,6 @@ export async function stopTimerAt(endDateTime) {
 
     await deleteRunningActivityConfig();
     runningActivity = null;
-    logTimerDebug('stop-timer', {
-        stoppedAt: safeEndDateTime,
-        activity: cloneActivity(activityResult.activity)
-    });
 
     return { success: true, activity: cloneActivity(activityResult.activity) };
 }
@@ -430,8 +404,5 @@ export async function updateRunningActivity(updates = {}) {
     await saveRunningActivityConfig(nextRunningActivity);
 
     runningActivity = nextRunningActivity;
-    logTimerDebug('update-running-activity', {
-        runningActivity: getRunningActivity()
-    });
     return { success: true, runningActivity: getRunningActivity() };
 }

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -96,7 +96,7 @@ export function getTodaysActivities(now = new Date()) {
                 extractDateFromDateTime(new Date(activity.startDateTime)) === today
         )
         .slice()
-        .sort((left, right) => new Date(left.startDateTime) - new Date(right.startDateTime))
+        .sort((left, right) => new Date(right.endDateTime) - new Date(left.endDateTime))
         .map(cloneActivity);
 }
 
@@ -106,7 +106,13 @@ export function getSuggestedActivityStartTime(now = new Date()) {
         return null;
     }
 
-    const latestActivity = todaysActivities[todaysActivities.length - 1];
+    const latestActivity = todaysActivities.reduce((latest, activity) => {
+        if (!latest) {
+            return activity;
+        }
+
+        return new Date(activity.endDateTime) > new Date(latest.endDateTime) ? activity : latest;
+    }, null);
     if (!latestActivity?.endDateTime) {
         return null;
     }

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -3,7 +3,7 @@ import {
     loadActivities as loadActivitiesFromStorage,
     deleteActivity as deleteActivityFromStorage
 } from '../storage.js';
-import { extractDateFromDateTime, extractTimeFromDateTime } from '../utils.js';
+import { extractDateFromDateTime, extractTimeFromDateTime, logger } from '../utils.js';
 import {
     loadRunningActivityConfig,
     saveRunningActivityConfig,
@@ -13,6 +13,14 @@ import {
 /** @type {Array<Object>} */
 let activities = [];
 let runningActivity = null;
+
+function logTimerDebug(event, details = {}) {
+    logger.info(`timer-debug:${event}`, {
+        deviceNowIso: new Date().toISOString(),
+        timezoneOffsetMinutes: new Date().getTimezoneOffset(),
+        ...details
+    });
+}
 
 function cloneActivity(activity) {
     return activity ? { ...activity } : activity;
@@ -280,6 +288,17 @@ export function createActivityFromTask(task) {
 
 export async function loadRunningActivity() {
     runningActivity = await loadRunningActivityConfig();
+    logTimerDebug('load-running-activity', {
+        runningActivity: runningActivity
+            ? {
+                  description: runningActivity.description,
+                  category: runningActivity.category || null,
+                  startDateTime: runningActivity.startDateTime,
+                  source: runningActivity.source || 'timer',
+                  sourceTaskId: runningActivity.sourceTaskId || null
+              }
+            : null
+    });
     return getRunningActivity();
 }
 
@@ -313,6 +332,9 @@ export async function startTimer({
     await saveRunningActivityConfig(timerState);
 
     runningActivity = timerState;
+    logTimerDebug('start-timer', {
+        runningActivity: getRunningActivity()
+    });
     return { success: true, runningActivity: getRunningActivity() };
 }
 
@@ -370,6 +392,10 @@ export async function stopTimerAt(endDateTime) {
 
     await deleteRunningActivityConfig();
     runningActivity = null;
+    logTimerDebug('stop-timer', {
+        stoppedAt: safeEndDateTime,
+        activity: cloneActivity(activityResult.activity)
+    });
 
     return { success: true, activity: cloneActivity(activityResult.activity) };
 }
@@ -404,5 +430,8 @@ export async function updateRunningActivity(updates = {}) {
     await saveRunningActivityConfig(nextRunningActivity);
 
     runningActivity = nextRunningActivity;
+    logTimerDebug('update-running-activity', {
+        runningActivity: getRunningActivity()
+    });
     return { success: true, runningActivity: getRunningActivity() };
 }

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -1,12 +1,17 @@
 import {
     putActivity,
     loadActivities as loadActivitiesFromStorage,
-    deleteActivity as deleteActivityFromStorage
+    deleteActivity as deleteActivityFromStorage,
+    putConfig,
+    loadConfig,
+    deleteConfig
 } from '../storage.js';
 import { extractDateFromDateTime } from '../utils.js';
 
 /** @type {Array<Object>} */
 let activities = [];
+const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
+let runningActivity = null;
 
 function cloneActivity(activity) {
     return activity ? { ...activity } : activity;
@@ -30,6 +35,33 @@ function generateActivityId() {
     return `activity-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+function toSafeIsoDateTime(value, fallback = new Date().toISOString()) {
+    if (!value) {
+        return fallback;
+    }
+
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? fallback : parsed.toISOString();
+}
+
+function clampTimerEndDateTime(startDateTime, requestedEndDateTime) {
+    const startMs = new Date(startDateTime).getTime();
+    const requestedMs = new Date(requestedEndDateTime).getTime();
+    const clampedMs = Number.isNaN(requestedMs) ? startMs : Math.max(startMs, requestedMs);
+    return new Date(clampedMs).toISOString();
+}
+
+function calculateDurationMinutes(startDateTime, endDateTime) {
+    const startMs = new Date(startDateTime).getTime();
+    const endMs = new Date(endDateTime).getTime();
+
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+        return 0;
+    }
+
+    return Math.max(0, Math.round((endMs - startMs) / 60000));
+}
+
 function replaceState(nextActivities = []) {
     activities = nextActivities.map((activity) => normalizeActivity(cloneActivity(activity)));
     sortByStartDateTime(activities);
@@ -38,6 +70,7 @@ function replaceState(nextActivities = []) {
 
 export function resetActivityState() {
     activities = [];
+    runningActivity = null;
 }
 
 export function updateActivityState(nextActivities = []) {
@@ -88,7 +121,12 @@ export async function addActivity(activityData) {
         return { success: false, reason: 'Activity start and end times are required.' };
     }
 
-    if (!activityData?.duration || activityData.duration <= 0) {
+    const allowsZeroDuration = activityData?.source === 'timer';
+    if (
+        typeof activityData?.duration !== 'number' ||
+        activityData.duration < 0 ||
+        (!allowsZeroDuration && activityData.duration <= 0)
+    ) {
         return { success: false, reason: 'Activity duration must be greater than 0.' };
     }
 
@@ -150,13 +188,130 @@ export async function removeActivity(activityId) {
 }
 
 export function createActivityFromTask(task) {
+    const now = new Date();
+    const plannedStart = new Date(task.startDateTime);
+    const endsInFuture = !Number.isNaN(plannedStart.getTime()) && plannedStart > now;
+    const endDateTime = endsInFuture ? now.toISOString() : task.endDateTime;
+    const startDateTime = endsInFuture
+        ? new Date(now.getTime() - task.duration * 60000).toISOString()
+        : task.startDateTime;
+
     return {
         description: task.description,
         category: task.category || null,
-        startDateTime: task.startDateTime,
-        endDateTime: task.endDateTime,
+        startDateTime,
+        endDateTime,
         duration: task.duration,
         source: 'auto',
         sourceTaskId: task.id || null
     };
+}
+
+export async function loadRunningActivity() {
+    const config = await loadConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    runningActivity = config
+        ? {
+              description: config.description,
+              category: config.category || null,
+              startDateTime: config.startDateTime
+          }
+        : null;
+
+    return getRunningActivity();
+}
+
+export function getRunningActivity() {
+    return runningActivity ? { ...runningActivity } : null;
+}
+
+export async function startTimer({ description, category } = {}) {
+    const trimmedDescription = description?.trim();
+    if (!trimmedDescription) {
+        return { success: false, reason: 'Description is required to start a timer.' };
+    }
+
+    if (runningActivity) {
+        return { success: false, reason: 'A timer is already running. Stop it first.' };
+    }
+
+    const timerState = {
+        description: trimmedDescription,
+        category: category || null,
+        startDateTime: new Date().toISOString()
+    };
+
+    await putConfig({
+        id: RUNNING_ACTIVITY_CONFIG_ID,
+        ...timerState
+    });
+
+    runningActivity = timerState;
+    return { success: true, runningActivity: getRunningActivity() };
+}
+
+export async function stopTimer() {
+    return stopTimerAt(new Date().toISOString());
+}
+
+export async function stopTimerAt(endDateTime) {
+    if (!runningActivity) {
+        return { success: false, reason: 'No timer is currently running.' };
+    }
+
+    const safeEndDateTime = clampTimerEndDateTime(
+        runningActivity.startDateTime,
+        toSafeIsoDateTime(endDateTime)
+    );
+    const activity = normalizeActivity({
+        id: generateActivityId(),
+        description: runningActivity.description,
+        category: runningActivity.category || null,
+        startDateTime: runningActivity.startDateTime,
+        endDateTime: safeEndDateTime,
+        duration: calculateDurationMinutes(runningActivity.startDateTime, safeEndDateTime),
+        source: 'timer',
+        sourceTaskId: null
+    });
+
+    await putActivity(activity);
+    activities.push(activity);
+    sortByStartDateTime(activities);
+    await deleteConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    runningActivity = null;
+
+    return { success: true, activity: cloneActivity(activity) };
+}
+
+export async function updateRunningActivity(updates = {}) {
+    if (!runningActivity) {
+        return { success: false, reason: 'No timer is currently running.' };
+    }
+
+    const nextDescription =
+        Object.prototype.hasOwnProperty.call(updates, 'description') &&
+        updates.description !== undefined
+            ? updates.description.trim()
+            : runningActivity.description;
+
+    if (!nextDescription) {
+        return { success: false, reason: 'Description is required while a timer is running.' };
+    }
+
+    const nextRunningActivity = {
+        description: nextDescription,
+        category: Object.prototype.hasOwnProperty.call(updates, 'category')
+            ? updates.category || null
+            : runningActivity.category || null,
+        startDateTime: Object.prototype.hasOwnProperty.call(updates, 'startDateTime')
+            ? toSafeIsoDateTime(updates.startDateTime, runningActivity.startDateTime)
+            : runningActivity.startDateTime
+    };
+
+    await putConfig({
+        id: RUNNING_ACTIVITY_CONFIG_ID,
+        ...nextRunningActivity
+    });
+
+    runningActivity = nextRunningActivity;
+    return { success: true, runningActivity: getRunningActivity() };
 }

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -1,16 +1,17 @@
 import {
     putActivity,
     loadActivities as loadActivitiesFromStorage,
-    deleteActivity as deleteActivityFromStorage,
-    putConfig,
-    loadConfig,
-    deleteConfig
+    deleteActivity as deleteActivityFromStorage
 } from '../storage.js';
 import { extractDateFromDateTime } from '../utils.js';
+import {
+    loadRunningActivityConfig,
+    saveRunningActivityConfig,
+    deleteRunningActivityConfig
+} from './running-activity-repository.js';
 
 /** @type {Array<Object>} */
 let activities = [];
-const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
 let runningActivity = null;
 
 function cloneActivity(activity) {
@@ -208,15 +209,7 @@ export function createActivityFromTask(task) {
 }
 
 export async function loadRunningActivity() {
-    const config = await loadConfig(RUNNING_ACTIVITY_CONFIG_ID);
-    runningActivity = config
-        ? {
-              description: config.description,
-              category: config.category || null,
-              startDateTime: config.startDateTime
-          }
-        : null;
-
+    runningActivity = await loadRunningActivityConfig();
     return getRunningActivity();
 }
 
@@ -240,13 +233,35 @@ export async function startTimer({ description, category } = {}) {
         startDateTime: new Date().toISOString()
     };
 
-    await putConfig({
-        id: RUNNING_ACTIVITY_CONFIG_ID,
-        ...timerState
-    });
+    await saveRunningActivityConfig(timerState);
 
     runningActivity = timerState;
     return { success: true, runningActivity: getRunningActivity() };
+}
+
+export async function startTimerReplacingCurrent(timerData) {
+    let stoppedActivity = null;
+
+    if (runningActivity) {
+        const stopResult = await stopTimer();
+        if (!stopResult?.success) {
+            return stopResult;
+        }
+        stoppedActivity = stopResult.activity || null;
+    }
+
+    const startResult = await startTimer(timerData);
+    if (!startResult?.success) {
+        return {
+            ...startResult,
+            stoppedActivity
+        };
+    }
+
+    return {
+        ...startResult,
+        stoppedActivity
+    };
 }
 
 export async function stopTimer() {
@@ -276,7 +291,7 @@ export async function stopTimerAt(endDateTime) {
     await putActivity(activity);
     activities.push(activity);
     sortByStartDateTime(activities);
-    await deleteConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    await deleteRunningActivityConfig();
     runningActivity = null;
 
     return { success: true, activity: cloneActivity(activity) };
@@ -307,10 +322,7 @@ export async function updateRunningActivity(updates = {}) {
             : runningActivity.startDateTime
     };
 
-    await putConfig({
-        id: RUNNING_ACTIVITY_CONFIG_ID,
-        ...nextRunningActivity
-    });
+    await saveRunningActivityConfig(nextRunningActivity);
 
     runningActivity = nextRunningActivity;
     return { success: true, runningActivity: getRunningActivity() };

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -9,6 +9,7 @@ import {
     saveRunningActivityConfig,
     deleteRunningActivityConfig
 } from './running-activity-repository.js';
+import { consumeUnscheduledTask } from '../tasks/manager.js';
 
 /** @type {Array<Object>} */
 let activities = [];
@@ -61,6 +62,28 @@ function calculateDurationMinutes(startDateTime, endDateTime) {
     }
 
     return Math.max(0, Math.round((endMs - startMs) / 60000));
+}
+
+function ensureMinimumCompletedActivityDuration(activityData) {
+    if (
+        !activityData?.startDateTime ||
+        !activityData?.endDateTime ||
+        typeof activityData?.duration !== 'number' ||
+        activityData.duration >= 1
+    ) {
+        return activityData;
+    }
+
+    const startMs = new Date(activityData.startDateTime).getTime();
+    if (Number.isNaN(startMs)) {
+        return activityData;
+    }
+
+    return {
+        ...activityData,
+        duration: 1,
+        endDateTime: new Date(startMs + 60000).toISOString()
+    };
 }
 
 function replaceState(nextActivities = []) {
@@ -132,28 +155,27 @@ export async function loadActivitiesState(loadActivities = loadActivitiesFromSto
 }
 
 export async function addActivity(activityData) {
-    const description = activityData?.description?.trim();
+    const normalizedActivityData = ensureMinimumCompletedActivityDuration(activityData);
+    const description = normalizedActivityData?.description?.trim();
 
     if (!description) {
         return { success: false, reason: 'Activity description is required.' };
     }
 
-    if (!activityData?.startDateTime || !activityData?.endDateTime) {
+    if (!normalizedActivityData?.startDateTime || !normalizedActivityData?.endDateTime) {
         return { success: false, reason: 'Activity start and end times are required.' };
     }
 
-    const allowsZeroDuration = activityData?.source === 'timer';
     if (
-        typeof activityData?.duration !== 'number' ||
-        activityData.duration < 0 ||
-        (!allowsZeroDuration && activityData.duration <= 0)
+        typeof normalizedActivityData?.duration !== 'number' ||
+        normalizedActivityData.duration <= 0
     ) {
         return { success: false, reason: 'Activity duration must be greater than 0.' };
     }
 
     const activity = normalizeActivity({
-        ...activityData,
-        id: activityData.id || generateActivityId(),
+        ...normalizedActivityData,
+        id: normalizedActivityData.id || generateActivityId(),
         description
     });
 
@@ -237,7 +259,12 @@ export function getRunningActivity() {
     return runningActivity ? { ...runningActivity } : null;
 }
 
-export async function startTimer({ description, category } = {}) {
+export async function startTimer({
+    description,
+    category,
+    source = 'timer',
+    sourceTaskId = null
+} = {}) {
     const trimmedDescription = description?.trim();
     if (!trimmedDescription) {
         return { success: false, reason: 'Description is required to start a timer.' };
@@ -250,7 +277,9 @@ export async function startTimer({ description, category } = {}) {
     const timerState = {
         description: trimmedDescription,
         category: category || null,
-        startDateTime: new Date().toISOString()
+        startDateTime: new Date().toISOString(),
+        source,
+        sourceTaskId
     };
 
     await saveRunningActivityConfig(timerState);
@@ -297,24 +326,27 @@ export async function stopTimerAt(endDateTime) {
         runningActivity.startDateTime,
         toSafeIsoDateTime(endDateTime)
     );
-    const activity = normalizeActivity({
-        id: generateActivityId(),
+    const activityResult = await addActivity({
         description: runningActivity.description,
         category: runningActivity.category || null,
         startDateTime: runningActivity.startDateTime,
         endDateTime: safeEndDateTime,
         duration: calculateDurationMinutes(runningActivity.startDateTime, safeEndDateTime),
-        source: 'timer',
-        sourceTaskId: null
+        source: runningActivity.source || 'timer',
+        sourceTaskId: runningActivity.sourceTaskId || null
     });
 
-    await putActivity(activity);
-    activities.push(activity);
-    sortByStartDateTime(activities);
+    if (!activityResult?.success) {
+        return activityResult;
+    }
+
+    if (runningActivity.sourceTaskId) {
+        consumeUnscheduledTask(runningActivity.sourceTaskId);
+    }
     await deleteRunningActivityConfig();
     runningActivity = null;
 
-    return { success: true, activity: cloneActivity(activity) };
+    return { success: true, activity: cloneActivity(activityResult.activity) };
 }
 
 export async function updateRunningActivity(updates = {}) {
@@ -339,7 +371,9 @@ export async function updateRunningActivity(updates = {}) {
             : runningActivity.category || null,
         startDateTime: Object.prototype.hasOwnProperty.call(updates, 'startDateTime')
             ? toSafeIsoDateTime(updates.startDateTime, runningActivity.startDateTime)
-            : runningActivity.startDateTime
+            : runningActivity.startDateTime,
+        source: runningActivity.source || 'timer',
+        sourceTaskId: runningActivity.sourceTaskId || null
     };
 
     await saveRunningActivityConfig(nextRunningActivity);

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -9,7 +9,6 @@ import {
     saveRunningActivityConfig,
     deleteRunningActivityConfig
 } from './running-activity-repository.js';
-import { consumeUnscheduledTask } from '../tasks/manager.js';
 
 /** @type {Array<Object>} */
 let activities = [];
@@ -369,9 +368,6 @@ export async function stopTimerAt(endDateTime) {
         return activityResult;
     }
 
-    if (runningActivity.sourceTaskId) {
-        consumeUnscheduledTask(runningActivity.sourceTaskId);
-    }
     await deleteRunningActivityConfig();
     runningActivity = null;
 

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -3,7 +3,7 @@ import {
     loadActivities as loadActivitiesFromStorage,
     deleteActivity as deleteActivityFromStorage
 } from '../storage.js';
-import { extractDateFromDateTime } from '../utils.js';
+import { extractDateFromDateTime, extractTimeFromDateTime } from '../utils.js';
 import {
     loadRunningActivityConfig,
     saveRunningActivityConfig,
@@ -98,6 +98,20 @@ export function getTodaysActivities(now = new Date()) {
         .slice()
         .sort((left, right) => new Date(left.startDateTime) - new Date(right.startDateTime))
         .map(cloneActivity);
+}
+
+export function getSuggestedActivityStartTime(now = new Date()) {
+    const todaysActivities = getTodaysActivities(now);
+    if (todaysActivities.length === 0) {
+        return null;
+    }
+
+    const latestActivity = todaysActivities[todaysActivities.length - 1];
+    if (!latestActivity?.endDateTime) {
+        return null;
+    }
+
+    return extractTimeFromDateTime(new Date(latestActivity.endDateTime));
 }
 
 export async function loadActivitiesState(loadActivities = loadActivitiesFromStorage) {

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -143,6 +143,35 @@ export function getSuggestedActivityStartTime(now = new Date()) {
     return extractTimeFromDateTime(new Date(latestActivity.endDateTime));
 }
 
+export function getLiveTodayActivitySummary(now = new Date()) {
+    if (!runningActivity?.startDateTime) {
+        return null;
+    }
+
+    const nowDate = now instanceof Date ? now : new Date(now);
+    const startDate = new Date(runningActivity.startDateTime);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(nowDate.getTime())) {
+        return null;
+    }
+
+    const today = extractDateFromDateTime(nowDate);
+    if (extractDateFromDateTime(startDate) !== today) {
+        return null;
+    }
+
+    const endDateTime = clampTimerEndDateTime(runningActivity.startDateTime, nowDate.toISOString());
+    const duration = calculateDurationMinutes(runningActivity.startDateTime, endDateTime);
+
+    return cloneActivity(
+        normalizeActivity({
+            ...runningActivity,
+            id: runningActivity.id || 'running-activity-summary',
+            endDateTime,
+            duration
+        })
+    );
+}
+
 export async function loadActivitiesState(loadActivities = loadActivitiesFromStorage) {
     if (typeof loadActivities !== 'function') {
         replaceState([]);

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -107,12 +107,14 @@ function summarizeActivitiesByParentGroup(activities) {
 
         if (existing) {
             existing.duration += activity.duration;
+            existing.count += 1;
             continue;
         }
 
         summaryMap.set(summaryKey, {
             ...summaryItem,
             duration: activity.duration,
+            count: 1,
             isUncategorized: Boolean(summaryItem.isUncategorized)
         });
     }
@@ -174,7 +176,8 @@ function renderParentSummaryLegendItem(summaryItem) {
     const interactionClasses = getParentSummaryInteractionClasses(summaryItem);
     const commonAttributes = `data-summary-parent-legend="${escapeHtml(summaryItem.key)}" data-summary-parent-key="${escapeHtml(summaryItem.key)}"`;
     const content = `<span data-summary-legend-swatch="${escapeHtml(summaryItem.key)}" class="h-2 w-2 rounded-full shrink-0" style="${getSummarySwatchStyle(summaryItem)}"></span>
-                    ${escapeHtml(summaryItem.label)} ${escapeHtml(calculateHoursAndMinutes(summaryItem.duration))}`;
+                    ${escapeHtml(summaryItem.label)} ${escapeHtml(calculateHoursAndMinutes(summaryItem.duration))}
+                    <span data-summary-parent-count="${escapeHtml(summaryItem.key)}" class="inline-flex min-w-[1.25rem] items-center justify-center rounded-full border border-slate-600/80 bg-slate-900/80 px-1.5 py-0.5 text-[10px] font-medium leading-none text-slate-300">${escapeHtml(summaryItem.count)}</span>`;
 
     if (summaryItem.isUncategorized) {
         return `<span ${commonAttributes} class="inline-flex items-center gap-2 ${interactionClasses.legend}">
@@ -308,6 +311,7 @@ function renderExpandedChildRail(activities, expandedParentGroupKey) {
 function renderActivitySummary(activities, options = {}) {
     const summaryItems = summarizeActivitiesByParentGroup(activities);
     const totalDuration = summaryItems.reduce((sum, item) => sum + item.duration, 0);
+    const totalCount = summaryItems.reduce((sum, item) => sum + item.count, 0);
 
     if (summaryItems.length === 0 || totalDuration <= 0) {
         return '';
@@ -322,7 +326,10 @@ function renderActivitySummary(activities, options = {}) {
 
     return `<div data-activity-summary class="px-3 py-3 rounded-lg bg-slate-800/50 border border-slate-700/50">
         <div class="flex items-end justify-between gap-3 mb-3">
-            <div class="text-[11px] uppercase tracking-[0.22em] text-sky-300">Category Breakdown</div>
+            <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-sky-300">
+                <span>Activity Breakdown</span>
+                <span data-summary-total-count class="inline-flex min-w-[1.35rem] items-center justify-center rounded-full border border-sky-700/60 bg-sky-950/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-sky-200 normal-case tracking-normal">${escapeHtml(totalCount)}</span>
+            </div>
             <div class="text-xs text-slate-300">Total <span class="font-medium text-slate-100">${escapeHtml(calculateHoursAndMinutes(totalDuration))}</span></div>
         </div>
         <div class="flex h-3 overflow-hidden rounded-full border border-slate-700 bg-slate-950/90">

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -342,6 +342,31 @@ function renderActivitySummary(activities, options = {}) {
     </div>`;
 }
 
+export function renderActivitySummaryOnly(activities, container, options = {}) {
+    const targetContainer = container || document.getElementById('activity-list');
+    if (!targetContainer) {
+        return;
+    }
+
+    const summaryActivities = Array.isArray(options.summaryActivities)
+        ? options.summaryActivities
+        : activities;
+    const summaryHtml = renderActivitySummary(summaryActivities, options);
+    const existingSummary = targetContainer.querySelector('[data-activity-summary]');
+
+    if (!summaryHtml) {
+        existingSummary?.remove();
+        return;
+    }
+
+    if (existingSummary) {
+        existingSummary.outerHTML = summaryHtml;
+        return;
+    }
+
+    targetContainer.insertAdjacentHTML('afterbegin', summaryHtml);
+}
+
 function renderInlineEditActivityItem(activity) {
     const durationHours = Math.floor(activity.duration / 60);
     const durationMinutes = activity.duration % 60;
@@ -452,17 +477,25 @@ export function renderActivities(activities, container, options = {}) {
         return;
     }
 
+    const summaryActivities = Array.isArray(options.summaryActivities)
+        ? options.summaryActivities
+        : activities;
+    const summaryHtml = renderActivitySummary(summaryActivities, options);
+
     if (!activities || activities.length === 0) {
+        const emptyStateMessage = summaryHtml
+            ? 'No completed activities logged today yet.'
+            : 'No activities tracked today. Log one or complete a scheduled task.';
         targetContainer.innerHTML = `
+            ${summaryHtml}
             <div class="py-6 text-slate-500 text-sm italic px-2">
                 <i class="fa-regular fa-clock mr-1"></i>
-                No activities tracked today. Log one or complete a scheduled task.
+                ${emptyStateMessage}
             </div>`;
         return;
     }
 
     const editingActivityId = options.editingActivityId || null;
-    const summaryHtml = renderActivitySummary(activities, options);
     const activitiesHtml = activities
         .map((activity) =>
             activity.id === editingActivityId

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -434,10 +434,11 @@ function renderInlineEditActivityItem(activity) {
     </form>`;
 }
 
-function renderActivityItem(activity) {
+function renderActivityItem(activity, options = {}) {
     const timeRange = formatTimeRange(activity.startDateTime, activity.endDateTime);
     const durationText = calculateHoursAndMinutes(activity.duration);
     const badge = renderCategoryBadge(activity.category);
+    const isConfirmingDelete = options.confirmingDeleteActivityId === activity.id;
     const isAuto = activity.source === 'auto';
     const provenanceHtml = isAuto
         ? `<span class="activity-source-link text-xs text-sky-400/60 italic cursor-default" data-source-task-id="${escapeHtml(activity.sourceTaskId || '')}" title="Auto-logged from task">
@@ -449,8 +450,8 @@ function renderActivityItem(activity) {
                <button class="btn-edit-activity text-slate-400 hover:text-slate-200 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Edit activity">
                    <i class="fa-solid fa-pen"></i>
                </button>
-               <button class="btn-delete-activity text-rose-400/60 hover:text-rose-400 transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Delete activity">
-                   <i class="fa-solid fa-trash-can"></i>
+               <button class="btn-delete-activity ${isConfirmingDelete ? 'text-rose-400' : 'text-rose-400/60 hover:text-rose-400'} transition-colors text-xs" data-activity-id="${escapeHtml(activity.id)}" title="Delete activity">
+                   <i class="fa-${isConfirmingDelete ? 'regular fa-check-circle' : 'solid fa-trash-can'}"></i>
                </button>
            </div>`;
 
@@ -500,7 +501,7 @@ export function renderActivities(activities, container, options = {}) {
         .map((activity) =>
             activity.id === editingActivityId
                 ? renderInlineEditActivityItem(activity)
-                : renderActivityItem(activity)
+                : renderActivityItem(activity, options)
         )
         .join('');
     targetContainer.innerHTML = `${summaryHtml}${activitiesHtml}`;

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -372,6 +372,8 @@ function renderInlineEditActivityItem(activity) {
     const durationMinutes = activity.duration % 60;
     const displayStartTime = extractTimeFromDateTime(new Date(activity.startDateTime));
     const activityDate = extractDateFromDateTime(new Date(activity.startDateTime));
+    const resolvedCategory = activity.category ? resolveCategoryKey(activity.category) : null;
+    const categoryColor = resolvedCategory?.record?.color || '#64748b';
     const endTimeHint = computeEndTimePreview(
         displayStartTime,
         durationHours.toString(),
@@ -396,9 +398,12 @@ function renderInlineEditActivityItem(activity) {
                     class="bg-slate-700 pl-10 pr-4 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100" required>
             </div>
             <div class="sm:flex-1 sm:min-w-[13rem]">
+                <div class="flex items-center gap-2">
+                <span class="activity-edit-category-dot w-3 h-3 rounded-full shrink-0" style="background-color: ${escapeHtml(categoryColor)};"></span>
                 <select name="category" class="bg-slate-700 px-3 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
                     ${renderCategoryOptions(activity.category)}
                 </select>
+                </div>
             </div>
         </div>
         <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:pb-5">

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -1,7 +1,9 @@
 import {
     renderCategoryBadge,
     getSelectableCategoryOptions,
-    getCategoryBadgeData
+    resolveCategoryKey,
+    getGroupByKey,
+    getCategoryByKey
 } from '../taxonomy/taxonomy-selectors.js';
 import {
     calculateHoursAndMinutes,
@@ -40,11 +42,66 @@ function renderCategoryOptions(selectedCategory) {
     return `${baseOption}${renderedOptions}`;
 }
 
-function summarizeActivitiesByCategory(activities) {
+function titleCaseKey(value) {
+    return String(value)
+        .split(/[-_/]+/)
+        .filter(Boolean)
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join(' ');
+}
+
+function buildFallbackParentMetadata(parentKey) {
+    return {
+        key: parentKey,
+        label: titleCaseKey(parentKey),
+        color: '#64748b',
+        isUncategorized: false
+    };
+}
+
+function buildResolvedParentMetadata(parentKey) {
+    const parentGroup = getGroupByKey(parentKey);
+    if (parentGroup) {
+        return {
+            key: parentGroup.key,
+            label: parentGroup.label,
+            color: parentGroup.color,
+            isUncategorized: false
+        };
+    }
+
+    return buildFallbackParentMetadata(parentKey);
+}
+
+function getParentSummaryMetadata(activity) {
+    if (!activity.category) {
+        return {
+            key: 'uncategorized',
+            label: 'Uncategorized',
+            color: '#64748b',
+            isUncategorized: true
+        };
+    }
+
+    const resolvedCategory = resolveCategoryKey(activity.category);
+    if (!resolvedCategory) {
+        const inferredParentKey = activity.category.split('/')[0] || activity.category;
+        return buildResolvedParentMetadata(inferredParentKey);
+    }
+
+    if (resolvedCategory.kind === 'group') {
+        return buildResolvedParentMetadata(resolvedCategory.record.key);
+    }
+
+    return buildResolvedParentMetadata(resolvedCategory.record.groupKey);
+}
+
+function summarizeActivitiesByParentGroup(activities) {
     const summaryMap = new Map();
 
     for (const activity of activities) {
-        const summaryKey = activity.category || 'uncategorized';
+        const summaryItem = getParentSummaryMetadata(activity);
+        const summaryKey = summaryItem.key;
         const existing = summaryMap.get(summaryKey);
 
         if (existing) {
@@ -52,17 +109,20 @@ function summarizeActivitiesByCategory(activities) {
             continue;
         }
 
-        const badgeData = activity.category ? getCategoryBadgeData(activity.category) : null;
         summaryMap.set(summaryKey, {
-            key: summaryKey,
-            label: badgeData?.label || 'Uncategorized',
+            ...summaryItem,
             duration: activity.duration,
-            color: badgeData?.color || '#64748b',
-            isUncategorized: !activity.category
+            isUncategorized: Boolean(summaryItem.isUncategorized)
         });
     }
 
-    return Array.from(summaryMap.values()).sort((left, right) => right.duration - left.duration);
+    return Array.from(summaryMap.values()).sort((left, right) => {
+        if (right.duration !== left.duration) {
+            return right.duration - left.duration;
+        }
+
+        return left.label.localeCompare(right.label) || left.key.localeCompare(right.key);
+    });
 }
 
 function getSummarySwatchStyle(summaryItem) {
@@ -83,8 +143,137 @@ function getSummarySegmentStyle(summaryItem, totalDuration) {
     return `width: ${widthPercentage}%; background-color: ${summaryItem.color};`;
 }
 
-function renderActivitySummary(activities) {
-    const summaryItems = summarizeActivitiesByCategory(activities);
+function getParentSummaryInteractionClasses(summaryItem) {
+    if (summaryItem.isUncategorized) {
+        return {
+            segment: 'cursor-default',
+            legend: 'cursor-default'
+        };
+    }
+
+    return {
+        segment: 'cursor-pointer',
+        legend: 'cursor-pointer'
+    };
+}
+
+function summarizeExpandedChildCategories(activities, expandedParentGroupKey) {
+    if (!expandedParentGroupKey || expandedParentGroupKey === 'uncategorized') {
+        return [];
+    }
+
+    const parentGroup = getGroupByKey(expandedParentGroupKey);
+    if (!parentGroup) {
+        return [];
+    }
+
+    const summaryMap = new Map();
+
+    for (const activity of activities) {
+        if (!activity.category) {
+            continue;
+        }
+
+        const resolvedCategory = resolveCategoryKey(activity.category);
+        if (!resolvedCategory) {
+            continue;
+        }
+
+        if (resolvedCategory.kind === 'group') {
+            if (resolvedCategory.record.key !== expandedParentGroupKey) {
+                continue;
+            }
+
+            const syntheticKey = `${expandedParentGroupKey}::__unspecified`;
+            const existing = summaryMap.get(syntheticKey);
+            if (existing) {
+                existing.duration += activity.duration;
+                continue;
+            }
+
+            summaryMap.set(syntheticKey, {
+                key: syntheticKey,
+                label: `Unspecified ${parentGroup.label}`,
+                color: parentGroup.color,
+                duration: activity.duration
+            });
+            continue;
+        }
+
+        const childCategory = getCategoryByKey(resolvedCategory.record.key);
+        if (!childCategory || childCategory.groupKey !== expandedParentGroupKey) {
+            continue;
+        }
+
+        const existing = summaryMap.get(childCategory.key);
+        if (existing) {
+            existing.duration += activity.duration;
+            continue;
+        }
+
+        summaryMap.set(childCategory.key, {
+            key: childCategory.key,
+            label: childCategory.label,
+            color: childCategory.color,
+            duration: activity.duration
+        });
+    }
+
+    return Array.from(summaryMap.values())
+        .filter((item) => item.duration > 0)
+        .sort((left, right) => {
+            if (right.duration !== left.duration) {
+                return right.duration - left.duration;
+            }
+
+            return left.label.localeCompare(right.label) || left.key.localeCompare(right.key);
+        });
+}
+
+function renderExpandedChildRail(activities, expandedParentGroupKey) {
+    const childItems = summarizeExpandedChildCategories(activities, expandedParentGroupKey);
+    if (childItems.length === 0) {
+        return '';
+    }
+
+    const parentGroup = getGroupByKey(expandedParentGroupKey);
+    if (!parentGroup) {
+        return '';
+    }
+
+    const totalDuration = childItems.reduce((sum, item) => sum + item.duration, 0);
+    const segmentsHtml = childItems
+        .map(
+            (item) =>
+                `<div data-summary-child-segment="${escapeHtml(item.key)}" class="h-full rounded-full" style="${getSummarySegmentStyle(item, totalDuration)}"></div>`
+        )
+        .join('');
+    const legendHtml = childItems
+        .map(
+            (item) =>
+                `<span data-summary-child-legend="${escapeHtml(item.key)}" class="inline-flex items-center gap-1.5">
+                    <span class="h-1.5 w-1.5 rounded-full shrink-0" style="background-color: ${item.color};"></span>
+                    ${escapeHtml(item.label)} ${escapeHtml(calculateHoursAndMinutes(item.duration))}
+                </span>`
+        )
+        .join('');
+
+    return `<div data-summary-expanded-group="${escapeHtml(expandedParentGroupKey)}" class="mt-2 space-y-1.5">
+        <div class="flex items-center justify-between gap-3 text-[11px] text-slate-400">
+            <span class="uppercase tracking-[0.18em] text-slate-300">${escapeHtml(parentGroup.label)}</span>
+            <span>${escapeHtml(calculateHoursAndMinutes(totalDuration))}</span>
+        </div>
+        <div class="flex h-1.5 overflow-hidden rounded-full bg-slate-950/90">
+            ${segmentsHtml}
+        </div>
+        <div class="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-slate-400">
+            ${legendHtml}
+        </div>
+    </div>`;
+}
+
+function renderActivitySummary(activities, options = {}) {
+    const summaryItems = summarizeActivitiesByParentGroup(activities);
     const totalDuration = summaryItems.reduce((sum, item) => sum + item.duration, 0);
 
     if (summaryItems.length === 0 || totalDuration <= 0) {
@@ -92,21 +281,22 @@ function renderActivitySummary(activities) {
     }
 
     const segmentsHtml = summaryItems
-        .map(
-            (item) =>
-                `<div data-summary-segment="${escapeHtml(item.key)}" class="h-full" style="${getSummarySegmentStyle(item, totalDuration)}"></div>`
-        )
+        .map((item) => {
+            const interactionClasses = getParentSummaryInteractionClasses(item);
+            return `<div data-summary-segment="${escapeHtml(item.key)}" data-summary-parent-segment="${escapeHtml(item.key)}" data-summary-parent-key="${escapeHtml(item.key)}" class="h-full ${interactionClasses.segment}" style="${getSummarySegmentStyle(item, totalDuration)}"></div>`;
+        })
         .join('');
 
     const legendHtml = summaryItems
-        .map(
-            (item) =>
-                `<span class="inline-flex items-center gap-2">
+        .map((item) => {
+            const interactionClasses = getParentSummaryInteractionClasses(item);
+            return `<span data-summary-parent-legend="${escapeHtml(item.key)}" data-summary-parent-key="${escapeHtml(item.key)}" class="inline-flex items-center gap-2 ${interactionClasses.legend}">
                     <span data-summary-legend-swatch="${escapeHtml(item.key)}" class="h-2 w-2 rounded-full shrink-0" style="${getSummarySwatchStyle(item)}"></span>
                     ${escapeHtml(item.label)} ${escapeHtml(calculateHoursAndMinutes(item.duration))}
-                </span>`
-        )
+                </span>`;
+        })
         .join('');
+    const expandedRailHtml = renderExpandedChildRail(activities, options.expandedParentGroupKey);
 
     return `<div data-activity-summary class="px-3 py-3 rounded-lg bg-slate-800/50 border border-slate-700/50">
         <div class="flex items-end justify-between gap-3 mb-3">
@@ -119,6 +309,7 @@ function renderActivitySummary(activities) {
         <div class="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 text-xs text-slate-300 sm:grid-cols-2">
             ${legendHtml}
         </div>
+        ${expandedRailHtml}
     </div>`;
 }
 
@@ -242,7 +433,7 @@ export function renderActivities(activities, container, options = {}) {
     }
 
     const editingActivityId = options.editingActivityId || null;
-    const summaryHtml = renderActivitySummary(activities);
+    const summaryHtml = renderActivitySummary(activities, options);
     const activitiesHtml = activities
         .map((activity) =>
             activity.id === editingActivityId

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -1,10 +1,7 @@
 import {
     renderCategoryBadge,
     getSelectableCategoryOptions,
-    resolveCategoryKey,
-    getGroupByKey,
-    getCategoryByKey,
-    getTaxonomySnapshot
+    resolveCategoryKey
 } from '../taxonomy/taxonomy-selectors.js';
 import {
     calculateHoursAndMinutes,
@@ -13,6 +10,7 @@ import {
     extractDateFromDateTime
 } from '../utils.js';
 import { computeEndTimePreview } from '../tasks/form-utils.js';
+import { buildActivitySummaryModel } from './summary.js';
 
 function escapeHtml(value) {
     return String(value)
@@ -41,91 +39,6 @@ function renderCategoryOptions(selectedCategory) {
         .join('');
 
     return `${baseOption}${renderedOptions}`;
-}
-
-function titleCaseKey(value) {
-    return String(value)
-        .split(/[-_/]+/)
-        .filter(Boolean)
-        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-        .join(' ');
-}
-
-function buildFallbackParentMetadata(parentKey) {
-    return {
-        key: parentKey,
-        label: titleCaseKey(parentKey),
-        color: '#64748b',
-        isUncategorized: false
-    };
-}
-
-function buildResolvedParentMetadata(parentKey) {
-    const parentGroup = getGroupByKey(parentKey);
-    if (parentGroup) {
-        return {
-            key: parentGroup.key,
-            label: parentGroup.label,
-            color: parentGroup.color,
-            isUncategorized: false
-        };
-    }
-
-    return buildFallbackParentMetadata(parentKey);
-}
-
-function getParentSummaryMetadata(activity) {
-    if (!activity.category) {
-        return {
-            key: 'uncategorized',
-            label: 'Uncategorized',
-            color: '#64748b',
-            isUncategorized: true
-        };
-    }
-
-    const resolvedCategory = resolveCategoryKey(activity.category);
-    if (!resolvedCategory) {
-        const inferredParentKey = activity.category.split('/')[0] || activity.category;
-        return buildResolvedParentMetadata(inferredParentKey);
-    }
-
-    if (resolvedCategory.kind === 'group') {
-        return buildResolvedParentMetadata(resolvedCategory.record.key);
-    }
-
-    return buildResolvedParentMetadata(resolvedCategory.record.groupKey);
-}
-
-function summarizeActivitiesByParentGroup(activities) {
-    const summaryMap = new Map();
-
-    for (const activity of activities) {
-        const summaryItem = getParentSummaryMetadata(activity);
-        const summaryKey = summaryItem.key;
-        const existing = summaryMap.get(summaryKey);
-
-        if (existing) {
-            existing.duration += activity.duration;
-            existing.count += 1;
-            continue;
-        }
-
-        summaryMap.set(summaryKey, {
-            ...summaryItem,
-            duration: activity.duration,
-            count: 1,
-            isUncategorized: Boolean(summaryItem.isUncategorized)
-        });
-    }
-
-    return Array.from(summaryMap.values()).sort((left, right) => {
-        if (right.duration !== left.duration) {
-            return right.duration - left.duration;
-        }
-
-        return left.label.localeCompare(right.label) || left.key.localeCompare(right.key);
-    });
 }
 
 function getSummarySwatchStyle(summaryItem) {
@@ -190,101 +103,17 @@ function renderParentSummaryLegendItem(summaryItem) {
                 </button>`;
 }
 
-function summarizeExpandedChildCategories(activities, expandedParentGroupKey) {
-    if (!expandedParentGroupKey || expandedParentGroupKey === 'uncategorized') {
-        return [];
-    }
-
-    const parentGroup = getGroupByKey(expandedParentGroupKey);
-    if (!parentGroup) {
-        return [];
-    }
-    const parentHasChildren = getTaxonomySnapshot().categories.some(
-        (category) => category.groupKey === expandedParentGroupKey
-    );
-
-    const summaryMap = new Map();
-
-    for (const activity of activities) {
-        if (!activity.category) {
-            continue;
-        }
-
-        const resolvedCategory = resolveCategoryKey(activity.category);
-        if (!resolvedCategory) {
-            continue;
-        }
-
-        if (resolvedCategory.kind === 'group') {
-            if (resolvedCategory.record.key !== expandedParentGroupKey) {
-                continue;
-            }
-
-            const syntheticKey = `${expandedParentGroupKey}::__unspecified`;
-            const existing = summaryMap.get(syntheticKey);
-            if (existing) {
-                existing.duration += activity.duration;
-                continue;
-            }
-
-            summaryMap.set(syntheticKey, {
-                key: syntheticKey,
-                label: parentHasChildren ? 'Unspecified' : parentGroup.label,
-                color: parentGroup.color,
-                duration: activity.duration
-            });
-            continue;
-        }
-
-        const childCategory = getCategoryByKey(resolvedCategory.record.key);
-        if (!childCategory || childCategory.groupKey !== expandedParentGroupKey) {
-            continue;
-        }
-
-        const existing = summaryMap.get(childCategory.key);
-        if (existing) {
-            existing.duration += activity.duration;
-            continue;
-        }
-
-        summaryMap.set(childCategory.key, {
-            key: childCategory.key,
-            label: childCategory.label,
-            color: childCategory.color,
-            duration: activity.duration
-        });
-    }
-
-    return Array.from(summaryMap.values())
-        .filter((item) => item.duration > 0)
-        .sort((left, right) => {
-            if (right.duration !== left.duration) {
-                return right.duration - left.duration;
-            }
-
-            return left.label.localeCompare(right.label) || left.key.localeCompare(right.key);
-        });
-}
-
-function renderExpandedChildRail(activities, expandedParentGroupKey) {
-    const childItems = summarizeExpandedChildCategories(activities, expandedParentGroupKey);
-    if (childItems.length === 0) {
+function renderExpandedChildRail(expandedGroup) {
+    if (!expandedGroup) {
         return '';
     }
-
-    const parentGroup = getGroupByKey(expandedParentGroupKey);
-    if (!parentGroup) {
-        return '';
-    }
-
-    const totalDuration = childItems.reduce((sum, item) => sum + item.duration, 0);
-    const segmentsHtml = childItems
+    const segmentsHtml = expandedGroup.items
         .map(
             (item) =>
-                `<div data-summary-child-segment="${escapeHtml(item.key)}" class="h-full rounded-full" style="${getSummarySegmentStyle(item, totalDuration)}"></div>`
+                `<div data-summary-child-segment="${escapeHtml(item.key)}" class="h-full rounded-full" style="${getSummarySegmentStyle(item, expandedGroup.totalDuration)}"></div>`
         )
         .join('');
-    const legendHtml = childItems
+    const legendHtml = expandedGroup.items
         .map(
             (item) =>
                 `<span data-summary-child-legend="${escapeHtml(item.key)}" class="inline-flex items-center gap-1.5">
@@ -294,10 +123,10 @@ function renderExpandedChildRail(activities, expandedParentGroupKey) {
         )
         .join('');
 
-    return `<div data-summary-expanded-group="${escapeHtml(expandedParentGroupKey)}" class="mt-2 space-y-1.5">
+    return `<div data-summary-expanded-group="${escapeHtml(expandedGroup.key)}" class="mt-2 space-y-1.5">
         <div class="flex items-center justify-between gap-3 text-[11px] text-slate-400">
-            <span class="uppercase tracking-[0.18em] text-slate-300">${escapeHtml(parentGroup.label)}</span>
-            <span>${escapeHtml(calculateHoursAndMinutes(totalDuration))}</span>
+            <span class="uppercase tracking-[0.18em] text-slate-300">${escapeHtml(expandedGroup.label)}</span>
+            <span>${escapeHtml(calculateHoursAndMinutes(expandedGroup.totalDuration))}</span>
         </div>
         <div class="flex h-1.5 overflow-hidden rounded-full bg-slate-950/90">
             ${segmentsHtml}
@@ -309,9 +138,10 @@ function renderExpandedChildRail(activities, expandedParentGroupKey) {
 }
 
 function renderActivitySummary(activities, options = {}) {
-    const summaryItems = summarizeActivitiesByParentGroup(activities);
-    const totalDuration = summaryItems.reduce((sum, item) => sum + item.duration, 0);
-    const totalCount = summaryItems.reduce((sum, item) => sum + item.count, 0);
+    const { summaryItems, totalDuration, totalCount, expandedGroup } = buildActivitySummaryModel(
+        activities,
+        options.expandedParentGroupKey
+    );
 
     if (summaryItems.length === 0 || totalDuration <= 0) {
         return '';
@@ -322,7 +152,7 @@ function renderActivitySummary(activities, options = {}) {
         .join('');
 
     const legendHtml = summaryItems.map((item) => renderParentSummaryLegendItem(item)).join('');
-    const expandedRailHtml = renderExpandedChildRail(activities, options.expandedParentGroupKey);
+    const expandedRailHtml = renderExpandedChildRail(expandedGroup);
 
     return `<div data-activity-summary class="px-3 py-3 rounded-lg bg-slate-800/50 border border-slate-700/50">
         <div class="flex items-end justify-between gap-3 mb-3">

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -1,6 +1,7 @@
 import {
     renderCategoryBadge,
-    getSelectableCategoryOptions
+    getSelectableCategoryOptions,
+    getCategoryBadgeData
 } from '../taxonomy/taxonomy-selectors.js';
 import {
     calculateHoursAndMinutes,
@@ -36,6 +37,88 @@ function renderCategoryOptions(selectedCategory) {
         .join('');
 
     return `${baseOption}${renderedOptions}`;
+}
+
+function summarizeActivitiesByCategory(activities) {
+    const summaryMap = new Map();
+
+    for (const activity of activities) {
+        const summaryKey = activity.category || 'uncategorized';
+        const existing = summaryMap.get(summaryKey);
+
+        if (existing) {
+            existing.duration += activity.duration;
+            continue;
+        }
+
+        const badgeData = activity.category ? getCategoryBadgeData(activity.category) : null;
+        summaryMap.set(summaryKey, {
+            key: summaryKey,
+            label: badgeData?.label || 'Uncategorized',
+            duration: activity.duration,
+            color: badgeData?.color || '#64748b',
+            isUncategorized: !activity.category
+        });
+    }
+
+    return Array.from(summaryMap.values()).sort((left, right) => right.duration - left.duration);
+}
+
+function getSummarySwatchStyle(summaryItem) {
+    if (summaryItem.isUncategorized) {
+        return 'background: repeating-linear-gradient(135deg, #64748b 0, #64748b 6px, #334155 6px, #334155 12px); border: 1px solid rgba(148, 163, 184, 0.35);';
+    }
+
+    return `background-color: ${summaryItem.color};`;
+}
+
+function getSummarySegmentStyle(summaryItem, totalDuration) {
+    const widthPercentage = totalDuration > 0 ? (summaryItem.duration / totalDuration) * 100 : 0;
+
+    if (summaryItem.isUncategorized) {
+        return `width: ${widthPercentage}%; background: repeating-linear-gradient(135deg, #64748b 0, #64748b 6px, #334155 6px, #334155 12px);`;
+    }
+
+    return `width: ${widthPercentage}%; background-color: ${summaryItem.color};`;
+}
+
+function renderActivitySummary(activities) {
+    const summaryItems = summarizeActivitiesByCategory(activities);
+    const totalDuration = summaryItems.reduce((sum, item) => sum + item.duration, 0);
+
+    if (summaryItems.length === 0 || totalDuration <= 0) {
+        return '';
+    }
+
+    const segmentsHtml = summaryItems
+        .map(
+            (item) =>
+                `<div data-summary-segment="${escapeHtml(item.key)}" class="h-full" style="${getSummarySegmentStyle(item, totalDuration)}"></div>`
+        )
+        .join('');
+
+    const legendHtml = summaryItems
+        .map(
+            (item) =>
+                `<span class="inline-flex items-center gap-2">
+                    <span data-summary-legend-swatch="${escapeHtml(item.key)}" class="h-2 w-2 rounded-full shrink-0" style="${getSummarySwatchStyle(item)}"></span>
+                    ${escapeHtml(item.label)} ${escapeHtml(calculateHoursAndMinutes(item.duration))}
+                </span>`
+        )
+        .join('');
+
+    return `<div data-activity-summary class="px-3 py-3 rounded-lg bg-slate-800/50 border border-slate-700/50">
+        <div class="flex items-end justify-between gap-3 mb-3">
+            <div class="text-[11px] uppercase tracking-[0.22em] text-sky-300">Category Breakdown</div>
+            <div class="text-xs text-slate-300">Total <span class="font-medium text-slate-100">${escapeHtml(calculateHoursAndMinutes(totalDuration))}</span></div>
+        </div>
+        <div class="flex h-3 overflow-hidden rounded-full border border-slate-700 bg-slate-950/90">
+            ${segmentsHtml}
+        </div>
+        <div class="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 text-xs text-slate-300 sm:grid-cols-2">
+            ${legendHtml}
+        </div>
+    </div>`;
 }
 
 function renderInlineEditActivityItem(activity) {
@@ -150,11 +233,13 @@ export function renderActivities(activities, container, options = {}) {
     }
 
     const editingActivityId = options.editingActivityId || null;
-    targetContainer.innerHTML = activities
+    const summaryHtml = renderActivitySummary(activities);
+    const activitiesHtml = activities
         .map((activity) =>
             activity.id === editingActivityId
                 ? renderInlineEditActivityItem(activity)
                 : renderActivityItem(activity)
         )
         .join('');
+    targetContainer.innerHTML = `${summaryHtml}${activitiesHtml}`;
 }

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -157,6 +157,35 @@ function getParentSummaryInteractionClasses(summaryItem) {
     };
 }
 
+function renderParentSummarySegment(summaryItem, totalDuration) {
+    const interactionClasses = getParentSummaryInteractionClasses(summaryItem);
+    const commonAttributes = `data-summary-segment="${escapeHtml(summaryItem.key)}" data-summary-parent-segment="${escapeHtml(summaryItem.key)}" data-summary-parent-key="${escapeHtml(summaryItem.key)}"`;
+    const commonStyle = getSummarySegmentStyle(summaryItem, totalDuration);
+
+    if (summaryItem.isUncategorized) {
+        return `<div ${commonAttributes} class="h-full ${interactionClasses.segment}" style="${commonStyle}"></div>`;
+    }
+
+    return `<button type="button" ${commonAttributes} class="block h-full appearance-none border-0 bg-transparent p-0 ${interactionClasses.segment}" style="${commonStyle}"></button>`;
+}
+
+function renderParentSummaryLegendItem(summaryItem) {
+    const interactionClasses = getParentSummaryInteractionClasses(summaryItem);
+    const commonAttributes = `data-summary-parent-legend="${escapeHtml(summaryItem.key)}" data-summary-parent-key="${escapeHtml(summaryItem.key)}"`;
+    const content = `<span data-summary-legend-swatch="${escapeHtml(summaryItem.key)}" class="h-2 w-2 rounded-full shrink-0" style="${getSummarySwatchStyle(summaryItem)}"></span>
+                    ${escapeHtml(summaryItem.label)} ${escapeHtml(calculateHoursAndMinutes(summaryItem.duration))}`;
+
+    if (summaryItem.isUncategorized) {
+        return `<span ${commonAttributes} class="inline-flex items-center gap-2 ${interactionClasses.legend}">
+                    ${content}
+                </span>`;
+    }
+
+    return `<button type="button" ${commonAttributes} class="inline-flex items-center gap-2 appearance-none border-0 bg-transparent p-0 text-left ${interactionClasses.legend}">
+                    ${content}
+                </button>`;
+}
+
 function summarizeExpandedChildCategories(activities, expandedParentGroupKey) {
     if (!expandedParentGroupKey || expandedParentGroupKey === 'uncategorized') {
         return [];
@@ -281,21 +310,10 @@ function renderActivitySummary(activities, options = {}) {
     }
 
     const segmentsHtml = summaryItems
-        .map((item) => {
-            const interactionClasses = getParentSummaryInteractionClasses(item);
-            return `<div data-summary-segment="${escapeHtml(item.key)}" data-summary-parent-segment="${escapeHtml(item.key)}" data-summary-parent-key="${escapeHtml(item.key)}" class="h-full ${interactionClasses.segment}" style="${getSummarySegmentStyle(item, totalDuration)}"></div>`;
-        })
+        .map((item) => renderParentSummarySegment(item, totalDuration))
         .join('');
 
-    const legendHtml = summaryItems
-        .map((item) => {
-            const interactionClasses = getParentSummaryInteractionClasses(item);
-            return `<span data-summary-parent-legend="${escapeHtml(item.key)}" data-summary-parent-key="${escapeHtml(item.key)}" class="inline-flex items-center gap-2 ${interactionClasses.legend}">
-                    <span data-summary-legend-swatch="${escapeHtml(item.key)}" class="h-2 w-2 rounded-full shrink-0" style="${getSummarySwatchStyle(item)}"></span>
-                    ${escapeHtml(item.label)} ${escapeHtml(calculateHoursAndMinutes(item.duration))}
-                </span>`;
-        })
-        .join('');
+    const legendHtml = summaryItems.map((item) => renderParentSummaryLegendItem(item)).join('');
     const expandedRailHtml = renderExpandedChildRail(activities, options.expandedParentGroupKey);
 
     return `<div data-activity-summary class="px-3 py-3 rounded-lg bg-slate-800/50 border border-slate-700/50">

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -142,7 +142,7 @@ export function renderActivities(activities, container, options = {}) {
 
     if (!activities || activities.length === 0) {
         targetContainer.innerHTML = `
-            <div class="text-center py-6 text-slate-500 text-sm">
+            <div class="py-6 text-slate-500 text-sm italic px-2">
                 <i class="fa-regular fa-clock mr-1"></i>
                 No activities tracked today. Log one or complete a scheduled task.
             </div>`;

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -3,7 +3,8 @@ import {
     getSelectableCategoryOptions,
     resolveCategoryKey,
     getGroupByKey,
-    getCategoryByKey
+    getCategoryByKey,
+    getTaxonomySnapshot
 } from '../taxonomy/taxonomy-selectors.js';
 import {
     calculateHoursAndMinutes,
@@ -195,6 +196,9 @@ function summarizeExpandedChildCategories(activities, expandedParentGroupKey) {
     if (!parentGroup) {
         return [];
     }
+    const parentHasChildren = getTaxonomySnapshot().categories.some(
+        (category) => category.groupKey === expandedParentGroupKey
+    );
 
     const summaryMap = new Map();
 
@@ -222,7 +226,7 @@ function summarizeExpandedChildCategories(activities, expandedParentGroupKey) {
 
             summaryMap.set(syntheticKey, {
                 key: syntheticKey,
-                label: `Unspecified ${parentGroup.label}`,
+                label: parentHasChildren ? 'Unspecified' : parentGroup.label,
                 color: parentGroup.color,
                 duration: activity.duration
             });

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -9,6 +9,7 @@ import {
     convertTo12HourTime,
     extractDateFromDateTime
 } from '../utils.js';
+import { computeEndTimePreview } from '../tasks/form-utils.js';
 
 function escapeHtml(value) {
     return String(value)
@@ -126,6 +127,11 @@ function renderInlineEditActivityItem(activity) {
     const durationMinutes = activity.duration % 60;
     const displayStartTime = extractTimeFromDateTime(new Date(activity.startDateTime));
     const activityDate = extractDateFromDateTime(new Date(activity.startDateTime));
+    const endTimeHint = computeEndTimePreview(
+        displayStartTime,
+        durationHours.toString(),
+        durationMinutes.toString()
+    );
     const isAuto = activity.source === 'auto';
     const provenanceHtml = isAuto
         ? `<div class="flex items-center gap-2 text-xs text-sky-400/70">
@@ -150,13 +156,14 @@ function renderInlineEditActivityItem(activity) {
                 </select>
             </div>
         </div>
-        <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+        <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:pb-5">
             <div class="relative sm:w-40">
                 <i class="fa-regular fa-clock absolute left-3 top-1/2 -translate-y-1/2 text-sky-400"></i>
                 <input type="time" name="start-time" value="${escapeHtml(displayStartTime)}"
                     class="bg-slate-700 pl-10 pr-3 py-2 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100" required>
             </div>
-            <div class="flex items-center gap-2 sm:w-44">
+            <div class="relative pb-5 sm:pb-0 sm:w-44">
+                <div class="flex items-center gap-2">
                 <div class="relative flex-1">
                     <i class="fa-regular fa-hourglass absolute left-3 top-1/2 -translate-y-1/2 text-sky-400"></i>
                     <input type="number" name="duration-hours" value="${durationHours}" min="0" placeholder="HH"
@@ -167,12 +174,14 @@ function renderInlineEditActivityItem(activity) {
                     <input type="number" name="duration-minutes" value="${durationMinutes.toString().padStart(2, '0')}" min="0" max="59" placeholder="MM"
                         class="bg-slate-700 px-3 py-2 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
                 </div>
+                <span class="edit-end-time-hint absolute top-full mt-1 right-0 text-xs text-sky-400/70 transition-opacity duration-300 whitespace-nowrap pointer-events-none ${endTimeHint ? '' : 'opacity-0'}">${endTimeHint ? `&#9656; ${escapeHtml(endTimeHint)}` : ''}</span>
+                </div>
             </div>
             <div class="flex items-center gap-2 sm:ml-auto">
                 <button type="button" class="btn-cancel-activity-edit px-4 py-2 rounded-lg font-medium transition-all duration-300 shadow flex items-center bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100">
                     <i class="fa-solid fa-xmark mr-2"></i>Cancel
                 </button>
-                <button type="button" class="btn-save-activity-edit px-4 py-2 rounded-lg font-medium transition-all duration-300 shadow flex items-center bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 text-white">
+                <button type="submit" class="btn-save-activity-edit px-4 py-2 rounded-lg font-medium transition-all duration-300 shadow flex items-center bg-gradient-to-r from-sky-500 to-sky-400 hover:from-sky-400 hover:to-sky-300 text-white">
                     <i class="fa-solid fa-check mr-2"></i>Save
                 </button>
             </div>

--- a/public/js/activities/running-activity-repository.js
+++ b/public/js/activities/running-activity-repository.js
@@ -10,7 +10,9 @@ function normalizeRunningActivityConfig(config) {
     return {
         description: config.description,
         category: config.category || null,
-        startDateTime: config.startDateTime
+        startDateTime: config.startDateTime,
+        source: config.source || 'timer',
+        sourceTaskId: config.sourceTaskId || null
     };
 }
 
@@ -24,7 +26,9 @@ export async function saveRunningActivityConfig(runningActivity) {
         id: RUNNING_ACTIVITY_CONFIG_ID,
         description: runningActivity.description,
         category: runningActivity.category || null,
-        startDateTime: runningActivity.startDateTime
+        startDateTime: runningActivity.startDateTime,
+        source: runningActivity.source || 'timer',
+        sourceTaskId: runningActivity.sourceTaskId || null
     });
 }
 

--- a/public/js/activities/running-activity-repository.js
+++ b/public/js/activities/running-activity-repository.js
@@ -1,0 +1,33 @@
+import { putConfig, loadConfig, deleteConfig } from '../storage.js';
+
+export const RUNNING_ACTIVITY_CONFIG_ID = 'config-running-activity';
+
+function normalizeRunningActivityConfig(config) {
+    if (!config) {
+        return null;
+    }
+
+    return {
+        description: config.description,
+        category: config.category || null,
+        startDateTime: config.startDateTime
+    };
+}
+
+export async function loadRunningActivityConfig() {
+    const config = await loadConfig(RUNNING_ACTIVITY_CONFIG_ID);
+    return normalizeRunningActivityConfig(config);
+}
+
+export async function saveRunningActivityConfig(runningActivity) {
+    await putConfig({
+        id: RUNNING_ACTIVITY_CONFIG_ID,
+        description: runningActivity.description,
+        category: runningActivity.category || null,
+        startDateTime: runningActivity.startDateTime
+    });
+}
+
+export async function deleteRunningActivityConfig() {
+    await deleteConfig(RUNNING_ACTIVITY_CONFIG_ID);
+}

--- a/public/js/activities/summary.js
+++ b/public/js/activities/summary.js
@@ -1,0 +1,187 @@
+import {
+    resolveCategoryKey,
+    getGroupByKey,
+    getCategoryByKey,
+    getTaxonomySnapshot
+} from '../taxonomy/taxonomy-selectors.js';
+
+function titleCaseKey(value) {
+    return String(value)
+        .split(/[-_/]+/)
+        .filter(Boolean)
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join(' ');
+}
+
+function buildFallbackParentMetadata(parentKey) {
+    return {
+        key: parentKey,
+        label: titleCaseKey(parentKey),
+        color: '#64748b',
+        isUncategorized: false
+    };
+}
+
+function buildResolvedParentMetadata(parentKey) {
+    const parentGroup = getGroupByKey(parentKey);
+    if (parentGroup) {
+        return {
+            key: parentGroup.key,
+            label: parentGroup.label,
+            color: parentGroup.color,
+            isUncategorized: false
+        };
+    }
+
+    return buildFallbackParentMetadata(parentKey);
+}
+
+function getParentSummaryMetadata(activity) {
+    if (!activity.category) {
+        return {
+            key: 'uncategorized',
+            label: 'Uncategorized',
+            color: '#64748b',
+            isUncategorized: true
+        };
+    }
+
+    const resolvedCategory = resolveCategoryKey(activity.category);
+    if (!resolvedCategory) {
+        const inferredParentKey = activity.category.split('/')[0] || activity.category;
+        return buildResolvedParentMetadata(inferredParentKey);
+    }
+
+    if (resolvedCategory.kind === 'group') {
+        return buildResolvedParentMetadata(resolvedCategory.record.key);
+    }
+
+    return buildResolvedParentMetadata(resolvedCategory.record.groupKey);
+}
+
+export function summarizeActivitiesByParentGroup(activities) {
+    const summaryMap = new Map();
+
+    for (const activity of activities) {
+        const summaryItem = getParentSummaryMetadata(activity);
+        const existing = summaryMap.get(summaryItem.key);
+
+        if (existing) {
+            existing.duration += activity.duration;
+            existing.count += 1;
+            continue;
+        }
+
+        summaryMap.set(summaryItem.key, {
+            ...summaryItem,
+            duration: activity.duration,
+            count: 1,
+            isUncategorized: Boolean(summaryItem.isUncategorized)
+        });
+    }
+
+    return Array.from(summaryMap.values()).sort((left, right) => {
+        if (right.duration !== left.duration) {
+            return right.duration - left.duration;
+        }
+
+        return left.label.localeCompare(right.label) || left.key.localeCompare(right.key);
+    });
+}
+
+export function summarizeExpandedChildCategories(activities, expandedParentGroupKey) {
+    if (!expandedParentGroupKey || expandedParentGroupKey === 'uncategorized') {
+        return null;
+    }
+
+    const parentGroup = getGroupByKey(expandedParentGroupKey);
+    if (!parentGroup) {
+        return null;
+    }
+
+    const parentHasChildren = getTaxonomySnapshot().categories.some(
+        (category) => category.groupKey === expandedParentGroupKey
+    );
+    const summaryMap = new Map();
+
+    for (const activity of activities) {
+        if (!activity.category) {
+            continue;
+        }
+
+        const resolvedCategory = resolveCategoryKey(activity.category);
+        if (!resolvedCategory) {
+            continue;
+        }
+
+        if (resolvedCategory.kind === 'group') {
+            if (resolvedCategory.record.key !== expandedParentGroupKey) {
+                continue;
+            }
+
+            const syntheticKey = `${expandedParentGroupKey}::__unspecified`;
+            const existing = summaryMap.get(syntheticKey);
+            if (existing) {
+                existing.duration += activity.duration;
+                continue;
+            }
+
+            summaryMap.set(syntheticKey, {
+                key: syntheticKey,
+                label: parentHasChildren ? 'Unspecified' : parentGroup.label,
+                color: parentGroup.color,
+                duration: activity.duration
+            });
+            continue;
+        }
+
+        const childCategory = getCategoryByKey(resolvedCategory.record.key);
+        if (!childCategory || childCategory.groupKey !== expandedParentGroupKey) {
+            continue;
+        }
+
+        const existing = summaryMap.get(childCategory.key);
+        if (existing) {
+            existing.duration += activity.duration;
+            continue;
+        }
+
+        summaryMap.set(childCategory.key, {
+            key: childCategory.key,
+            label: childCategory.label,
+            color: childCategory.color,
+            duration: activity.duration
+        });
+    }
+
+    const items = Array.from(summaryMap.values())
+        .filter((item) => item.duration > 0)
+        .sort((left, right) => {
+            if (right.duration !== left.duration) {
+                return right.duration - left.duration;
+            }
+
+            return left.label.localeCompare(right.label) || left.key.localeCompare(right.key);
+        });
+
+    if (items.length === 0) {
+        return null;
+    }
+
+    return {
+        key: expandedParentGroupKey,
+        label: parentGroup.label,
+        items,
+        totalDuration: items.reduce((sum, item) => sum + item.duration, 0)
+    };
+}
+
+export function buildActivitySummaryModel(activities, expandedParentGroupKey = null) {
+    const summaryItems = summarizeActivitiesByParentGroup(activities);
+    return {
+        summaryItems,
+        totalDuration: summaryItems.reduce((sum, item) => sum + item.duration, 0),
+        totalCount: summaryItems.reduce((sum, item) => sum + item.count, 0),
+        expandedGroup: summarizeExpandedChildCategories(activities, expandedParentGroupKey)
+    };
+}

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -2,21 +2,23 @@ import { showAlert } from '../modal-manager.js';
 import { getRunningActivity, updateRunningActivity } from './manager.js';
 import { handleStartTimer, handleStopTimer } from './handlers.js';
 
-let timerIntervalId = null;
-let timerUiAbortController = null;
-let pendingTimerMutation = null;
-let suppressTimerFieldPersistence = false;
-let refreshActivitySummaryCallback = null;
-let lastSummaryElapsedMinutes = null;
-let nextActivityDraft = {
-    description: '',
-    category: ''
+const timerUiState = {
+    intervalId: null,
+    abortController: null,
+    pendingMutation: null,
+    suppressFieldPersistence: false,
+    refreshActivitySummary: null,
+    lastSummaryElapsedMinutes: null,
+    nextActivityDraft: {
+        description: '',
+        category: ''
+    }
 };
 
 function shouldSuppressTimerFieldPersistence() {
     const startTimerButton = document.getElementById('start-timer-btn');
     return (
-        suppressTimerFieldPersistence ||
+        timerUiState.suppressFieldPersistence ||
         (!!getRunningActivity() && document.activeElement === startTimerButton)
     );
 }
@@ -42,39 +44,39 @@ function setStartTimerButtonLabel() {
 }
 
 function refreshActivitySummary() {
-    if (typeof refreshActivitySummaryCallback === 'function') {
-        refreshActivitySummaryCallback();
+    if (typeof timerUiState.refreshActivitySummary === 'function') {
+        timerUiState.refreshActivitySummary();
     }
 }
 
 function stopElapsedCounter() {
-    if (timerIntervalId) {
-        clearInterval(timerIntervalId);
-        timerIntervalId = null;
+    if (timerUiState.intervalId) {
+        clearInterval(timerUiState.intervalId);
+        timerUiState.intervalId = null;
     }
-    lastSummaryElapsedMinutes = null;
+    timerUiState.lastSummaryElapsedMinutes = null;
 }
 
 function queueTimerMutation(mutation) {
-    const operation = pendingTimerMutation
-        ? pendingTimerMutation.catch(() => {}).then(() => mutation())
+    const operation = timerUiState.pendingMutation
+        ? timerUiState.pendingMutation.catch(() => {}).then(() => mutation())
         : Promise.resolve(mutation());
     const trackedOperation = operation.catch(() => {});
-    pendingTimerMutation = trackedOperation;
+    timerUiState.pendingMutation = trackedOperation;
     trackedOperation.finally(() => {
-        if (pendingTimerMutation === trackedOperation) {
-            pendingTimerMutation = null;
+        if (timerUiState.pendingMutation === trackedOperation) {
+            timerUiState.pendingMutation = null;
         }
     });
     return operation;
 }
 
 async function waitForPendingTimerMutation() {
-    if (!pendingTimerMutation) {
+    if (!timerUiState.pendingMutation) {
         return;
     }
 
-    await pendingTimerMutation;
+    await timerUiState.pendingMutation;
 }
 
 function formatElapsed(elapsedMs) {
@@ -101,25 +103,25 @@ function startElapsedCounter(startDateTime) {
         elapsedElement.textContent = formatElapsed(elapsedMs);
 
         const elapsedMinutes = Math.max(0, Math.round(elapsedMs / 60000));
-        if (lastSummaryElapsedMinutes === null) {
-            lastSummaryElapsedMinutes = elapsedMinutes;
+        if (timerUiState.lastSummaryElapsedMinutes === null) {
+            timerUiState.lastSummaryElapsedMinutes = elapsedMinutes;
             return;
         }
 
         if (
-            elapsedMinutes !== lastSummaryElapsedMinutes &&
-            typeof refreshActivitySummaryCallback === 'function'
+            elapsedMinutes !== timerUiState.lastSummaryElapsedMinutes &&
+            typeof timerUiState.refreshActivitySummary === 'function'
         ) {
-            lastSummaryElapsedMinutes = elapsedMinutes;
+            timerUiState.lastSummaryElapsedMinutes = elapsedMinutes;
             refreshActivitySummary();
             return;
         }
 
-        lastSummaryElapsedMinutes = elapsedMinutes;
+        timerUiState.lastSummaryElapsedMinutes = elapsedMinutes;
     };
 
     updateElapsed();
-    timerIntervalId = setInterval(updateElapsed, 1000);
+    timerUiState.intervalId = setInterval(updateElapsed, 1000);
 }
 
 function syncNextCategoryOptions() {
@@ -133,20 +135,20 @@ function syncNextCategoryOptions() {
         nextCategorySelect.innerHTML = mainCategorySelect.innerHTML;
     }
 
-    nextCategorySelect.value = nextActivityDraft.category || '';
+    nextCategorySelect.value = timerUiState.nextActivityDraft.category || '';
 }
 
 function syncNextActivityDraftFields() {
     const nextDescriptionInput = document.getElementById('next-activity-description');
     if (nextDescriptionInput instanceof HTMLInputElement) {
-        nextDescriptionInput.value = nextActivityDraft.description;
+        nextDescriptionInput.value = timerUiState.nextActivityDraft.description;
     }
 
     syncNextCategoryOptions();
 }
 
 function clearNextActivityDraft() {
-    nextActivityDraft = {
+    timerUiState.nextActivityDraft = {
         description: '',
         category: ''
     };
@@ -211,16 +213,16 @@ export function hideTimerDisplay() {
 }
 
 export function disposeTimerUI() {
-    if (timerUiAbortController) {
-        timerUiAbortController.abort();
-        timerUiAbortController = null;
+    if (timerUiState.abortController) {
+        timerUiState.abortController.abort();
+        timerUiState.abortController = null;
     }
 
     stopElapsedCounter();
-    pendingTimerMutation = null;
-    suppressTimerFieldPersistence = false;
-    refreshActivitySummaryCallback = null;
-    nextActivityDraft = {
+    timerUiState.pendingMutation = null;
+    timerUiState.suppressFieldPersistence = false;
+    timerUiState.refreshActivitySummary = null;
+    timerUiState.nextActivityDraft = {
         description: '',
         category: ''
     };
@@ -248,9 +250,9 @@ export function syncTimerFormState() {
 
 export function initializeTimerUI(deps) {
     disposeTimerUI();
-    timerUiAbortController = new AbortController();
-    const { signal } = timerUiAbortController;
-    refreshActivitySummaryCallback =
+    timerUiState.abortController = new AbortController();
+    const { signal } = timerUiState.abortController;
+    timerUiState.refreshActivitySummary =
         typeof deps.refreshActivitySummary === 'function' ? deps.refreshActivitySummary : null;
 
     const radios = document.querySelectorAll('input[name="task-type"]');
@@ -269,7 +271,7 @@ export function initializeTimerUI(deps) {
         startTimerButton.addEventListener(
             'mousedown',
             () => {
-                suppressTimerFieldPersistence = !!getRunningActivity();
+                timerUiState.suppressFieldPersistence = !!getRunningActivity();
             },
             { signal }
         );
@@ -331,7 +333,7 @@ export function initializeTimerUI(deps) {
                         syncTimerFormState();
                         deps.refreshUI();
                     } finally {
-                        suppressTimerFieldPersistence = false;
+                        timerUiState.suppressFieldPersistence = false;
                     }
                 })();
             },
@@ -365,7 +367,7 @@ export function initializeTimerUI(deps) {
         nextDescriptionInput.addEventListener(
             'input',
             () => {
-                nextActivityDraft.description = nextDescriptionInput.value;
+                timerUiState.nextActivityDraft.description = nextDescriptionInput.value;
             },
             { signal }
         );
@@ -376,7 +378,7 @@ export function initializeTimerUI(deps) {
         nextCategorySelect.addEventListener(
             'change',
             () => {
-                nextActivityDraft.category = nextCategorySelect.value || '';
+                timerUiState.nextActivityDraft.category = nextCategorySelect.value || '';
             },
             { signal }
         );
@@ -387,7 +389,7 @@ export function initializeTimerUI(deps) {
         timerDescriptionInput.addEventListener(
             'focusout',
             (event) => {
-                suppressTimerFieldPersistence =
+                timerUiState.suppressFieldPersistence =
                     !!getRunningActivity() &&
                     event.relatedTarget === document.getElementById('start-timer-btn');
             },
@@ -425,7 +427,7 @@ export function initializeTimerUI(deps) {
         timerCategorySelect.addEventListener(
             'focusout',
             (event) => {
-                suppressTimerFieldPersistence =
+                timerUiState.suppressFieldPersistence =
                     !!getRunningActivity() &&
                     event.relatedTarget === document.getElementById('start-timer-btn');
             },
@@ -462,7 +464,7 @@ export function initializeTimerUI(deps) {
         timerStartTimeInput.addEventListener(
             'focusout',
             (event) => {
-                suppressTimerFieldPersistence =
+                timerUiState.suppressFieldPersistence =
                     !!getRunningActivity() &&
                     event.relatedTarget === document.getElementById('start-timer-btn');
             },

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -1,4 +1,5 @@
 import { showAlert } from '../modal-manager.js';
+import { logger } from '../utils.js';
 import { getRunningActivity, updateRunningActivity } from './manager.js';
 import { handleStartTimer, handleStopTimer } from './handlers.js';
 
@@ -14,6 +15,14 @@ const timerUiState = {
         category: ''
     }
 };
+
+function logTimerDebug(event, details = {}) {
+    logger.info(`timer-debug:${event}`, {
+        deviceNowIso: new Date().toISOString(),
+        timezoneOffsetMinutes: new Date().getTimezoneOffset(),
+        ...details
+    });
+}
 
 function shouldSuppressTimerFieldPersistence() {
     const startTimerButton = document.getElementById('start-timer-btn');
@@ -100,7 +109,14 @@ function startElapsedCounter(startDateTime) {
 
     const updateElapsed = () => {
         const elapsedMs = Date.now() - startMs;
-        elapsedElement.textContent = formatElapsed(elapsedMs);
+        const displayedElapsed = formatElapsed(elapsedMs);
+        elapsedElement.textContent = displayedElapsed;
+        logTimerDebug('tick', {
+            startDateTime,
+            startMs,
+            elapsedMs,
+            displayedElapsed
+        });
 
         const elapsedMinutes = Math.max(0, Math.round(elapsedMs / 60000));
         if (timerUiState.lastSummaryElapsedMinutes === null) {
@@ -198,6 +214,13 @@ export function showTimerDisplay(runningActivity) {
         timerCategorySelect.value = runningActivity.category || '';
     }
 
+    logTimerDebug('show-display', {
+        startDateTime: runningActivity.startDateTime,
+        source: runningActivity.source || 'timer',
+        sourceTaskId: runningActivity.sourceTaskId || null,
+        description: runningActivity.description,
+        category: runningActivity.category || null
+    });
     syncNextActivityDraftFields();
     startElapsedCounter(runningActivity.startDateTime);
 }
@@ -219,6 +242,10 @@ export function hideTimerDisplay() {
     if (formFields) {
         formFields.classList.remove('hidden');
     }
+
+    logTimerDebug('hide-display', {
+        hasRunningActivity: !!getRunningActivity()
+    });
 }
 
 export function disposeTimerUI() {

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -3,7 +3,7 @@ import { getRunningActivity, updateRunningActivity } from './manager.js';
 import { handleStartTimer, handleStopTimer } from './handlers.js';
 
 const timerUiState = {
-    intervalId: null,
+    tickTimeoutId: null,
     abortController: null,
     pendingMutation: null,
     suppressFieldPersistence: false,
@@ -50,9 +50,9 @@ function refreshActivitySummary() {
 }
 
 function stopElapsedCounter() {
-    if (timerUiState.intervalId) {
-        clearInterval(timerUiState.intervalId);
-        timerUiState.intervalId = null;
+    if (timerUiState.tickTimeoutId) {
+        clearTimeout(timerUiState.tickTimeoutId);
+        timerUiState.tickTimeoutId = null;
     }
     timerUiState.lastSummaryElapsedMinutes = null;
 }
@@ -120,8 +120,17 @@ function startElapsedCounter(startDateTime) {
         timerUiState.lastSummaryElapsedMinutes = elapsedMinutes;
     };
 
+    const scheduleNextUpdate = () => {
+        const elapsedMs = Math.max(0, Date.now() - startMs);
+        const nextDelay = Math.max(1, 1000 - (elapsedMs % 1000));
+        timerUiState.tickTimeoutId = setTimeout(() => {
+            updateElapsed();
+            scheduleNextUpdate();
+        }, nextDelay);
+    };
+
     updateElapsed();
-    timerUiState.intervalId = setInterval(updateElapsed, 1000);
+    scheduleNextUpdate();
 }
 
 function syncNextCategoryOptions() {

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -16,14 +16,6 @@ const timerUiState = {
     }
 };
 
-function logTimerDebug(event, details = {}) {
-    logger.info(`timer-debug:${event}`, {
-        deviceNowIso: new Date().toISOString(),
-        timezoneOffsetMinutes: new Date().getTimezoneOffset(),
-        ...details
-    });
-}
-
 function shouldSuppressTimerFieldPersistence() {
     const startTimerButton = document.getElementById('start-timer-btn');
     return (
@@ -98,6 +90,42 @@ function formatElapsed(elapsedMs) {
     ).padStart(2, '0')}`;
 }
 
+function getTimerDebugSnapshot() {
+    const runningActivity = getRunningActivity();
+    const elapsedElement = document.getElementById('timer-elapsed');
+    const timerDisplay = document.getElementById('timer-display');
+    const now = new Date();
+    const startMs = runningActivity?.startDateTime
+        ? new Date(runningActivity.startDateTime).getTime()
+        : null;
+    const elapsedMs =
+        runningActivity && typeof startMs === 'number' && !Number.isNaN(startMs)
+            ? Math.max(0, now.getTime() - startMs)
+            : null;
+
+    return {
+        deviceNowIso: now.toISOString(),
+        timezoneOffsetMinutes: now.getTimezoneOffset(),
+        runningActivity,
+        elapsedMs,
+        displayedElapsed: elapsedElement?.textContent || null,
+        isTimerVisible:
+            !!timerDisplay && !timerDisplay.classList.contains('hidden') && runningActivity !== null
+    };
+}
+
+function registerTimerDebugHelper() {
+    window.dumpTimerDebug = () => {
+        const snapshot = getTimerDebugSnapshot();
+        logger.info('timer-debug:snapshot', snapshot);
+        return snapshot;
+    };
+}
+
+function unregisterTimerDebugHelper() {
+    delete window.dumpTimerDebug;
+}
+
 function startElapsedCounter(startDateTime) {
     stopElapsedCounter();
 
@@ -109,14 +137,7 @@ function startElapsedCounter(startDateTime) {
 
     const updateElapsed = () => {
         const elapsedMs = Date.now() - startMs;
-        const displayedElapsed = formatElapsed(elapsedMs);
-        elapsedElement.textContent = displayedElapsed;
-        logTimerDebug('tick', {
-            startDateTime,
-            startMs,
-            elapsedMs,
-            displayedElapsed
-        });
+        elapsedElement.textContent = formatElapsed(elapsedMs);
 
         const elapsedMinutes = Math.max(0, Math.round(elapsedMs / 60000));
         if (timerUiState.lastSummaryElapsedMinutes === null) {
@@ -214,13 +235,6 @@ export function showTimerDisplay(runningActivity) {
         timerCategorySelect.value = runningActivity.category || '';
     }
 
-    logTimerDebug('show-display', {
-        startDateTime: runningActivity.startDateTime,
-        source: runningActivity.source || 'timer',
-        sourceTaskId: runningActivity.sourceTaskId || null,
-        description: runningActivity.description,
-        category: runningActivity.category || null
-    });
     syncNextActivityDraftFields();
     startElapsedCounter(runningActivity.startDateTime);
 }
@@ -242,13 +256,10 @@ export function hideTimerDisplay() {
     if (formFields) {
         formFields.classList.remove('hidden');
     }
-
-    logTimerDebug('hide-display', {
-        hasRunningActivity: !!getRunningActivity()
-    });
 }
 
 export function disposeTimerUI() {
+    unregisterTimerDebugHelper();
     if (timerUiState.abortController) {
         timerUiState.abortController.abort();
         timerUiState.abortController = null;
@@ -286,6 +297,7 @@ export function syncTimerFormState() {
 
 export function initializeTimerUI(deps) {
     disposeTimerUI();
+    registerTimerDebugHelper();
     timerUiState.abortController = new AbortController();
     const { signal } = timerUiState.abortController;
     timerUiState.refreshActivitySummary =

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -114,9 +114,68 @@ function getTimerDebugSnapshot() {
     };
 }
 
+async function getTimerDebugSnapshotWithServerEstimate() {
+    const snapshot = getTimerDebugSnapshot();
+    const canEstimateServerTime =
+        typeof fetch === 'function' &&
+        snapshot.runningActivity?.startDateTime &&
+        typeof snapshot.elapsedMs === 'number';
+
+    if (!canEstimateServerTime) {
+        return {
+            ...snapshot,
+            serverDateHeader: null,
+            serverRoundTripMs: null,
+            estimatedServerOffsetMs: null,
+            correctedElapsedMs: snapshot.elapsedMs,
+            correctedDisplayedElapsed:
+                typeof snapshot.elapsedMs === 'number' ? formatElapsed(snapshot.elapsedMs) : null
+        };
+    }
+
+    const requestStartedAtMs = Date.now();
+    const response = await fetch(window.location.href, {
+        method: 'HEAD',
+        cache: 'no-store'
+    });
+    const requestCompletedAtMs = Date.now();
+    const serverDateHeader = response?.headers?.get('Date') || null;
+    const serverDateMs = serverDateHeader ? new Date(serverDateHeader).getTime() : null;
+
+    if (typeof serverDateMs !== 'number' || Number.isNaN(serverDateMs)) {
+        return {
+            ...snapshot,
+            serverDateHeader,
+            serverRoundTripMs: requestCompletedAtMs - requestStartedAtMs,
+            estimatedServerOffsetMs: null,
+            correctedElapsedMs: snapshot.elapsedMs,
+            correctedDisplayedElapsed:
+                typeof snapshot.elapsedMs === 'number' ? formatElapsed(snapshot.elapsedMs) : null
+        };
+    }
+
+    const localMidpointMs = requestStartedAtMs + (requestCompletedAtMs - requestStartedAtMs) / 2;
+    const estimatedServerOffsetMs = serverDateMs - localMidpointMs;
+    const correctedElapsedMs = Math.max(
+        0,
+        new Date(snapshot.deviceNowIso).getTime() +
+            estimatedServerOffsetMs -
+            new Date(snapshot.runningActivity.startDateTime).getTime()
+    );
+
+    return {
+        ...snapshot,
+        serverDateHeader,
+        serverRoundTripMs: requestCompletedAtMs - requestStartedAtMs,
+        estimatedServerOffsetMs,
+        correctedElapsedMs,
+        correctedDisplayedElapsed: formatElapsed(correctedElapsedMs)
+    };
+}
+
 function registerTimerDebugHelper() {
-    window.dumpTimerDebug = () => {
-        const snapshot = getTimerDebugSnapshot();
+    window.dumpTimerDebug = async () => {
+        const snapshot = await getTimerDebugSnapshotWithServerEstimate();
         logger.info('timer-debug:snapshot', snapshot);
         return snapshot;
     };

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -6,6 +6,8 @@ let timerIntervalId = null;
 let timerUiAbortController = null;
 let pendingTimerMutation = null;
 let suppressTimerFieldPersistence = false;
+let refreshActivitySummaryCallback = null;
+let lastSummaryElapsedMinutes = null;
 let nextActivityDraft = {
     description: '',
     category: ''
@@ -39,11 +41,18 @@ function setStartTimerButtonLabel() {
     startTimerButton.innerHTML = '<i class="fa-solid fa-play mr-2"></i>Start Timer';
 }
 
+function refreshActivitySummary() {
+    if (typeof refreshActivitySummaryCallback === 'function') {
+        refreshActivitySummaryCallback();
+    }
+}
+
 function stopElapsedCounter() {
     if (timerIntervalId) {
         clearInterval(timerIntervalId);
         timerIntervalId = null;
     }
+    lastSummaryElapsedMinutes = null;
 }
 
 function queueTimerMutation(mutation) {
@@ -88,7 +97,25 @@ function startElapsedCounter(startDateTime) {
     }
 
     const updateElapsed = () => {
-        elapsedElement.textContent = formatElapsed(Date.now() - startMs);
+        const elapsedMs = Date.now() - startMs;
+        elapsedElement.textContent = formatElapsed(elapsedMs);
+
+        const elapsedMinutes = Math.max(0, Math.round(elapsedMs / 60000));
+        if (lastSummaryElapsedMinutes === null) {
+            lastSummaryElapsedMinutes = elapsedMinutes;
+            return;
+        }
+
+        if (
+            elapsedMinutes !== lastSummaryElapsedMinutes &&
+            typeof refreshActivitySummaryCallback === 'function'
+        ) {
+            lastSummaryElapsedMinutes = elapsedMinutes;
+            refreshActivitySummary();
+            return;
+        }
+
+        lastSummaryElapsedMinutes = elapsedMinutes;
     };
 
     updateElapsed();
@@ -192,6 +219,7 @@ export function disposeTimerUI() {
     stopElapsedCounter();
     pendingTimerMutation = null;
     suppressTimerFieldPersistence = false;
+    refreshActivitySummaryCallback = null;
     nextActivityDraft = {
         description: '',
         category: ''
@@ -222,6 +250,8 @@ export function initializeTimerUI(deps) {
     disposeTimerUI();
     timerUiAbortController = new AbortController();
     const { signal } = timerUiAbortController;
+    refreshActivitySummaryCallback =
+        typeof deps.refreshActivitySummary === 'function' ? deps.refreshActivitySummary : null;
 
     const radios = document.querySelectorAll('input[name="task-type"]');
     radios.forEach((radio) => {
@@ -376,6 +406,7 @@ export function initializeTimerUI(deps) {
                             if (result?.success && result.runningActivity) {
                                 timerDescriptionInput.value =
                                     result.runningActivity.description || '';
+                                refreshActivitySummary();
                                 return;
                             }
 
@@ -412,6 +443,7 @@ export function initializeTimerUI(deps) {
                         (result) => {
                             if (result?.success && result.runningActivity) {
                                 timerCategorySelect.value = result.runningActivity.category || '';
+                                refreshActivitySummary();
                                 return;
                             }
 
@@ -460,6 +492,7 @@ export function initializeTimerUI(deps) {
                         (result) => {
                             if (result?.success && result.runningActivity) {
                                 showTimerDisplay(result.runningActivity);
+                                refreshActivitySummary();
                                 return;
                             }
 

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -1,0 +1,282 @@
+import { showAlert } from '../modal-manager.js';
+import { getRunningActivity, updateRunningActivity } from './manager.js';
+import { handleStartTimer, handleStopTimer } from './handlers.js';
+
+let timerIntervalId = null;
+let timerUiAbortController = null;
+
+function stopElapsedCounter() {
+    if (timerIntervalId) {
+        clearInterval(timerIntervalId);
+        timerIntervalId = null;
+    }
+}
+
+function formatElapsed(elapsedMs) {
+    const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(
+        seconds
+    ).padStart(2, '0')}`;
+}
+
+function startElapsedCounter(startDateTime) {
+    stopElapsedCounter();
+
+    const startMs = new Date(startDateTime).getTime();
+    const elapsedElement = document.getElementById('timer-elapsed');
+    if (!elapsedElement || Number.isNaN(startMs)) {
+        return;
+    }
+
+    const updateElapsed = () => {
+        elapsedElement.textContent = formatElapsed(Date.now() - startMs);
+    };
+
+    updateElapsed();
+    timerIntervalId = setInterval(updateElapsed, 1000);
+}
+
+export function showTimerDisplay(runningActivity) {
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+    if (!formFields || !timerDisplay || !runningActivity) {
+        return;
+    }
+
+    formFields.classList.add('hidden');
+    timerDisplay.classList.remove('hidden');
+
+    const descriptionInput = document.getElementById('timer-description');
+    if (descriptionInput instanceof HTMLInputElement) {
+        descriptionInput.value = runningActivity.description || '';
+    }
+
+    const startTimeInput = document.getElementById('timer-start-time');
+    if (startTimeInput instanceof HTMLInputElement && runningActivity.startDateTime) {
+        const startDate = new Date(runningActivity.startDateTime);
+        startTimeInput.value = `${String(startDate.getHours()).padStart(2, '0')}:${String(
+            startDate.getMinutes()
+        ).padStart(2, '0')}`;
+    }
+
+    const timerCategorySelect = document.getElementById('timer-category');
+    if (timerCategorySelect instanceof HTMLSelectElement) {
+        const mainCategorySelect = document.querySelector('#task-form select[name="category"]');
+        if (mainCategorySelect instanceof HTMLSelectElement) {
+            timerCategorySelect.innerHTML = mainCategorySelect.innerHTML;
+        }
+        timerCategorySelect.value = runningActivity.category || '';
+    }
+
+    startElapsedCounter(runningActivity.startDateTime);
+}
+
+export function hideTimerDisplay() {
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+
+    stopElapsedCounter();
+
+    if (timerDisplay) {
+        timerDisplay.classList.add('hidden');
+    }
+    if (formFields) {
+        formFields.classList.remove('hidden');
+    }
+}
+
+export function disposeTimerUI() {
+    if (timerUiAbortController) {
+        timerUiAbortController.abort();
+        timerUiAbortController = null;
+    }
+
+    stopElapsedCounter();
+}
+
+export function syncTimerFormState() {
+    const activityRadio = document.getElementById('activity');
+    const isActivityMode = activityRadio instanceof HTMLInputElement && activityRadio.checked;
+    const runningActivity = getRunningActivity();
+    const startTimerButton = document.getElementById('start-timer-btn');
+
+    if (isActivityMode && runningActivity) {
+        showTimerDisplay(runningActivity);
+        if (startTimerButton) {
+            startTimerButton.classList.remove('hidden');
+        }
+        return;
+    }
+
+    hideTimerDisplay();
+    if (startTimerButton) {
+        startTimerButton.classList.toggle('hidden', !isActivityMode);
+    }
+}
+
+export function initializeTimerUI(deps) {
+    disposeTimerUI();
+    timerUiAbortController = new AbortController();
+    const { signal } = timerUiAbortController;
+
+    const radios = document.querySelectorAll('input[name="task-type"]');
+    radios.forEach((radio) => {
+        radio.addEventListener(
+            'change',
+            () => {
+                syncTimerFormState();
+            },
+            { signal }
+        );
+    });
+
+    const startTimerButton = document.getElementById('start-timer-btn');
+    if (startTimerButton) {
+        startTimerButton.addEventListener(
+            'click',
+            () => {
+                const runningActivity = getRunningActivity();
+                const formDescriptionInput = document.querySelector(
+                    '#task-form input[name="description"]'
+                );
+                const formCategorySelect = document.querySelector(
+                    '#task-form select[name="category"]'
+                );
+                const timerDescriptionInput = document.getElementById('timer-description');
+                const timerCategorySelect = document.getElementById('timer-category');
+
+                const activeDescriptionInput = runningActivity
+                    ? timerDescriptionInput
+                    : formDescriptionInput;
+                const activeCategorySelect = runningActivity
+                    ? timerCategorySelect
+                    : formCategorySelect;
+                const description =
+                    activeDescriptionInput instanceof HTMLInputElement
+                        ? activeDescriptionInput.value.trim()
+                        : '';
+                const category =
+                    activeCategorySelect instanceof HTMLSelectElement
+                        ? activeCategorySelect.value || null
+                        : null;
+
+                if (!description) {
+                    showAlert('Please enter a description before starting the timer.', 'sky');
+                    return;
+                }
+
+                void handleStartTimer({ description, category }).then((result) => {
+                    if (!result?.success) {
+                        return;
+                    }
+
+                    if (formDescriptionInput instanceof HTMLInputElement) {
+                        formDescriptionInput.value = '';
+                    }
+                    syncTimerFormState();
+                    deps.refreshUI();
+                });
+            },
+            { signal }
+        );
+    }
+
+    const stopTimerButton = document.getElementById('timer-stop-btn');
+    if (stopTimerButton) {
+        stopTimerButton.addEventListener(
+            'click',
+            () => {
+                void handleStopTimer().then((result) => {
+                    if (!result?.success) {
+                        return;
+                    }
+
+                    syncTimerFormState();
+                    deps.refreshUI();
+                });
+            },
+            { signal }
+        );
+    }
+
+    const timerDescriptionInput = document.getElementById('timer-description');
+    if (timerDescriptionInput instanceof HTMLInputElement) {
+        timerDescriptionInput.addEventListener(
+            'change',
+            () => {
+                const previousValue = getRunningActivity()?.description || '';
+                void updateRunningActivity({ description: timerDescriptionInput.value }).then(
+                    (result) => {
+                        if (result?.success && result.runningActivity) {
+                            timerDescriptionInput.value = result.runningActivity.description || '';
+                            return;
+                        }
+
+                        timerDescriptionInput.value = previousValue;
+                        showAlert(result?.reason || 'Could not update timer.', 'sky');
+                    }
+                );
+            },
+            { signal }
+        );
+    }
+
+    const timerCategorySelect = document.getElementById('timer-category');
+    if (timerCategorySelect instanceof HTMLSelectElement) {
+        timerCategorySelect.addEventListener(
+            'change',
+            () => {
+                const previousValue = getRunningActivity()?.category || '';
+                void updateRunningActivity({ category: timerCategorySelect.value || null }).then(
+                    (result) => {
+                        if (result?.success && result.runningActivity) {
+                            timerCategorySelect.value = result.runningActivity.category || '';
+                            return;
+                        }
+
+                        timerCategorySelect.value = previousValue;
+                        showAlert(result?.reason || 'Could not update timer.', 'sky');
+                    }
+                );
+            },
+            { signal }
+        );
+    }
+
+    const timerStartTimeInput = document.getElementById('timer-start-time');
+    if (timerStartTimeInput instanceof HTMLInputElement) {
+        timerStartTimeInput.addEventListener(
+            'change',
+            () => {
+                const runningActivity = getRunningActivity();
+                if (!runningActivity || !timerStartTimeInput.value) {
+                    return;
+                }
+
+                const previousDate = new Date(runningActivity.startDateTime);
+                const previousValue = `${String(previousDate.getHours()).padStart(2, '0')}:${String(
+                    previousDate.getMinutes()
+                ).padStart(2, '0')}`;
+                const nextStartDate = new Date(runningActivity.startDateTime);
+                const [hours, minutes] = timerStartTimeInput.value.split(':').map(Number);
+                nextStartDate.setHours(hours, minutes, 0, 0);
+
+                void updateRunningActivity({ startDateTime: nextStartDate.toISOString() }).then(
+                    (result) => {
+                        if (result?.success && result.runningActivity) {
+                            showTimerDisplay(result.runningActivity);
+                            return;
+                        }
+
+                        timerStartTimeInput.value = previousValue;
+                        showAlert(result?.reason || 'Could not update timer.', 'sky');
+                    }
+                );
+            },
+            { signal }
+        );
+    }
+}

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -4,12 +4,55 @@ import { handleStartTimer, handleStopTimer } from './handlers.js';
 
 let timerIntervalId = null;
 let timerUiAbortController = null;
+let pendingTimerMutation = null;
+let suppressTimerFieldPersistence = false;
+
+function shouldSuppressTimerFieldPersistence() {
+    const startTimerButton = document.getElementById('start-timer-btn');
+    return (
+        suppressTimerFieldPersistence ||
+        (!!getRunningActivity() && document.activeElement === startTimerButton)
+    );
+}
+
+function moveStartTimerButton(targetId) {
+    const startTimerButton = document.getElementById('start-timer-btn');
+    const target = document.getElementById(targetId);
+
+    if (!startTimerButton || !target || startTimerButton.parentElement === target) {
+        return;
+    }
+
+    target.appendChild(startTimerButton);
+}
 
 function stopElapsedCounter() {
     if (timerIntervalId) {
         clearInterval(timerIntervalId);
         timerIntervalId = null;
     }
+}
+
+function queueTimerMutation(mutation) {
+    const operation = pendingTimerMutation
+        ? pendingTimerMutation.catch(() => {}).then(() => mutation())
+        : Promise.resolve(mutation());
+    const trackedOperation = operation.catch(() => {});
+    pendingTimerMutation = trackedOperation;
+    trackedOperation.finally(() => {
+        if (pendingTimerMutation === trackedOperation) {
+            pendingTimerMutation = null;
+        }
+    });
+    return operation;
+}
+
+async function waitForPendingTimerMutation() {
+    if (!pendingTimerMutation) {
+        return;
+    }
+
+    await pendingTimerMutation;
 }
 
 function formatElapsed(elapsedMs) {
@@ -48,6 +91,7 @@ export function showTimerDisplay(runningActivity) {
 
     formFields.classList.add('hidden');
     timerDisplay.classList.remove('hidden');
+    moveStartTimerButton('timer-action-group');
 
     const descriptionInput = document.getElementById('timer-description');
     if (descriptionInput instanceof HTMLInputElement) {
@@ -79,6 +123,7 @@ export function hideTimerDisplay() {
     const timerDisplay = document.getElementById('timer-display');
 
     stopElapsedCounter();
+    moveStartTimerButton('activity-action-group');
 
     if (timerDisplay) {
         timerDisplay.classList.add('hidden');
@@ -95,6 +140,8 @@ export function disposeTimerUI() {
     }
 
     stopElapsedCounter();
+    pendingTimerMutation = null;
+    suppressTimerFieldPersistence = false;
 }
 
 export function syncTimerFormState() {
@@ -136,49 +183,72 @@ export function initializeTimerUI(deps) {
     const startTimerButton = document.getElementById('start-timer-btn');
     if (startTimerButton) {
         startTimerButton.addEventListener(
+            'mousedown',
+            () => {
+                suppressTimerFieldPersistence = !!getRunningActivity();
+            },
+            { signal }
+        );
+        startTimerButton.addEventListener(
             'click',
             () => {
-                const runningActivity = getRunningActivity();
-                const formDescriptionInput = document.querySelector(
-                    '#task-form input[name="description"]'
-                );
-                const formCategorySelect = document.querySelector(
-                    '#task-form select[name="category"]'
-                );
-                const timerDescriptionInput = document.getElementById('timer-description');
-                const timerCategorySelect = document.getElementById('timer-category');
+                void (async () => {
+                    try {
+                        await waitForPendingTimerMutation();
 
-                const activeDescriptionInput = runningActivity
-                    ? timerDescriptionInput
-                    : formDescriptionInput;
-                const activeCategorySelect = runningActivity
-                    ? timerCategorySelect
-                    : formCategorySelect;
-                const description =
-                    activeDescriptionInput instanceof HTMLInputElement
-                        ? activeDescriptionInput.value.trim()
-                        : '';
-                const category =
-                    activeCategorySelect instanceof HTMLSelectElement
-                        ? activeCategorySelect.value || null
-                        : null;
+                        const runningActivity = getRunningActivity();
+                        const formDescriptionInput = document.querySelector(
+                            '#task-form input[name="description"]'
+                        );
+                        const formCategorySelect = document.querySelector(
+                            '#task-form select[name="category"]'
+                        );
+                        const timerDescriptionInput = document.getElementById('timer-description');
+                        const timerCategorySelect = document.getElementById('timer-category');
 
-                if (!description) {
-                    showAlert('Please enter a description before starting the timer.', 'sky');
-                    return;
-                }
+                        const activeDescriptionInput = runningActivity
+                            ? timerDescriptionInput
+                            : formDescriptionInput;
+                        const activeCategorySelect = runningActivity
+                            ? timerCategorySelect
+                            : formCategorySelect;
+                        const description =
+                            activeDescriptionInput instanceof HTMLInputElement
+                                ? activeDescriptionInput.value.trim()
+                                : '';
+                        const category =
+                            activeCategorySelect instanceof HTMLSelectElement
+                                ? activeCategorySelect.value || null
+                                : null;
 
-                void handleStartTimer({ description, category }).then((result) => {
-                    if (!result?.success) {
-                        return;
+                        if (!description) {
+                            if (runningActivity) {
+                                syncTimerFormState();
+                            }
+                            showAlert(
+                                'Please enter a description before starting the timer.',
+                                'sky'
+                            );
+                            return;
+                        }
+
+                        const result = await handleStartTimer({ description, category });
+                        if (!result?.success) {
+                            if (runningActivity) {
+                                syncTimerFormState();
+                            }
+                            return;
+                        }
+
+                        if (formDescriptionInput instanceof HTMLInputElement) {
+                            formDescriptionInput.value = '';
+                        }
+                        syncTimerFormState();
+                        deps.refreshUI();
+                    } finally {
+                        suppressTimerFieldPersistence = false;
                     }
-
-                    if (formDescriptionInput instanceof HTMLInputElement) {
-                        formDescriptionInput.value = '';
-                    }
-                    syncTimerFormState();
-                    deps.refreshUI();
-                });
+                })();
             },
             { signal }
         );
@@ -189,14 +259,17 @@ export function initializeTimerUI(deps) {
         stopTimerButton.addEventListener(
             'click',
             () => {
-                void handleStopTimer().then((result) => {
+                void (async () => {
+                    await waitForPendingTimerMutation();
+
+                    const result = await handleStopTimer();
                     if (!result?.success) {
                         return;
                     }
 
                     syncTimerFormState();
                     deps.refreshUI();
-                });
+                })();
             },
             { signal }
         );
@@ -205,19 +278,34 @@ export function initializeTimerUI(deps) {
     const timerDescriptionInput = document.getElementById('timer-description');
     if (timerDescriptionInput instanceof HTMLInputElement) {
         timerDescriptionInput.addEventListener(
+            'focusout',
+            (event) => {
+                suppressTimerFieldPersistence =
+                    !!getRunningActivity() &&
+                    event.relatedTarget === document.getElementById('start-timer-btn');
+            },
+            { signal }
+        );
+        timerDescriptionInput.addEventListener(
             'change',
             () => {
+                if (shouldSuppressTimerFieldPersistence()) {
+                    return;
+                }
                 const previousValue = getRunningActivity()?.description || '';
-                void updateRunningActivity({ description: timerDescriptionInput.value }).then(
-                    (result) => {
-                        if (result?.success && result.runningActivity) {
-                            timerDescriptionInput.value = result.runningActivity.description || '';
-                            return;
-                        }
+                void queueTimerMutation(() =>
+                    updateRunningActivity({ description: timerDescriptionInput.value }).then(
+                        (result) => {
+                            if (result?.success && result.runningActivity) {
+                                timerDescriptionInput.value =
+                                    result.runningActivity.description || '';
+                                return;
+                            }
 
-                        timerDescriptionInput.value = previousValue;
-                        showAlert(result?.reason || 'Could not update timer.', 'sky');
-                    }
+                            timerDescriptionInput.value = previousValue;
+                            showAlert(result?.reason || 'Could not update timer.', 'sky');
+                        }
+                    )
                 );
             },
             { signal }
@@ -227,19 +315,33 @@ export function initializeTimerUI(deps) {
     const timerCategorySelect = document.getElementById('timer-category');
     if (timerCategorySelect instanceof HTMLSelectElement) {
         timerCategorySelect.addEventListener(
+            'focusout',
+            (event) => {
+                suppressTimerFieldPersistence =
+                    !!getRunningActivity() &&
+                    event.relatedTarget === document.getElementById('start-timer-btn');
+            },
+            { signal }
+        );
+        timerCategorySelect.addEventListener(
             'change',
             () => {
+                if (shouldSuppressTimerFieldPersistence()) {
+                    return;
+                }
                 const previousValue = getRunningActivity()?.category || '';
-                void updateRunningActivity({ category: timerCategorySelect.value || null }).then(
-                    (result) => {
-                        if (result?.success && result.runningActivity) {
-                            timerCategorySelect.value = result.runningActivity.category || '';
-                            return;
-                        }
+                void queueTimerMutation(() =>
+                    updateRunningActivity({ category: timerCategorySelect.value || null }).then(
+                        (result) => {
+                            if (result?.success && result.runningActivity) {
+                                timerCategorySelect.value = result.runningActivity.category || '';
+                                return;
+                            }
 
-                        timerCategorySelect.value = previousValue;
-                        showAlert(result?.reason || 'Could not update timer.', 'sky');
-                    }
+                            timerCategorySelect.value = previousValue;
+                            showAlert(result?.reason || 'Could not update timer.', 'sky');
+                        }
+                    )
                 );
             },
             { signal }
@@ -249,8 +351,20 @@ export function initializeTimerUI(deps) {
     const timerStartTimeInput = document.getElementById('timer-start-time');
     if (timerStartTimeInput instanceof HTMLInputElement) {
         timerStartTimeInput.addEventListener(
+            'focusout',
+            (event) => {
+                suppressTimerFieldPersistence =
+                    !!getRunningActivity() &&
+                    event.relatedTarget === document.getElementById('start-timer-btn');
+            },
+            { signal }
+        );
+        timerStartTimeInput.addEventListener(
             'change',
             () => {
+                if (shouldSuppressTimerFieldPersistence()) {
+                    return;
+                }
                 const runningActivity = getRunningActivity();
                 if (!runningActivity || !timerStartTimeInput.value) {
                     return;
@@ -264,16 +378,18 @@ export function initializeTimerUI(deps) {
                 const [hours, minutes] = timerStartTimeInput.value.split(':').map(Number);
                 nextStartDate.setHours(hours, minutes, 0, 0);
 
-                void updateRunningActivity({ startDateTime: nextStartDate.toISOString() }).then(
-                    (result) => {
-                        if (result?.success && result.runningActivity) {
-                            showTimerDisplay(result.runningActivity);
-                            return;
-                        }
+                void queueTimerMutation(() =>
+                    updateRunningActivity({ startDateTime: nextStartDate.toISOString() }).then(
+                        (result) => {
+                            if (result?.success && result.runningActivity) {
+                                showTimerDisplay(result.runningActivity);
+                                return;
+                            }
 
-                        timerStartTimeInput.value = previousValue;
-                        showAlert(result?.reason || 'Could not update timer.', 'sky');
-                    }
+                            timerStartTimeInput.value = previousValue;
+                            showAlert(result?.reason || 'Could not update timer.', 'sky');
+                        }
+                    )
                 );
             },
             { signal }

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -6,6 +6,10 @@ let timerIntervalId = null;
 let timerUiAbortController = null;
 let pendingTimerMutation = null;
 let suppressTimerFieldPersistence = false;
+let nextActivityDraft = {
+    description: '',
+    category: ''
+};
 
 function shouldSuppressTimerFieldPersistence() {
     const startTimerButton = document.getElementById('start-timer-btn');
@@ -24,6 +28,15 @@ function moveStartTimerButton(targetId) {
     }
 
     target.appendChild(startTimerButton);
+}
+
+function setStartTimerButtonLabel() {
+    const startTimerButton = document.getElementById('start-timer-btn');
+    if (!startTimerButton) {
+        return;
+    }
+
+    startTimerButton.innerHTML = '<i class="fa-solid fa-play mr-2"></i>Start Timer';
 }
 
 function stopElapsedCounter() {
@@ -82,6 +95,37 @@ function startElapsedCounter(startDateTime) {
     timerIntervalId = setInterval(updateElapsed, 1000);
 }
 
+function syncNextCategoryOptions() {
+    const nextCategorySelect = document.getElementById('next-activity-category');
+    if (!(nextCategorySelect instanceof HTMLSelectElement)) {
+        return;
+    }
+
+    const mainCategorySelect = document.querySelector('#task-form select[name="category"]');
+    if (mainCategorySelect instanceof HTMLSelectElement) {
+        nextCategorySelect.innerHTML = mainCategorySelect.innerHTML;
+    }
+
+    nextCategorySelect.value = nextActivityDraft.category || '';
+}
+
+function syncNextActivityDraftFields() {
+    const nextDescriptionInput = document.getElementById('next-activity-description');
+    if (nextDescriptionInput instanceof HTMLInputElement) {
+        nextDescriptionInput.value = nextActivityDraft.description;
+    }
+
+    syncNextCategoryOptions();
+}
+
+function clearNextActivityDraft() {
+    nextActivityDraft = {
+        description: '',
+        category: ''
+    };
+    syncNextActivityDraftFields();
+}
+
 export function showTimerDisplay(runningActivity) {
     const formFields = document.getElementById('task-form-fields');
     const timerDisplay = document.getElementById('timer-display');
@@ -91,7 +135,8 @@ export function showTimerDisplay(runningActivity) {
 
     formFields.classList.add('hidden');
     timerDisplay.classList.remove('hidden');
-    moveStartTimerButton('timer-action-group');
+    moveStartTimerButton('next-activity-action-group');
+    setStartTimerButtonLabel();
 
     const descriptionInput = document.getElementById('timer-description');
     if (descriptionInput instanceof HTMLInputElement) {
@@ -115,6 +160,7 @@ export function showTimerDisplay(runningActivity) {
         timerCategorySelect.value = runningActivity.category || '';
     }
 
+    syncNextActivityDraftFields();
     startElapsedCounter(runningActivity.startDateTime);
 }
 
@@ -124,6 +170,10 @@ export function hideTimerDisplay() {
 
     stopElapsedCounter();
     moveStartTimerButton('activity-action-group');
+    setStartTimerButtonLabel();
+    if (!getRunningActivity()) {
+        clearNextActivityDraft();
+    }
 
     if (timerDisplay) {
         timerDisplay.classList.add('hidden');
@@ -142,6 +192,10 @@ export function disposeTimerUI() {
     stopElapsedCounter();
     pendingTimerMutation = null;
     suppressTimerFieldPersistence = false;
+    nextActivityDraft = {
+        description: '',
+        category: ''
+    };
 }
 
 export function syncTimerFormState() {
@@ -203,14 +257,12 @@ export function initializeTimerUI(deps) {
                         const formCategorySelect = document.querySelector(
                             '#task-form select[name="category"]'
                         );
-                        const timerDescriptionInput = document.getElementById('timer-description');
-                        const timerCategorySelect = document.getElementById('timer-category');
 
                         const activeDescriptionInput = runningActivity
-                            ? timerDescriptionInput
+                            ? document.getElementById('next-activity-description')
                             : formDescriptionInput;
                         const activeCategorySelect = runningActivity
-                            ? timerCategorySelect
+                            ? document.getElementById('next-activity-category')
                             : formCategorySelect;
                         const description =
                             activeDescriptionInput instanceof HTMLInputElement
@@ -226,7 +278,9 @@ export function initializeTimerUI(deps) {
                                 syncTimerFormState();
                             }
                             showAlert(
-                                'Please enter a description before starting the timer.',
+                                runningActivity
+                                    ? 'Please enter a description before starting the next timer.'
+                                    : 'Please enter a description before starting the timer.',
                                 'sky'
                             );
                             return;
@@ -243,6 +297,7 @@ export function initializeTimerUI(deps) {
                         if (formDescriptionInput instanceof HTMLInputElement) {
                             formDescriptionInput.value = '';
                         }
+                        clearNextActivityDraft();
                         syncTimerFormState();
                         deps.refreshUI();
                     } finally {
@@ -270,6 +325,28 @@ export function initializeTimerUI(deps) {
                     syncTimerFormState();
                     deps.refreshUI();
                 })();
+            },
+            { signal }
+        );
+    }
+
+    const nextDescriptionInput = document.getElementById('next-activity-description');
+    if (nextDescriptionInput instanceof HTMLInputElement) {
+        nextDescriptionInput.addEventListener(
+            'input',
+            () => {
+                nextActivityDraft.description = nextDescriptionInput.value;
+            },
+            { signal }
+        );
+    }
+
+    const nextCategorySelect = document.getElementById('next-activity-category');
+    if (nextCategorySelect instanceof HTMLSelectElement) {
+        nextCategorySelect.addEventListener(
+            'change',
+            () => {
+                nextActivityDraft.category = nextCategorySelect.value || '';
             },
             { signal }
         );

--- a/public/js/activities/timer-ui.js
+++ b/public/js/activities/timer-ui.js
@@ -6,6 +6,10 @@ import { handleStartTimer, handleStopTimer } from './handlers.js';
 const timerUiState = {
     tickTimeoutId: null,
     abortController: null,
+    sessionId: 0,
+    serverClockOffsetMs: null,
+    serverDateHeader: null,
+    serverRoundTripMs: null,
     pendingMutation: null,
     suppressFieldPersistence: false,
     refreshActivitySummary: null,
@@ -48,6 +52,10 @@ function refreshActivitySummary() {
     if (typeof timerUiState.refreshActivitySummary === 'function') {
         timerUiState.refreshActivitySummary();
     }
+}
+
+function getEffectiveNowMs() {
+    return Date.now() + (timerUiState.serverClockOffsetMs ?? 0);
 }
 
 function stopElapsedCounter() {
@@ -116,27 +124,36 @@ function getTimerDebugSnapshot() {
 
 async function getTimerDebugSnapshotWithServerEstimate() {
     const snapshot = getTimerDebugSnapshot();
-    const canEstimateServerTime =
-        typeof fetch === 'function' &&
-        snapshot.runningActivity?.startDateTime &&
-        typeof snapshot.elapsedMs === 'number';
+    const correctedElapsedMs =
+        typeof snapshot.elapsedMs === 'number'
+            ? Math.max(0, snapshot.elapsedMs + (timerUiState.serverClockOffsetMs ?? 0))
+            : null;
 
-    if (!canEstimateServerTime) {
+    return {
+        ...snapshot,
+        serverDateHeader: timerUiState.serverDateHeader,
+        serverRoundTripMs: timerUiState.serverRoundTripMs,
+        estimatedServerOffsetMs: timerUiState.serverClockOffsetMs,
+        correctedElapsedMs,
+        correctedDisplayedElapsed:
+            typeof correctedElapsedMs === 'number' ? formatElapsed(correctedElapsedMs) : null
+    };
+}
+
+async function measureServerClockOffset() {
+    if (typeof fetch !== 'function') {
         return {
-            ...snapshot,
             serverDateHeader: null,
             serverRoundTripMs: null,
-            estimatedServerOffsetMs: null,
-            correctedElapsedMs: snapshot.elapsedMs,
-            correctedDisplayedElapsed:
-                typeof snapshot.elapsedMs === 'number' ? formatElapsed(snapshot.elapsedMs) : null
+            estimatedServerOffsetMs: null
         };
     }
 
     const requestStartedAtMs = Date.now();
     const response = await fetch(window.location.href, {
         method: 'HEAD',
-        cache: 'no-store'
+        cache: 'no-store',
+        signal: timerUiState.abortController?.signal
     });
     const requestCompletedAtMs = Date.now();
     const serverDateHeader = response?.headers?.get('Date') || null;
@@ -144,33 +161,68 @@ async function getTimerDebugSnapshotWithServerEstimate() {
 
     if (typeof serverDateMs !== 'number' || Number.isNaN(serverDateMs)) {
         return {
-            ...snapshot,
             serverDateHeader,
             serverRoundTripMs: requestCompletedAtMs - requestStartedAtMs,
-            estimatedServerOffsetMs: null,
-            correctedElapsedMs: snapshot.elapsedMs,
-            correctedDisplayedElapsed:
-                typeof snapshot.elapsedMs === 'number' ? formatElapsed(snapshot.elapsedMs) : null
+            estimatedServerOffsetMs: null
         };
     }
 
     const localMidpointMs = requestStartedAtMs + (requestCompletedAtMs - requestStartedAtMs) / 2;
-    const estimatedServerOffsetMs = serverDateMs - localMidpointMs;
-    const correctedElapsedMs = Math.max(
-        0,
-        new Date(snapshot.deviceNowIso).getTime() +
-            estimatedServerOffsetMs -
-            new Date(snapshot.runningActivity.startDateTime).getTime()
-    );
 
     return {
-        ...snapshot,
         serverDateHeader,
         serverRoundTripMs: requestCompletedAtMs - requestStartedAtMs,
-        estimatedServerOffsetMs,
-        correctedElapsedMs,
-        correctedDisplayedElapsed: formatElapsed(correctedElapsedMs)
+        estimatedServerOffsetMs: serverDateMs - localMidpointMs
     };
+}
+
+async function refreshServerClockOffset(sessionId) {
+    const previousOffsetMs = timerUiState.serverClockOffsetMs;
+    let nextOffsetMs = null;
+    let estimate = {
+        serverDateHeader: null,
+        serverRoundTripMs: null,
+        estimatedServerOffsetMs: null
+    };
+
+    try {
+        estimate = await measureServerClockOffset();
+        nextOffsetMs =
+            typeof estimate.estimatedServerOffsetMs === 'number' &&
+            !Number.isNaN(estimate.estimatedServerOffsetMs)
+                ? estimate.estimatedServerOffsetMs
+                : null;
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            return;
+        }
+    }
+
+    if (timerUiState.sessionId !== sessionId || timerUiState.abortController?.signal?.aborted) {
+        return;
+    }
+
+    timerUiState.serverClockOffsetMs = nextOffsetMs;
+    timerUiState.serverDateHeader = estimate.serverDateHeader;
+    timerUiState.serverRoundTripMs = estimate.serverRoundTripMs;
+
+    if (previousOffsetMs === nextOffsetMs) {
+        return;
+    }
+
+    const runningActivity = getRunningActivity();
+    const timerDisplay = document.getElementById('timer-display');
+    const isTimerVisible =
+        runningActivity &&
+        timerDisplay instanceof HTMLElement &&
+        !timerDisplay.classList.contains('hidden');
+
+    if (!isTimerVisible) {
+        return;
+    }
+
+    startElapsedCounter(runningActivity.startDateTime);
+    refreshActivitySummary();
 }
 
 function registerTimerDebugHelper() {
@@ -195,7 +247,7 @@ function startElapsedCounter(startDateTime) {
     }
 
     const updateElapsed = () => {
-        const elapsedMs = Date.now() - startMs;
+        const elapsedMs = getEffectiveNowMs() - startMs;
         elapsedElement.textContent = formatElapsed(elapsedMs);
 
         const elapsedMinutes = Math.max(0, Math.round(elapsedMs / 60000));
@@ -217,7 +269,7 @@ function startElapsedCounter(startDateTime) {
     };
 
     const scheduleNextUpdate = () => {
-        const elapsedMs = Math.max(0, Date.now() - startMs);
+        const elapsedMs = Math.max(0, getEffectiveNowMs() - startMs);
         const nextDelay = Math.max(1, 1000 - (elapsedMs % 1000));
         timerUiState.tickTimeoutId = setTimeout(() => {
             updateElapsed();
@@ -319,12 +371,16 @@ export function hideTimerDisplay() {
 
 export function disposeTimerUI() {
     unregisterTimerDebugHelper();
+    timerUiState.sessionId += 1;
     if (timerUiState.abortController) {
         timerUiState.abortController.abort();
         timerUiState.abortController = null;
     }
 
     stopElapsedCounter();
+    timerUiState.serverClockOffsetMs = null;
+    timerUiState.serverDateHeader = null;
+    timerUiState.serverRoundTripMs = null;
     timerUiState.pendingMutation = null;
     timerUiState.suppressFieldPersistence = false;
     timerUiState.refreshActivitySummary = null;
@@ -357,10 +413,12 @@ export function syncTimerFormState() {
 export function initializeTimerUI(deps) {
     disposeTimerUI();
     registerTimerDebugHelper();
+    timerUiState.sessionId += 1;
     timerUiState.abortController = new AbortController();
     const { signal } = timerUiState.abortController;
     timerUiState.refreshActivitySummary =
         typeof deps.refreshActivitySummary === 'function' ? deps.refreshActivitySummary : null;
+    void refreshServerClockOffset(timerUiState.sessionId);
 
     const radios = document.querySelectorAll('input[name="task-type"]');
     radios.forEach((radio) => {

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -4,6 +4,7 @@ import { renderActivities, renderActivitySummaryOnly } from './renderer.js';
 import { handleAddActivity, handleDeleteActivity, handleSaveActivityEdit } from './handlers.js';
 import { disposeTimerUI, hideTimerDisplay } from './timer-ui.js';
 import { computeEndTimePreview } from '../tasks/form-utils.js';
+import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
 
 let editingActivityId = null;
 let expandedParentGroupKey = null;
@@ -274,13 +275,22 @@ export function handleActivityListKeydown(event, deps) {
 
 export function handleActivityListInput(event) {
     const target = event.target;
-    if (!(target instanceof HTMLInputElement)) {
+    if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLSelectElement)) {
         return false;
     }
 
     const editForm = target.closest('form.activity-inline-edit-form[data-activity-id]');
     if (!(editForm instanceof HTMLFormElement)) {
         return false;
+    }
+
+    if (target instanceof HTMLSelectElement && target.name === 'category') {
+        const categoryDot = editForm.querySelector('.activity-edit-category-dot');
+        if (categoryDot instanceof HTMLElement) {
+            const resolvedCategory = resolveCategoryKey(target.value);
+            categoryDot.style.backgroundColor = resolvedCategory?.record?.color || '#64748b';
+        }
+        return true;
     }
 
     const startInput = editForm.querySelector('input[name="start-time"]');

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -1,9 +1,18 @@
+import { showAlert } from '../modal-manager.js';
 import { extractActivityFormData } from './form-utils.js';
-import { getTodaysActivities } from './manager.js';
+import { getTodaysActivities, getRunningActivity, updateRunningActivity } from './manager.js';
 import { renderActivities } from './renderer.js';
-import { handleAddActivity, handleDeleteActivity, handleSaveActivityEdit } from './handlers.js';
+import {
+    handleAddActivity,
+    handleDeleteActivity,
+    handleSaveActivityEdit,
+    handleStartTimer,
+    handleStopTimer
+} from './handlers.js';
 
 let editingActivityId = null;
+let timerIntervalId = null;
+let timerUiAbortController = null;
 
 export function resetActivityInlineEditState() {
     editingActivityId = null;
@@ -13,6 +22,89 @@ function clearDeleteConfirmState(deps) {
     const wasConfirming = deps.resetAllConfirmingDeleteFlags();
     if (wasConfirming) {
         deps.refreshUI();
+    }
+}
+
+function stopElapsedCounter() {
+    if (timerIntervalId) {
+        clearInterval(timerIntervalId);
+        timerIntervalId = null;
+    }
+}
+
+function formatElapsed(elapsedMs) {
+    const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(
+        seconds
+    ).padStart(2, '0')}`;
+}
+
+function startElapsedCounter(startDateTime) {
+    stopElapsedCounter();
+
+    const startMs = new Date(startDateTime).getTime();
+    const elapsedElement = document.getElementById('timer-elapsed');
+    if (!elapsedElement || Number.isNaN(startMs)) {
+        return;
+    }
+
+    const updateElapsed = () => {
+        elapsedElement.textContent = formatElapsed(Date.now() - startMs);
+    };
+
+    updateElapsed();
+    timerIntervalId = setInterval(updateElapsed, 1000);
+}
+
+export function showTimerDisplay(runningActivity) {
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+    if (!formFields || !timerDisplay || !runningActivity) {
+        return;
+    }
+
+    formFields.classList.add('hidden');
+    timerDisplay.classList.remove('hidden');
+
+    const descriptionInput = document.getElementById('timer-description');
+    if (descriptionInput instanceof HTMLInputElement) {
+        descriptionInput.value = runningActivity.description || '';
+    }
+
+    const startTimeInput = document.getElementById('timer-start-time');
+    if (startTimeInput instanceof HTMLInputElement && runningActivity.startDateTime) {
+        const startDate = new Date(runningActivity.startDateTime);
+        startTimeInput.value = `${String(startDate.getHours()).padStart(2, '0')}:${String(
+            startDate.getMinutes()
+        ).padStart(2, '0')}`;
+    }
+
+    const timerCategorySelect = document.getElementById('timer-category');
+    if (timerCategorySelect instanceof HTMLSelectElement) {
+        const mainCategorySelect = document.querySelector('#task-form select[name="category"]');
+        if (mainCategorySelect instanceof HTMLSelectElement) {
+            timerCategorySelect.innerHTML = mainCategorySelect.innerHTML;
+        }
+        timerCategorySelect.value = runningActivity.category || '';
+    }
+
+    startElapsedCounter(runningActivity.startDateTime);
+}
+
+export function hideTimerDisplay() {
+    const formFields = document.getElementById('task-form-fields');
+    const timerDisplay = document.getElementById('timer-display');
+
+    stopElapsedCounter();
+
+    if (timerDisplay) {
+        timerDisplay.classList.add('hidden');
+    }
+    if (formFields) {
+        formFields.classList.remove('hidden');
     }
 }
 
@@ -30,6 +122,7 @@ export function syncActivitiesUI(enabled) {
 
     if (!enabled) {
         editingActivityId = null;
+        hideTimerDisplay();
         const activityRadio = document.getElementById('activity');
         const scheduledRadio = document.getElementById('scheduled');
         if (activityRadio instanceof HTMLInputElement) {
@@ -53,10 +146,34 @@ export function renderTodayActivities(enabled) {
     );
 }
 
+export function syncTimerFormState() {
+    const activityRadio = document.getElementById('activity');
+    const isActivityMode = activityRadio instanceof HTMLInputElement && activityRadio.checked;
+    const runningActivity = getRunningActivity();
+    const startTimerButton = document.getElementById('start-timer-btn');
+
+    if (isActivityMode && runningActivity) {
+        showTimerDisplay(runningActivity);
+        if (startTimerButton) {
+            startTimerButton.classList.remove('hidden');
+        }
+        return;
+    }
+
+    hideTimerDisplay();
+    if (startTimerButton) {
+        startTimerButton.classList.toggle('hidden', !isActivityMode);
+    }
+}
+
 export async function handleActivityAwareFormSubmit(formElement, deps) {
     const selectedTaskType = new FormData(formElement).get('task-type')?.toString();
     if (!deps.activitiesEnabled || selectedTaskType !== 'activity') {
         await deps.handleTaskSubmit(formElement);
+        return;
+    }
+
+    if (getRunningActivity()) {
         return;
     }
 
@@ -90,6 +207,172 @@ export async function handleActivityAwareFormSubmit(formElement, deps) {
 
     deps.initializeTaskTypeToggle();
     deps.focusTaskDescriptionInput();
+}
+
+export function initializeTimerUI(deps) {
+    if (timerUiAbortController) {
+        timerUiAbortController.abort();
+    }
+    timerUiAbortController = new AbortController();
+    const { signal } = timerUiAbortController;
+
+    const radios = document.querySelectorAll('input[name="task-type"]');
+    radios.forEach((radio) => {
+        radio.addEventListener(
+            'change',
+            () => {
+                syncTimerFormState();
+            },
+            { signal }
+        );
+    });
+
+    const startTimerButton = document.getElementById('start-timer-btn');
+    if (startTimerButton) {
+        startTimerButton.addEventListener(
+            'click',
+            () => {
+                const runningActivity = getRunningActivity();
+                const formDescriptionInput = document.querySelector(
+                    '#task-form input[name="description"]'
+                );
+                const formCategorySelect = document.querySelector(
+                    '#task-form select[name="category"]'
+                );
+                const timerDescriptionInput = document.getElementById('timer-description');
+                const timerCategorySelect = document.getElementById('timer-category');
+
+                const activeDescriptionInput = runningActivity
+                    ? timerDescriptionInput
+                    : formDescriptionInput;
+                const activeCategorySelect = runningActivity
+                    ? timerCategorySelect
+                    : formCategorySelect;
+                const description =
+                    activeDescriptionInput instanceof HTMLInputElement
+                        ? activeDescriptionInput.value.trim()
+                        : '';
+                const category =
+                    activeCategorySelect instanceof HTMLSelectElement
+                        ? activeCategorySelect.value || null
+                        : null;
+
+                if (!description) {
+                    showAlert('Please enter a description before starting the timer.', 'sky');
+                    return;
+                }
+
+                void handleStartTimer({ description, category }).then((result) => {
+                    if (!result?.success) {
+                        return;
+                    }
+
+                    if (formDescriptionInput instanceof HTMLInputElement) {
+                        formDescriptionInput.value = '';
+                    }
+                    syncTimerFormState();
+                    deps.refreshUI();
+                });
+            },
+            { signal }
+        );
+    }
+
+    const stopTimerButton = document.getElementById('timer-stop-btn');
+    if (stopTimerButton) {
+        stopTimerButton.addEventListener(
+            'click',
+            () => {
+                void handleStopTimer().then((result) => {
+                    if (!result?.success) {
+                        return;
+                    }
+
+                    syncTimerFormState();
+                    deps.refreshUI();
+                });
+            },
+            { signal }
+        );
+    }
+
+    const timerDescriptionInput = document.getElementById('timer-description');
+    if (timerDescriptionInput instanceof HTMLInputElement) {
+        timerDescriptionInput.addEventListener(
+            'change',
+            () => {
+                const previousValue = getRunningActivity()?.description || '';
+                void updateRunningActivity({ description: timerDescriptionInput.value }).then(
+                    (result) => {
+                        if (result?.success && result.runningActivity) {
+                            timerDescriptionInput.value = result.runningActivity.description || '';
+                            return;
+                        }
+
+                        timerDescriptionInput.value = previousValue;
+                        showAlert(result?.reason || 'Could not update timer.', 'sky');
+                    }
+                );
+            },
+            { signal }
+        );
+    }
+
+    const timerCategorySelect = document.getElementById('timer-category');
+    if (timerCategorySelect instanceof HTMLSelectElement) {
+        timerCategorySelect.addEventListener(
+            'change',
+            () => {
+                const previousValue = getRunningActivity()?.category || '';
+                void updateRunningActivity({ category: timerCategorySelect.value || null }).then(
+                    (result) => {
+                        if (result?.success && result.runningActivity) {
+                            timerCategorySelect.value = result.runningActivity.category || '';
+                            return;
+                        }
+
+                        timerCategorySelect.value = previousValue;
+                        showAlert(result?.reason || 'Could not update timer.', 'sky');
+                    }
+                );
+            },
+            { signal }
+        );
+    }
+
+    const timerStartTimeInput = document.getElementById('timer-start-time');
+    if (timerStartTimeInput instanceof HTMLInputElement) {
+        timerStartTimeInput.addEventListener(
+            'change',
+            () => {
+                const runningActivity = getRunningActivity();
+                if (!runningActivity || !timerStartTimeInput.value) {
+                    return;
+                }
+
+                const previousDate = new Date(runningActivity.startDateTime);
+                const previousValue = `${String(previousDate.getHours()).padStart(2, '0')}:${String(
+                    previousDate.getMinutes()
+                ).padStart(2, '0')}`;
+                const nextStartDate = new Date(runningActivity.startDateTime);
+                const [hours, minutes] = timerStartTimeInput.value.split(':').map(Number);
+                nextStartDate.setHours(hours, minutes, 0, 0);
+
+                void updateRunningActivity({ startDateTime: nextStartDate.toISOString() }).then(
+                    (result) => {
+                        if (result?.success && result.runningActivity) {
+                            showTimerDisplay(result.runningActivity);
+                            return;
+                        }
+
+                        timerStartTimeInput.value = previousValue;
+                        showAlert(result?.reason || 'Could not update timer.', 'sky');
+                    }
+                );
+            },
+            { signal }
+        );
+    }
 }
 
 export function handleActivityListClick(target, deps) {

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -1,12 +1,19 @@
 import { extractActivityFormData } from './form-utils.js';
-import { getTodaysActivities, getRunningActivity } from './manager.js';
-import { renderActivities } from './renderer.js';
+import { getTodaysActivities, getRunningActivity, getLiveTodayActivitySummary } from './manager.js';
+import { renderActivities, renderActivitySummaryOnly } from './renderer.js';
 import { handleAddActivity, handleDeleteActivity, handleSaveActivityEdit } from './handlers.js';
 import { disposeTimerUI, hideTimerDisplay } from './timer-ui.js';
 import { computeEndTimePreview } from '../tasks/form-utils.js';
 
 let editingActivityId = null;
 let expandedParentGroupKey = null;
+
+function getActivitiesForSummary() {
+    const todaysActivities = getTodaysActivities();
+    const liveRunningSummary = getLiveTodayActivitySummary();
+
+    return liveRunningSummary ? [...todaysActivities, liveRunningSummary] : todaysActivities;
+}
 
 export function resetActivityInlineEditState() {
     editingActivityId = null;
@@ -53,11 +60,28 @@ export function renderTodayActivities(enabled) {
         return;
     }
 
+    const todaysActivities = getTodaysActivities();
     renderActivities(
-        getTodaysActivities(),
+        todaysActivities,
         /** @type {HTMLElement|null} */ (document.getElementById('activity-list')),
-        { editingActivityId, expandedParentGroupKey }
+        {
+            editingActivityId,
+            expandedParentGroupKey,
+            summaryActivities: getActivitiesForSummary()
+        }
     );
+}
+
+export function refreshTodayActivitySummary(enabled) {
+    if (!enabled) {
+        return;
+    }
+
+    const activityList = /** @type {HTMLElement|null} */ (document.getElementById('activity-list'));
+    renderActivitySummaryOnly(getTodaysActivities(), activityList, {
+        expandedParentGroupKey,
+        summaryActivities: getActivitiesForSummary()
+    });
 }
 
 export async function handleActivityAwareFormSubmit(formElement, deps) {

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -6,9 +6,11 @@ import { disposeTimerUI, hideTimerDisplay } from './timer-ui.js';
 import { computeEndTimePreview } from '../tasks/form-utils.js';
 
 let editingActivityId = null;
+let expandedParentGroupKey = null;
 
 export function resetActivityInlineEditState() {
     editingActivityId = null;
+    expandedParentGroupKey = null;
 }
 
 function clearDeleteConfirmState(deps) {
@@ -32,6 +34,7 @@ export function syncActivitiesUI(enabled) {
 
     if (!enabled) {
         editingActivityId = null;
+        expandedParentGroupKey = null;
         disposeTimerUI();
         hideTimerDisplay();
         const activityRadio = document.getElementById('activity');
@@ -53,7 +56,7 @@ export function renderTodayActivities(enabled) {
     renderActivities(
         getTodaysActivities(),
         /** @type {HTMLElement|null} */ (document.getElementById('activity-list')),
-        { editingActivityId }
+        { editingActivityId, expandedParentGroupKey }
     );
 }
 
@@ -103,6 +106,24 @@ export async function handleActivityAwareFormSubmit(formElement, deps) {
 export function handleActivityListClick(target, deps) {
     if (!(target instanceof HTMLElement)) {
         return false;
+    }
+
+    const summaryParentTarget = target.closest(
+        '[data-summary-parent-key][data-summary-parent-legend], [data-summary-parent-key][data-summary-parent-segment]'
+    );
+    if (summaryParentTarget instanceof HTMLElement) {
+        const parentKey = summaryParentTarget.dataset.summaryParentKey;
+        if (!parentKey) {
+            return false;
+        }
+
+        if (parentKey === 'uncategorized') {
+            return true;
+        }
+
+        expandedParentGroupKey = expandedParentGroupKey === parentKey ? null : parentKey;
+        deps.refreshUI();
+        return true;
     }
 
     const editActivityButton = target.closest('.btn-edit-activity');

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -3,6 +3,7 @@ import { getTodaysActivities, getRunningActivity } from './manager.js';
 import { renderActivities } from './renderer.js';
 import { handleAddActivity, handleDeleteActivity, handleSaveActivityEdit } from './handlers.js';
 import { disposeTimerUI, hideTimerDisplay } from './timer-ui.js';
+import { computeEndTimePreview } from '../tasks/form-utils.js';
 
 let editingActivityId = null;
 
@@ -124,19 +125,13 @@ export function handleActivityListClick(target, deps) {
         return true;
     }
 
-    const saveActivityEditButton = target.closest('.btn-save-activity-edit');
+    const saveActivityEditButton = target.closest('.btn-save-activity-edit[type="button"]');
     if (saveActivityEditButton instanceof HTMLElement) {
         const editForm = saveActivityEditButton.closest(
             'form.activity-inline-edit-form[data-activity-id]'
         );
-        const activityId = editForm?.getAttribute('data-activity-id');
-        if (activityId && editForm instanceof HTMLFormElement) {
-            void handleSaveActivityEdit(activityId, editForm).then((result) => {
-                if (result?.success) {
-                    editingActivityId = null;
-                }
-                deps.refreshUI();
-            });
+        if (editForm instanceof HTMLFormElement) {
+            void saveInlineActivityEdit(editForm, deps);
         }
         return true;
     }
@@ -165,4 +160,89 @@ export function handleActivityListClick(target, deps) {
     }
 
     return false;
+}
+
+async function saveInlineActivityEdit(editForm, deps) {
+    const activityId = editForm.getAttribute('data-activity-id');
+    if (!activityId) {
+        return false;
+    }
+
+    const result = await handleSaveActivityEdit(activityId, editForm);
+    if (result?.success) {
+        editingActivityId = null;
+    }
+    deps.refreshUI();
+    return true;
+}
+
+export function handleActivityListSubmit(event, deps) {
+    const editForm = event.target;
+    if (!(editForm instanceof HTMLFormElement)) {
+        return false;
+    }
+
+    if (!editForm.matches('form.activity-inline-edit-form[data-activity-id]')) {
+        return false;
+    }
+
+    event.preventDefault();
+    void saveInlineActivityEdit(editForm, deps);
+    return true;
+}
+
+export function handleActivityListKeydown(event, deps) {
+    if (event.key !== 'Enter') {
+        return false;
+    }
+
+    if (!(event.target instanceof HTMLInputElement)) {
+        return false;
+    }
+
+    const editForm = event.target.closest('form.activity-inline-edit-form[data-activity-id]');
+    if (!(editForm instanceof HTMLFormElement)) {
+        return false;
+    }
+
+    event.preventDefault();
+    void saveInlineActivityEdit(editForm, deps);
+    return true;
+}
+
+export function handleActivityListInput(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) {
+        return false;
+    }
+
+    const editForm = target.closest('form.activity-inline-edit-form[data-activity-id]');
+    if (!(editForm instanceof HTMLFormElement)) {
+        return false;
+    }
+
+    const startInput = editForm.querySelector('input[name="start-time"]');
+    const hoursInput = editForm.querySelector('input[name="duration-hours"]');
+    const minutesInput = editForm.querySelector('input[name="duration-minutes"]');
+    const hintElement = editForm.querySelector('.edit-end-time-hint');
+
+    if (
+        !(startInput instanceof HTMLInputElement) ||
+        !(hoursInput instanceof HTMLInputElement) ||
+        !(minutesInput instanceof HTMLInputElement) ||
+        !(hintElement instanceof HTMLElement)
+    ) {
+        return false;
+    }
+
+    const preview = computeEndTimePreview(startInput.value, hoursInput.value, minutesInput.value);
+    if (preview) {
+        hintElement.textContent = `\u25b8 ${preview}`;
+        hintElement.classList.remove('opacity-0');
+    } else {
+        hintElement.textContent = '';
+        hintElement.classList.add('opacity-0');
+    }
+
+    return true;
 }

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -6,10 +6,12 @@ import { disposeTimerUI, hideTimerDisplay } from './timer-ui.js';
 import { computeEndTimePreview } from '../tasks/form-utils.js';
 import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
 
-let editingActivityId = null;
-let expandedParentGroupKey = null;
-let confirmingDeleteActivityId = null;
-const inFlightActivitySaveIds = new Set();
+const activityUiState = {
+    editingActivityId: null,
+    expandedParentGroupKey: null,
+    confirmingDeleteActivityId: null,
+    inFlightActivitySaveIds: new Set()
+};
 
 function getActivitiesForSummary() {
     const todaysActivities = getTodaysActivities();
@@ -19,16 +21,16 @@ function getActivitiesForSummary() {
 }
 
 export function resetActivityInlineEditState() {
-    editingActivityId = null;
-    expandedParentGroupKey = null;
-    confirmingDeleteActivityId = null;
-    inFlightActivitySaveIds.clear();
+    activityUiState.editingActivityId = null;
+    activityUiState.expandedParentGroupKey = null;
+    activityUiState.confirmingDeleteActivityId = null;
+    activityUiState.inFlightActivitySaveIds.clear();
 }
 
 function clearDeleteConfirmState(deps) {
     const wasConfirmingTaskDelete = deps.resetAllConfirmingDeleteFlags();
-    const wasConfirmingActivityDelete = confirmingDeleteActivityId !== null;
-    confirmingDeleteActivityId = null;
+    const wasConfirmingActivityDelete = activityUiState.confirmingDeleteActivityId !== null;
+    activityUiState.confirmingDeleteActivityId = null;
 
     const wasConfirming = wasConfirmingTaskDelete || wasConfirmingActivityDelete;
     if (wasConfirming) {
@@ -49,8 +51,8 @@ export function syncActivitiesUI(enabled) {
     }
 
     if (!enabled) {
-        editingActivityId = null;
-        expandedParentGroupKey = null;
+        activityUiState.editingActivityId = null;
+        activityUiState.expandedParentGroupKey = null;
         disposeTimerUI();
         hideTimerDisplay();
         const activityRadio = document.getElementById('activity');
@@ -74,9 +76,9 @@ export function renderTodayActivities(enabled) {
         todaysActivities,
         /** @type {HTMLElement|null} */ (document.getElementById('activity-list')),
         {
-            editingActivityId,
-            expandedParentGroupKey,
-            confirmingDeleteActivityId,
+            editingActivityId: activityUiState.editingActivityId,
+            expandedParentGroupKey: activityUiState.expandedParentGroupKey,
+            confirmingDeleteActivityId: activityUiState.confirmingDeleteActivityId,
             summaryActivities: getActivitiesForSummary()
         }
     );
@@ -89,7 +91,7 @@ export function refreshTodayActivitySummary(enabled) {
 
     const activityList = /** @type {HTMLElement|null} */ (document.getElementById('activity-list'));
     renderActivitySummaryOnly(getTodaysActivities(), activityList, {
-        expandedParentGroupKey,
+        expandedParentGroupKey: activityUiState.expandedParentGroupKey,
         summaryActivities: getActivitiesForSummary()
     });
 }
@@ -155,7 +157,8 @@ export function handleActivityListClick(target, deps) {
             return true;
         }
 
-        expandedParentGroupKey = expandedParentGroupKey === parentKey ? null : parentKey;
+        activityUiState.expandedParentGroupKey =
+            activityUiState.expandedParentGroupKey === parentKey ? null : parentKey;
         deps.refreshUI();
         return true;
     }
@@ -167,7 +170,7 @@ export function handleActivityListClick(target, deps) {
             editActivityButton.dataset.activityId || activityItem?.getAttribute('data-activity-id');
         clearDeleteConfirmState(deps);
         if (activityId) {
-            editingActivityId = activityId;
+            activityUiState.editingActivityId = activityId;
             deps.refreshUI();
         }
         return true;
@@ -175,7 +178,7 @@ export function handleActivityListClick(target, deps) {
 
     const cancelActivityEditButton = target.closest('.btn-cancel-activity-edit');
     if (cancelActivityEditButton instanceof HTMLElement) {
-        editingActivityId = null;
+        activityUiState.editingActivityId = null;
         deps.refreshUI();
         return true;
     }
@@ -200,16 +203,16 @@ export function handleActivityListClick(target, deps) {
         if (activityId) {
             deps.resetAllConfirmingDeleteFlags();
 
-            if (confirmingDeleteActivityId === activityId) {
-                confirmingDeleteActivityId = null;
-                if (editingActivityId === activityId) {
-                    editingActivityId = null;
+            if (activityUiState.confirmingDeleteActivityId === activityId) {
+                activityUiState.confirmingDeleteActivityId = null;
+                if (activityUiState.editingActivityId === activityId) {
+                    activityUiState.editingActivityId = null;
                 }
                 void handleDeleteActivity(activityId);
             } else {
-                confirmingDeleteActivityId = activityId;
-                if (editingActivityId === activityId) {
-                    editingActivityId = null;
+                activityUiState.confirmingDeleteActivityId = activityId;
+                if (activityUiState.editingActivityId === activityId) {
+                    activityUiState.editingActivityId = null;
                 }
                 deps.refreshUI();
             }
@@ -233,20 +236,20 @@ async function saveInlineActivityEdit(editForm, deps) {
         return false;
     }
 
-    if (inFlightActivitySaveIds.has(activityId)) {
+    if (activityUiState.inFlightActivitySaveIds.has(activityId)) {
         return true;
     }
 
-    inFlightActivitySaveIds.add(activityId);
+    activityUiState.inFlightActivitySaveIds.add(activityId);
     try {
         const result = await handleSaveActivityEdit(activityId, editForm);
         if (result?.success) {
-            editingActivityId = null;
+            activityUiState.editingActivityId = null;
         }
         deps.refreshUI();
         return true;
     } finally {
-        inFlightActivitySaveIds.delete(activityId);
+        activityUiState.inFlightActivitySaveIds.delete(activityId);
     }
 }
 

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -9,6 +9,7 @@ import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
 let editingActivityId = null;
 let expandedParentGroupKey = null;
 let confirmingDeleteActivityId = null;
+const inFlightActivitySaveIds = new Set();
 
 function getActivitiesForSummary() {
     const todaysActivities = getTodaysActivities();
@@ -21,6 +22,7 @@ export function resetActivityInlineEditState() {
     editingActivityId = null;
     expandedParentGroupKey = null;
     confirmingDeleteActivityId = null;
+    inFlightActivitySaveIds.clear();
 }
 
 function clearDeleteConfirmState(deps) {
@@ -231,12 +233,21 @@ async function saveInlineActivityEdit(editForm, deps) {
         return false;
     }
 
-    const result = await handleSaveActivityEdit(activityId, editForm);
-    if (result?.success) {
-        editingActivityId = null;
+    if (inFlightActivitySaveIds.has(activityId)) {
+        return true;
     }
-    deps.refreshUI();
-    return true;
+
+    inFlightActivitySaveIds.add(activityId);
+    try {
+        const result = await handleSaveActivityEdit(activityId, editForm);
+        if (result?.success) {
+            editingActivityId = null;
+        }
+        deps.refreshUI();
+        return true;
+    } finally {
+        inFlightActivitySaveIds.delete(activityId);
+    }
 }
 
 export function handleActivityListSubmit(event, deps) {

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -1,18 +1,10 @@
-import { showAlert } from '../modal-manager.js';
 import { extractActivityFormData } from './form-utils.js';
-import { getTodaysActivities, getRunningActivity, updateRunningActivity } from './manager.js';
+import { getTodaysActivities, getRunningActivity } from './manager.js';
 import { renderActivities } from './renderer.js';
-import {
-    handleAddActivity,
-    handleDeleteActivity,
-    handleSaveActivityEdit,
-    handleStartTimer,
-    handleStopTimer
-} from './handlers.js';
+import { handleAddActivity, handleDeleteActivity, handleSaveActivityEdit } from './handlers.js';
+import { disposeTimerUI, hideTimerDisplay } from './timer-ui.js';
 
 let editingActivityId = null;
-let timerIntervalId = null;
-let timerUiAbortController = null;
 
 export function resetActivityInlineEditState() {
     editingActivityId = null;
@@ -22,89 +14,6 @@ function clearDeleteConfirmState(deps) {
     const wasConfirming = deps.resetAllConfirmingDeleteFlags();
     if (wasConfirming) {
         deps.refreshUI();
-    }
-}
-
-function stopElapsedCounter() {
-    if (timerIntervalId) {
-        clearInterval(timerIntervalId);
-        timerIntervalId = null;
-    }
-}
-
-function formatElapsed(elapsedMs) {
-    const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(
-        seconds
-    ).padStart(2, '0')}`;
-}
-
-function startElapsedCounter(startDateTime) {
-    stopElapsedCounter();
-
-    const startMs = new Date(startDateTime).getTime();
-    const elapsedElement = document.getElementById('timer-elapsed');
-    if (!elapsedElement || Number.isNaN(startMs)) {
-        return;
-    }
-
-    const updateElapsed = () => {
-        elapsedElement.textContent = formatElapsed(Date.now() - startMs);
-    };
-
-    updateElapsed();
-    timerIntervalId = setInterval(updateElapsed, 1000);
-}
-
-export function showTimerDisplay(runningActivity) {
-    const formFields = document.getElementById('task-form-fields');
-    const timerDisplay = document.getElementById('timer-display');
-    if (!formFields || !timerDisplay || !runningActivity) {
-        return;
-    }
-
-    formFields.classList.add('hidden');
-    timerDisplay.classList.remove('hidden');
-
-    const descriptionInput = document.getElementById('timer-description');
-    if (descriptionInput instanceof HTMLInputElement) {
-        descriptionInput.value = runningActivity.description || '';
-    }
-
-    const startTimeInput = document.getElementById('timer-start-time');
-    if (startTimeInput instanceof HTMLInputElement && runningActivity.startDateTime) {
-        const startDate = new Date(runningActivity.startDateTime);
-        startTimeInput.value = `${String(startDate.getHours()).padStart(2, '0')}:${String(
-            startDate.getMinutes()
-        ).padStart(2, '0')}`;
-    }
-
-    const timerCategorySelect = document.getElementById('timer-category');
-    if (timerCategorySelect instanceof HTMLSelectElement) {
-        const mainCategorySelect = document.querySelector('#task-form select[name="category"]');
-        if (mainCategorySelect instanceof HTMLSelectElement) {
-            timerCategorySelect.innerHTML = mainCategorySelect.innerHTML;
-        }
-        timerCategorySelect.value = runningActivity.category || '';
-    }
-
-    startElapsedCounter(runningActivity.startDateTime);
-}
-
-export function hideTimerDisplay() {
-    const formFields = document.getElementById('task-form-fields');
-    const timerDisplay = document.getElementById('timer-display');
-
-    stopElapsedCounter();
-
-    if (timerDisplay) {
-        timerDisplay.classList.add('hidden');
-    }
-    if (formFields) {
-        formFields.classList.remove('hidden');
     }
 }
 
@@ -122,6 +31,7 @@ export function syncActivitiesUI(enabled) {
 
     if (!enabled) {
         editingActivityId = null;
+        disposeTimerUI();
         hideTimerDisplay();
         const activityRadio = document.getElementById('activity');
         const scheduledRadio = document.getElementById('scheduled');
@@ -144,26 +54,6 @@ export function renderTodayActivities(enabled) {
         /** @type {HTMLElement|null} */ (document.getElementById('activity-list')),
         { editingActivityId }
     );
-}
-
-export function syncTimerFormState() {
-    const activityRadio = document.getElementById('activity');
-    const isActivityMode = activityRadio instanceof HTMLInputElement && activityRadio.checked;
-    const runningActivity = getRunningActivity();
-    const startTimerButton = document.getElementById('start-timer-btn');
-
-    if (isActivityMode && runningActivity) {
-        showTimerDisplay(runningActivity);
-        if (startTimerButton) {
-            startTimerButton.classList.remove('hidden');
-        }
-        return;
-    }
-
-    hideTimerDisplay();
-    if (startTimerButton) {
-        startTimerButton.classList.toggle('hidden', !isActivityMode);
-    }
 }
 
 export async function handleActivityAwareFormSubmit(formElement, deps) {
@@ -207,172 +97,6 @@ export async function handleActivityAwareFormSubmit(formElement, deps) {
 
     deps.initializeTaskTypeToggle();
     deps.focusTaskDescriptionInput();
-}
-
-export function initializeTimerUI(deps) {
-    if (timerUiAbortController) {
-        timerUiAbortController.abort();
-    }
-    timerUiAbortController = new AbortController();
-    const { signal } = timerUiAbortController;
-
-    const radios = document.querySelectorAll('input[name="task-type"]');
-    radios.forEach((radio) => {
-        radio.addEventListener(
-            'change',
-            () => {
-                syncTimerFormState();
-            },
-            { signal }
-        );
-    });
-
-    const startTimerButton = document.getElementById('start-timer-btn');
-    if (startTimerButton) {
-        startTimerButton.addEventListener(
-            'click',
-            () => {
-                const runningActivity = getRunningActivity();
-                const formDescriptionInput = document.querySelector(
-                    '#task-form input[name="description"]'
-                );
-                const formCategorySelect = document.querySelector(
-                    '#task-form select[name="category"]'
-                );
-                const timerDescriptionInput = document.getElementById('timer-description');
-                const timerCategorySelect = document.getElementById('timer-category');
-
-                const activeDescriptionInput = runningActivity
-                    ? timerDescriptionInput
-                    : formDescriptionInput;
-                const activeCategorySelect = runningActivity
-                    ? timerCategorySelect
-                    : formCategorySelect;
-                const description =
-                    activeDescriptionInput instanceof HTMLInputElement
-                        ? activeDescriptionInput.value.trim()
-                        : '';
-                const category =
-                    activeCategorySelect instanceof HTMLSelectElement
-                        ? activeCategorySelect.value || null
-                        : null;
-
-                if (!description) {
-                    showAlert('Please enter a description before starting the timer.', 'sky');
-                    return;
-                }
-
-                void handleStartTimer({ description, category }).then((result) => {
-                    if (!result?.success) {
-                        return;
-                    }
-
-                    if (formDescriptionInput instanceof HTMLInputElement) {
-                        formDescriptionInput.value = '';
-                    }
-                    syncTimerFormState();
-                    deps.refreshUI();
-                });
-            },
-            { signal }
-        );
-    }
-
-    const stopTimerButton = document.getElementById('timer-stop-btn');
-    if (stopTimerButton) {
-        stopTimerButton.addEventListener(
-            'click',
-            () => {
-                void handleStopTimer().then((result) => {
-                    if (!result?.success) {
-                        return;
-                    }
-
-                    syncTimerFormState();
-                    deps.refreshUI();
-                });
-            },
-            { signal }
-        );
-    }
-
-    const timerDescriptionInput = document.getElementById('timer-description');
-    if (timerDescriptionInput instanceof HTMLInputElement) {
-        timerDescriptionInput.addEventListener(
-            'change',
-            () => {
-                const previousValue = getRunningActivity()?.description || '';
-                void updateRunningActivity({ description: timerDescriptionInput.value }).then(
-                    (result) => {
-                        if (result?.success && result.runningActivity) {
-                            timerDescriptionInput.value = result.runningActivity.description || '';
-                            return;
-                        }
-
-                        timerDescriptionInput.value = previousValue;
-                        showAlert(result?.reason || 'Could not update timer.', 'sky');
-                    }
-                );
-            },
-            { signal }
-        );
-    }
-
-    const timerCategorySelect = document.getElementById('timer-category');
-    if (timerCategorySelect instanceof HTMLSelectElement) {
-        timerCategorySelect.addEventListener(
-            'change',
-            () => {
-                const previousValue = getRunningActivity()?.category || '';
-                void updateRunningActivity({ category: timerCategorySelect.value || null }).then(
-                    (result) => {
-                        if (result?.success && result.runningActivity) {
-                            timerCategorySelect.value = result.runningActivity.category || '';
-                            return;
-                        }
-
-                        timerCategorySelect.value = previousValue;
-                        showAlert(result?.reason || 'Could not update timer.', 'sky');
-                    }
-                );
-            },
-            { signal }
-        );
-    }
-
-    const timerStartTimeInput = document.getElementById('timer-start-time');
-    if (timerStartTimeInput instanceof HTMLInputElement) {
-        timerStartTimeInput.addEventListener(
-            'change',
-            () => {
-                const runningActivity = getRunningActivity();
-                if (!runningActivity || !timerStartTimeInput.value) {
-                    return;
-                }
-
-                const previousDate = new Date(runningActivity.startDateTime);
-                const previousValue = `${String(previousDate.getHours()).padStart(2, '0')}:${String(
-                    previousDate.getMinutes()
-                ).padStart(2, '0')}`;
-                const nextStartDate = new Date(runningActivity.startDateTime);
-                const [hours, minutes] = timerStartTimeInput.value.split(':').map(Number);
-                nextStartDate.setHours(hours, minutes, 0, 0);
-
-                void updateRunningActivity({ startDateTime: nextStartDate.toISOString() }).then(
-                    (result) => {
-                        if (result?.success && result.runningActivity) {
-                            showTimerDisplay(result.runningActivity);
-                            return;
-                        }
-
-                        timerStartTimeInput.value = previousValue;
-                        showAlert(result?.reason || 'Could not update timer.', 'sky');
-                    }
-                );
-            },
-            { signal }
-        );
-    }
 }
 
 export function handleActivityListClick(target, deps) {

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -7,6 +7,7 @@ import { computeEndTimePreview } from '../tasks/form-utils.js';
 
 let editingActivityId = null;
 let expandedParentGroupKey = null;
+let confirmingDeleteActivityId = null;
 
 function getActivitiesForSummary() {
     const todaysActivities = getTodaysActivities();
@@ -18,10 +19,15 @@ function getActivitiesForSummary() {
 export function resetActivityInlineEditState() {
     editingActivityId = null;
     expandedParentGroupKey = null;
+    confirmingDeleteActivityId = null;
 }
 
 function clearDeleteConfirmState(deps) {
-    const wasConfirming = deps.resetAllConfirmingDeleteFlags();
+    const wasConfirmingTaskDelete = deps.resetAllConfirmingDeleteFlags();
+    const wasConfirmingActivityDelete = confirmingDeleteActivityId !== null;
+    confirmingDeleteActivityId = null;
+
+    const wasConfirming = wasConfirmingTaskDelete || wasConfirmingActivityDelete;
     if (wasConfirming) {
         deps.refreshUI();
     }
@@ -67,6 +73,7 @@ export function renderTodayActivities(enabled) {
         {
             editingActivityId,
             expandedParentGroupKey,
+            confirmingDeleteActivityId,
             summaryActivities: getActivitiesForSummary()
         }
     );
@@ -187,12 +194,22 @@ export function handleActivityListClick(target, deps) {
         const activityId =
             deleteActivityButton.dataset.activityId ||
             activityItem?.getAttribute('data-activity-id');
-        clearDeleteConfirmState(deps);
         if (activityId) {
-            if (editingActivityId === activityId) {
-                editingActivityId = null;
+            deps.resetAllConfirmingDeleteFlags();
+
+            if (confirmingDeleteActivityId === activityId) {
+                confirmingDeleteActivityId = null;
+                if (editingActivityId === activityId) {
+                    editingActivityId = null;
+                }
+                void handleDeleteActivity(activityId);
+            } else {
+                confirmingDeleteActivityId = activityId;
+                if (editingActivityId === activityId) {
+                    editingActivityId = null;
+                }
+                deps.refreshUI();
             }
-            void handleDeleteActivity(activityId);
         }
         return true;
     }

--- a/public/js/app-coordinator.js
+++ b/public/js/app-coordinator.js
@@ -1,5 +1,10 @@
 import { refreshUI } from './dom-renderer.js';
-import { addActivity, createActivityFromTask } from './activities/manager.js';
+import {
+    addActivity,
+    createActivityFromTask,
+    getRunningActivity,
+    stopTimerAt
+} from './activities/manager.js';
 import { consumeActivitySmokeFailure } from './activities/smoke-hooks.js';
 import { isActivitiesEnabled } from './settings-manager.js';
 import { triggerConfettiAnimation } from './tasks/scheduled-renderer.js';
@@ -17,6 +22,24 @@ function refreshWhenPresent(value) {
 
 function refreshForClearEvent() {
     refreshUI();
+}
+
+function toMs(dateTime) {
+    const value = new Date(dateTime).getTime();
+    return Number.isNaN(value) ? null : value;
+}
+
+function rangesOverlap(startA, endA, startB, endB) {
+    const aStart = toMs(startA);
+    const aEnd = toMs(endA);
+    const bStart = toMs(startB);
+    const bEnd = toMs(endB);
+
+    if ([aStart, aEnd, bStart, bEnd].some((value) => value === null)) {
+        return false;
+    }
+
+    return aStart < bEnd && bStart < aEnd;
 }
 
 /**
@@ -69,8 +92,23 @@ export function onTaskCompleted({ task }) {
                 : addActivity(activity);
 
             void autoLogPromise
-                .then((result) => {
+                .then(async (result) => {
                     if (result?.success && result.activity) {
+                        const runningActivity = getRunningActivity();
+                        if (
+                            runningActivity &&
+                            rangesOverlap(
+                                runningActivity.startDateTime,
+                                new Date().toISOString(),
+                                result.activity.startDateTime,
+                                result.activity.endDateTime
+                            )
+                        ) {
+                            const stopResult = await stopTimerAt(result.activity.startDateTime);
+                            if (stopResult?.success && stopResult.activity) {
+                                onActivityCreated({ activity: stopResult.activity });
+                            }
+                        }
                         onActivityCreated({ activity: result.activity });
                     }
                 })

--- a/public/js/app-lifecycle.js
+++ b/public/js/app-lifecycle.js
@@ -1,0 +1,143 @@
+import { extractDateFromDateTime } from './utils.js';
+
+export function createRoomSessionLifecycle({
+    loadAppState,
+    refreshUI,
+    getActivitiesEnabled,
+    syncRestoredRunningTimer,
+    getTaskState,
+    refreshActiveTaskColor,
+    refreshCurrentGapHighlight,
+    refreshStartTimeField,
+    getRunningActivity,
+    stopTimerAt,
+    syncTimerFormState,
+    refreshTaskDisplays,
+    onSyncStatusChange,
+    updateSyncStatusUI,
+    triggerSync,
+    logger
+}) {
+    let refreshFromStoragePromise = null;
+    let unsubscribeSyncStatus = null;
+    let activeTaskColorInterval = null;
+    let midnightTimerStopInFlight = false;
+    let lastObservedDate = extractDateFromDateTime(new Date());
+
+    async function refreshFromStorage() {
+        if (refreshFromStoragePromise) {
+            return refreshFromStoragePromise;
+        }
+
+        refreshFromStoragePromise = (async () => {
+            await loadAppState();
+            refreshUI();
+            syncRestoredRunningTimer(getActivitiesEnabled());
+            refreshActiveTaskColor(getTaskState());
+            refreshCurrentGapHighlight();
+        })();
+
+        try {
+            await refreshFromStoragePromise;
+        } finally {
+            refreshFromStoragePromise = null;
+        }
+    }
+
+    function refreshFromExternalChange() {
+        refreshFromStorage().catch((err) => {
+            logger.error('Failed to refresh tasks after external change:', err);
+        });
+    }
+
+    function syncOnFocus() {
+        triggerSync({ respectCooldown: true }).catch((err) => {
+            logger.error('Failed to sync tasks after window focus:', err);
+        });
+    }
+
+    function startClockTickLoop() {
+        activeTaskColorInterval = setInterval(() => {
+            const now = new Date();
+            const currentDate = extractDateFromDateTime(now);
+
+            if (currentDate !== lastObservedDate) {
+                lastObservedDate = currentDate;
+
+                if (getActivitiesEnabled() && getRunningActivity() && !midnightTimerStopInFlight) {
+                    midnightTimerStopInFlight = true;
+                    const midnightBoundary = new Date(now);
+                    midnightBoundary.setHours(0, 0, 0, 0);
+
+                    stopTimerAt(midnightBoundary.toISOString())
+                        .then((result) => {
+                            if (result?.success) {
+                                syncTimerFormState();
+                                refreshTaskDisplays();
+                            }
+                        })
+                        .catch((error) => {
+                            logger.error('Failed to stop running timer at midnight:', error);
+                        })
+                        .finally(() => {
+                            midnightTimerStopInFlight = false;
+                        });
+                }
+            }
+
+            refreshActiveTaskColor(getTaskState(), now);
+            refreshCurrentGapHighlight(now);
+            refreshStartTimeField();
+        }, 1000);
+    }
+
+    function start({ signal }) {
+        unsubscribeSyncStatus = onSyncStatusChange((status) => {
+            updateSyncStatusUI(status);
+            if (status === 'synced') {
+                refreshFromStorage().catch((err) => {
+                    logger.error('Failed to refresh tasks after sync:', err);
+                });
+            }
+        });
+
+        document.addEventListener(
+            'visibilitychange',
+            () => {
+                if (!document.hidden) {
+                    refreshFromExternalChange();
+                }
+            },
+            { signal }
+        );
+
+        window.addEventListener('focus', syncOnFocus, { signal });
+        startClockTickLoop();
+        window.addEventListener(
+            'beforeunload',
+            () => {
+                if (activeTaskColorInterval) {
+                    clearInterval(activeTaskColorInterval);
+                }
+            },
+            { signal }
+        );
+    }
+
+    function stop() {
+        if (unsubscribeSyncStatus) {
+            unsubscribeSyncStatus();
+            unsubscribeSyncStatus = null;
+        }
+        if (activeTaskColorInterval) {
+            clearInterval(activeTaskColorInterval);
+            activeTaskColorInterval = null;
+        }
+    }
+
+    return {
+        refreshFromStorage,
+        start,
+        stop
+    };
+}

--- a/public/js/app-lifecycle.js
+++ b/public/js/app-lifecycle.js
@@ -11,8 +11,6 @@ export function createRoomSessionLifecycle({
     refreshStartTimeField,
     getRunningActivity,
     stopTimerAt,
-    syncTimerFormState,
-    refreshTaskDisplays,
     onSyncStatusChange,
     updateSyncStatusUI,
     triggerSync,
@@ -72,8 +70,12 @@ export function createRoomSessionLifecycle({
                     stopTimerAt(midnightBoundary.toISOString())
                         .then((result) => {
                             if (result?.success) {
-                                syncTimerFormState();
-                                refreshTaskDisplays();
+                                refreshFromStorage().catch((err) => {
+                                    logger.error(
+                                        'Failed to refresh tasks after midnight timer stop:',
+                                        err
+                                    );
+                                });
                             }
                         })
                         .catch((error) => {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37,10 +37,9 @@ import {
     syncActivitiesUI,
     renderTodayActivities,
     handleActivityAwareFormSubmit,
-    handleActivityListClick,
-    initializeTimerUI,
-    syncTimerFormState
+    handleActivityListClick
 } from './activities/ui-handlers.js';
+import { initializeTimerUI, syncTimerFormState } from './activities/timer-ui.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,7 +3,6 @@ import {
     updateTaskState,
     getTaskState,
     resetAllConfirmingDeleteFlags,
-    getSuggestedStartTime,
     getSortedUnscheduledTasks
 } from './tasks/manager.js';
 import { initializeModalEventListeners } from './modal-manager.js';
@@ -21,6 +20,7 @@ import {
     renderTasks,
     renderUnscheduledTasks,
     refreshUI,
+    getSuggestedFormStartTime,
     updateStartTimeField,
     initializePageEventListeners,
     refreshStartTimeField,
@@ -303,8 +303,8 @@ async function initAndBootApp(roomCode) {
         }
     }
 
-    const suggested = getSuggestedStartTime();
-    logger.debug('initAndBootApp - getSuggestedStartTime() returned:', suggested);
+    const suggested = getSuggestedFormStartTime();
+    logger.debug('initAndBootApp - getSuggestedFormStartTime() returned:', suggested);
     updateStartTimeField(suggested, true);
 
     focusTaskDescriptionInput();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -34,17 +34,13 @@ import {
     getRunningActivity,
     stopTimerAt
 } from './activities/manager.js';
+import { syncActivitiesUI, renderTodayActivities } from './activities/ui-handlers.js';
+import { syncTimerFormState } from './activities/timer-ui.js';
 import {
-    syncActivitiesUI,
-    renderTodayActivities,
-    refreshTodayActivitySummary,
-    handleActivityAwareFormSubmit,
-    handleActivityListClick,
-    handleActivityListSubmit,
-    handleActivityListKeydown,
-    handleActivityListInput
-} from './activities/ui-handlers.js';
-import { initializeTimerUI, syncTimerFormState } from './activities/timer-ui.js';
+    createActivityAppCallbacks,
+    initializeActivityUi,
+    syncRestoredRunningTimer
+} from './activities/app-wiring.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';
@@ -71,23 +67,6 @@ let refreshFromStoragePromise = null;
 
 /** @type {() => void} */
 let refreshTaskDisplays = () => {};
-
-function syncTimerUiFromLoadedState() {
-    if (!isActivitiesEnabled()) {
-        return;
-    }
-
-    const runningActivity = getRunningActivity();
-    if (runningActivity) {
-        const activityRadio = document.getElementById('activity');
-        if (activityRadio instanceof HTMLInputElement && !activityRadio.checked) {
-            activityRadio.checked = true;
-            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
-        }
-    }
-
-    syncTimerFormState();
-}
 
 function refreshTaxonomyUI() {
     refreshTaskCategoryDropdownUI();
@@ -133,7 +112,7 @@ async function refreshFromStorage() {
     refreshFromStoragePromise = (async () => {
         await loadAppState();
         refreshUI();
-        syncTimerUiFromLoadedState();
+        syncRestoredRunningTimer(isActivitiesEnabled());
         refreshActiveTaskColor(getTaskState());
         refreshCurrentGapHighlight();
     })();
@@ -192,34 +171,26 @@ async function initAndBootApp(roomCode) {
         refreshCurrentGapHighlight();
     };
 
-    const appCallbacks = {
-        onTaskFormSubmit: async (formElement) => {
-            await handleActivityAwareFormSubmit(formElement, {
-                activitiesEnabled: isActivitiesEnabled(),
-                resetTaskFormPreviewState,
-                initializeTaskTypeToggle,
-                focusTaskDescriptionInput,
-                handleTaskSubmit: async (taskFormElement) => {
-                    const taskData = extractTaskFormData(taskFormElement);
-                    if (!taskData) {
-                        focusTaskDescriptionInput();
-                        return;
-                    }
-                    const overlapEl = document.getElementById('overlap-warning');
-                    const reschedulePreApproved = !!(overlapEl && overlapEl.textContent.trim());
-                    await handleAddTaskProcess(taskFormElement, taskData, {
-                        reschedulePreApproved
-                    });
-                }
-            });
-        },
-        onGlobalClick: (event) => {
-            handleActivityListClick(event.target, {
-                refreshUI,
-                resetAllConfirmingDeleteFlags
+    const appCallbacks = createActivityAppCallbacks({
+        getActivitiesEnabled: () => isActivitiesEnabled(),
+        refreshUI,
+        resetAllConfirmingDeleteFlags,
+        focusTaskDescriptionInput,
+        resetTaskFormPreviewState,
+        initializeTaskTypeToggle,
+        handleTaskSubmit: async (taskFormElement) => {
+            const taskData = extractTaskFormData(taskFormElement);
+            if (!taskData) {
+                focusTaskDescriptionInput();
+                return;
+            }
+            const overlapEl = document.getElementById('overlap-warning');
+            const reschedulePreApproved = !!(overlapEl && overlapEl.textContent.trim());
+            await handleAddTaskProcess(taskFormElement, taskData, {
+                reschedulePreApproved
             });
         }
-    };
+    });
 
     // Initialize event listeners
     const taskFormElement = getTaskFormElement();
@@ -281,37 +252,16 @@ async function initAndBootApp(roomCode) {
 
     initializePageEventListeners(appCallbacks, taskFormElement);
     initializeTaskTypeToggle();
-    initializeTimerUI({
-        refreshUI: refreshTaskDisplays,
-        refreshActivitySummary: () => refreshTodayActivitySummary(isActivitiesEnabled())
+    initializeActivityUi({
+        signal,
+        refreshUI,
+        refreshTaskDisplays,
+        getActivitiesEnabled: () => isActivitiesEnabled()
     });
     startRealTimeClock();
     initializeUnscheduledTaskListEventListeners(unscheduledTaskEventCallbacks);
     initializeModalEventListeners(unscheduledTaskEventCallbacks);
     initializeClearTasksHandlers();
-
-    const activityListElement = document.getElementById('activity-list');
-    if (activityListElement) {
-        activityListElement.addEventListener(
-            'submit',
-            (event) => {
-                handleActivityListSubmit(event, {
-                    refreshUI
-                });
-            },
-            { signal }
-        );
-        activityListElement.addEventListener(
-            'keydown',
-            (event) => {
-                handleActivityListKeydown(event, {
-                    refreshUI
-                });
-            },
-            { signal }
-        );
-        activityListElement.addEventListener('input', handleActivityListInput, { signal });
-    }
 
     // Wire up sync status indicator + refresh after sync
     unsubscribeSyncStatus = onSyncStatusChange((status) => {
@@ -351,13 +301,7 @@ async function initAndBootApp(roomCode) {
     refreshTaskDisplays();
     const restoredRunningActivity = isActivitiesEnabled() ? getRunningActivity() : null;
     if (restoredRunningActivity) {
-        const activityRadio = document.getElementById('activity');
-        if (activityRadio instanceof HTMLInputElement) {
-            activityRadio.checked = true;
-            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
-        }
-
-        syncTimerUiFromLoadedState();
+        syncRestoredRunningTimer(isActivitiesEnabled());
 
         const activityToggle = document.getElementById('activity-toggle-option');
         if (activityToggle) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37,7 +37,10 @@ import {
     syncActivitiesUI,
     renderTodayActivities,
     handleActivityAwareFormSubmit,
-    handleActivityListClick
+    handleActivityListClick,
+    handleActivityListSubmit,
+    handleActivityListKeydown,
+    handleActivityListInput
 } from './activities/ui-handlers.js';
 import { initializeTimerUI, syncTimerFormState } from './activities/timer-ui.js';
 import { prepareStorage, loadTasks } from './storage.js';
@@ -223,6 +226,15 @@ async function initAndBootApp(roomCode) {
                 addTaskBtn,
                 () => getTaskState().filter((t) => t.type === 'scheduled'),
                 {
+                    shouldWarn: () => {
+                        const selectedTaskType = taskFormElement?.querySelector(
+                            'input[name="task-type"]:checked'
+                        );
+                        return (
+                            selectedTaskType instanceof HTMLInputElement &&
+                            selectedTaskType.value !== 'activity'
+                        );
+                    },
                     defaultButtonHTML: '<i class="fa-regular fa-plus mr-2"></i>Add Task',
                     defaultButtonClasses: addTaskBtn.className,
                     overlapButtonHTML:
@@ -254,6 +266,29 @@ async function initAndBootApp(roomCode) {
     initializeUnscheduledTaskListEventListeners(unscheduledTaskEventCallbacks);
     initializeModalEventListeners(unscheduledTaskEventCallbacks);
     initializeClearTasksHandlers();
+
+    const activityListElement = document.getElementById('activity-list');
+    if (activityListElement) {
+        activityListElement.addEventListener(
+            'submit',
+            (event) => {
+                handleActivityListSubmit(event, {
+                    refreshUI
+                });
+            },
+            { signal }
+        );
+        activityListElement.addEventListener(
+            'keydown',
+            (event) => {
+                handleActivityListKeydown(event, {
+                    refreshUI
+                });
+            },
+            { signal }
+        );
+        activityListElement.addEventListener('input', handleActivityListInput, { signal });
+    }
 
     // Wire up sync status indicator + refresh after sync
     unsubscribeSyncStatus = onSyncStatusChange((status) => {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -72,6 +72,23 @@ let refreshFromStoragePromise = null;
 /** @type {() => void} */
 let refreshTaskDisplays = () => {};
 
+function syncTimerUiFromLoadedState() {
+    if (!isActivitiesEnabled()) {
+        return;
+    }
+
+    const runningActivity = getRunningActivity();
+    if (runningActivity) {
+        const activityRadio = document.getElementById('activity');
+        if (activityRadio instanceof HTMLInputElement && !activityRadio.checked) {
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+    }
+
+    syncTimerFormState();
+}
+
 function refreshTaxonomyUI() {
     refreshTaskCategoryDropdownUI();
     refreshTaskDisplays();
@@ -116,6 +133,7 @@ async function refreshFromStorage() {
     refreshFromStoragePromise = (async () => {
         await loadAppState();
         refreshUI();
+        syncTimerUiFromLoadedState();
         refreshActiveTaskColor(getTaskState());
         refreshCurrentGapHighlight();
     })();
@@ -331,14 +349,15 @@ async function initAndBootApp(roomCode) {
 
     // Initial render
     refreshTaskDisplays();
-    if (isActivitiesEnabled() && getRunningActivity()) {
+    const restoredRunningActivity = isActivitiesEnabled() ? getRunningActivity() : null;
+    if (restoredRunningActivity) {
         const activityRadio = document.getElementById('activity');
         if (activityRadio instanceof HTMLInputElement) {
             activityRadio.checked = true;
             activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
         }
 
-        syncTimerFormState();
+        syncTimerUiFromLoadedState();
 
         const activityToggle = document.getElementById('activity-toggle-option');
         if (activityToggle) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -31,7 +31,8 @@ import {
 import {
     loadActivitiesState,
     loadRunningActivity,
-    getRunningActivity
+    getRunningActivity,
+    stopTimerAt
 } from './activities/manager.js';
 import {
     syncActivitiesUI,
@@ -49,7 +50,7 @@ import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';
 import { initializeSettingsModalListeners, renderSettingsContent } from './settings-renderer.js';
 import { refreshTaskCategoryDropdownUI } from './settings/taxonomy-settings.js';
-import { logger } from './utils.js';
+import { logger, extractDateFromDateTime } from './utils.js';
 import { createScheduledTaskCallbacks } from './tasks/scheduled-handlers.js';
 import { createUnscheduledTaskCallbacks } from './tasks/unscheduled-handlers.js';
 import { handleAddTaskProcess } from './tasks/add-handler.js';
@@ -355,9 +356,38 @@ async function initAndBootApp(roomCode) {
     focusTaskDescriptionInput();
 
     // Active task color refresh interval
+    let lastObservedDate = extractDateFromDateTime(new Date());
+    let midnightTimerStopInFlight = false;
     const activeTaskColorInterval = setInterval(() => {
-        refreshActiveTaskColor(getTaskState());
-        refreshCurrentGapHighlight();
+        const now = new Date();
+        const currentDate = extractDateFromDateTime(now);
+
+        if (currentDate !== lastObservedDate) {
+            lastObservedDate = currentDate;
+
+            if (isActivitiesEnabled() && getRunningActivity() && !midnightTimerStopInFlight) {
+                midnightTimerStopInFlight = true;
+                const midnightBoundary = new Date(now);
+                midnightBoundary.setHours(0, 0, 0, 0);
+
+                stopTimerAt(midnightBoundary.toISOString())
+                    .then((result) => {
+                        if (result?.success) {
+                            syncTimerFormState();
+                            refreshTaskDisplays();
+                        }
+                    })
+                    .catch((error) => {
+                        logger.error('Failed to stop running timer at midnight:', error);
+                    })
+                    .finally(() => {
+                        midnightTimerStopInFlight = false;
+                    });
+            }
+        }
+
+        refreshActiveTaskColor(getTaskState(), now);
+        refreshCurrentGapHighlight(now);
         refreshStartTimeField();
     }, 1000);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28,12 +28,18 @@ import {
     startRealTimeClock,
     initializeUnscheduledTaskListEventListeners
 } from './dom-renderer.js';
-import { loadActivitiesState } from './activities/manager.js';
+import {
+    loadActivitiesState,
+    loadRunningActivity,
+    getRunningActivity
+} from './activities/manager.js';
 import {
     syncActivitiesUI,
     renderTodayActivities,
     handleActivityAwareFormSubmit,
-    handleActivityListClick
+    handleActivityListClick,
+    initializeTimerUI,
+    syncTimerFormState
 } from './activities/ui-handlers.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
@@ -94,6 +100,7 @@ async function loadAppState() {
     await loadTasksIntoState();
     if (isActivitiesEnabled()) {
         await loadActivitiesState();
+        await loadRunningActivity();
     }
 }
 
@@ -243,6 +250,7 @@ async function initAndBootApp(roomCode) {
 
     initializePageEventListeners(appCallbacks, taskFormElement);
     initializeTaskTypeToggle();
+    initializeTimerUI({ refreshUI: refreshTaskDisplays });
     startRealTimeClock();
     initializeUnscheduledTaskListEventListeners(unscheduledTaskEventCallbacks);
     initializeModalEventListeners(unscheduledTaskEventCallbacks);
@@ -284,6 +292,17 @@ async function initAndBootApp(roomCode) {
 
     // Initial render
     refreshTaskDisplays();
+    if (isActivitiesEnabled() && getRunningActivity()) {
+        syncTimerFormState();
+
+        const activityToggle = document.getElementById('activity-toggle-option');
+        if (activityToggle) {
+            activityToggle.classList.add('ring-2', 'ring-sky-400/50');
+            setTimeout(() => {
+                activityToggle.classList.remove('ring-2', 'ring-sky-400/50');
+            }, 3000);
+        }
+    }
 
     const suggested = getSuggestedStartTime();
     logger.debug('initAndBootApp - getSuggestedStartTime() returned:', suggested);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -35,7 +35,6 @@ import {
     stopTimerAt
 } from './activities/manager.js';
 import { syncActivitiesUI, renderTodayActivities } from './activities/ui-handlers.js';
-import { syncTimerFormState } from './activities/timer-ui.js';
 import {
     createActivityAppCallbacks,
     initializeActivityUi,
@@ -180,8 +179,6 @@ async function initAndBootApp(roomCode) {
         refreshStartTimeField,
         getRunningActivity,
         stopTimerAt,
-        syncTimerFormState,
-        refreshTaskDisplays,
         onSyncStatusChange,
         updateSyncStatusUI,
         triggerSync,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -292,6 +292,12 @@ async function initAndBootApp(roomCode) {
     // Initial render
     refreshTaskDisplays();
     if (isActivitiesEnabled() && getRunningActivity()) {
+        const activityRadio = document.getElementById('activity');
+        if (activityRadio instanceof HTMLInputElement) {
+            activityRadio.checked = true;
+            activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+
         syncTimerFormState();
 
         const activityToggle = document.getElementById('activity-toggle-option');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -41,12 +41,13 @@ import {
     initializeActivityUi,
     syncRestoredRunningTimer
 } from './activities/app-wiring.js';
+import { createRoomSessionLifecycle } from './app-lifecycle.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';
 import { initializeSettingsModalListeners, renderSettingsContent } from './settings-renderer.js';
 import { refreshTaskCategoryDropdownUI } from './settings/taxonomy-settings.js';
-import { logger, extractDateFromDateTime } from './utils.js';
+import { logger } from './utils.js';
 import { createScheduledTaskCallbacks } from './tasks/scheduled-handlers.js';
 import { createUnscheduledTaskCallbacks } from './tasks/unscheduled-handlers.js';
 import { handleAddTaskProcess } from './tasks/add-handler.js';
@@ -59,11 +60,8 @@ import { COUCHDB_URL } from './config.js';
 /** @type {AbortController|null} */
 let appLifecycleAbortController = null;
 
-/** @type {(() => void) | null} */
-let unsubscribeSyncStatus = null;
-
-/** @type {Promise<void> | null} */
-let refreshFromStoragePromise = null;
+/** @type {{ refreshFromStorage: () => Promise<void>, start: ({ signal }: { signal: AbortSignal }) => void, stop: () => void } | null} */
+let roomSessionLifecycle = null;
 
 /** @type {() => void} */
 let refreshTaskDisplays = () => {};
@@ -104,41 +102,20 @@ async function loadAppState() {
     }
 }
 
-async function refreshFromStorage() {
-    if (refreshFromStoragePromise) {
-        return refreshFromStoragePromise;
-    }
-
-    refreshFromStoragePromise = (async () => {
-        await loadAppState();
-        refreshUI();
-        syncRestoredRunningTimer(isActivitiesEnabled());
-        refreshActiveTaskColor(getTaskState());
-        refreshCurrentGapHighlight();
-    })();
-
-    try {
-        await refreshFromStoragePromise;
-    } finally {
-        refreshFromStoragePromise = null;
-    }
-}
-
 /**
  * Initialize storage and boot the main app UI.
  * @param {string} roomCode
  */
 async function initAndBootApp(roomCode) {
+    if (roomSessionLifecycle) {
+        roomSessionLifecycle.stop();
+        roomSessionLifecycle = null;
+    }
     if (appLifecycleAbortController) {
         appLifecycleAbortController.abort();
     }
     appLifecycleAbortController = new AbortController();
     const { signal } = appLifecycleAbortController;
-
-    if (unsubscribeSyncStatus) {
-        unsubscribeSyncStatus();
-        unsubscribeSyncStatus = null;
-    }
 
     showMainApp(roomCode);
 
@@ -190,6 +167,25 @@ async function initAndBootApp(roomCode) {
                 reschedulePreApproved
             });
         }
+    });
+
+    roomSessionLifecycle = createRoomSessionLifecycle({
+        loadAppState,
+        refreshUI,
+        getActivitiesEnabled: () => isActivitiesEnabled(),
+        syncRestoredRunningTimer,
+        getTaskState,
+        refreshActiveTaskColor,
+        refreshCurrentGapHighlight,
+        refreshStartTimeField,
+        getRunningActivity,
+        stopTimerAt,
+        syncTimerFormState,
+        refreshTaskDisplays,
+        onSyncStatusChange,
+        updateSyncStatusUI,
+        triggerSync,
+        logger
     });
 
     // Initialize event listeners
@@ -262,40 +258,7 @@ async function initAndBootApp(roomCode) {
     initializeUnscheduledTaskListEventListeners(unscheduledTaskEventCallbacks);
     initializeModalEventListeners(unscheduledTaskEventCallbacks);
     initializeClearTasksHandlers();
-
-    // Wire up sync status indicator + refresh after sync
-    unsubscribeSyncStatus = onSyncStatusChange((status) => {
-        updateSyncStatusUI(status);
-        if (status === 'synced') {
-            refreshFromStorage().catch((err) => {
-                logger.error('Failed to refresh tasks after sync:', err);
-            });
-        }
-    });
-
-    const refreshFromExternalChange = () => {
-        refreshFromStorage().catch((err) => {
-            logger.error('Failed to refresh tasks after external change:', err);
-        });
-    };
-
-    const syncOnFocus = () => {
-        triggerSync({ respectCooldown: true }).catch((err) => {
-            logger.error('Failed to sync tasks after window focus:', err);
-        });
-    };
-
-    document.addEventListener(
-        'visibilitychange',
-        () => {
-            if (!document.hidden) {
-                refreshFromExternalChange();
-            }
-        },
-        { signal }
-    );
-
-    window.addEventListener('focus', syncOnFocus, { signal });
+    roomSessionLifecycle.start({ signal });
 
     // Initial render
     refreshTaskDisplays();
@@ -317,50 +280,6 @@ async function initAndBootApp(roomCode) {
     updateStartTimeField(suggested, true);
 
     focusTaskDescriptionInput();
-
-    // Active task color refresh interval
-    let lastObservedDate = extractDateFromDateTime(new Date());
-    let midnightTimerStopInFlight = false;
-    const activeTaskColorInterval = setInterval(() => {
-        const now = new Date();
-        const currentDate = extractDateFromDateTime(now);
-
-        if (currentDate !== lastObservedDate) {
-            lastObservedDate = currentDate;
-
-            if (isActivitiesEnabled() && getRunningActivity() && !midnightTimerStopInFlight) {
-                midnightTimerStopInFlight = true;
-                const midnightBoundary = new Date(now);
-                midnightBoundary.setHours(0, 0, 0, 0);
-
-                stopTimerAt(midnightBoundary.toISOString())
-                    .then((result) => {
-                        if (result?.success) {
-                            syncTimerFormState();
-                            refreshTaskDisplays();
-                        }
-                    })
-                    .catch((error) => {
-                        logger.error('Failed to stop running timer at midnight:', error);
-                    })
-                    .finally(() => {
-                        midnightTimerStopInFlight = false;
-                    });
-            }
-        }
-
-        refreshActiveTaskColor(getTaskState(), now);
-        refreshCurrentGapHighlight(now);
-        refreshStartTimeField();
-    }, 1000);
-
-    window.addEventListener(
-        'beforeunload',
-        () => {
-            clearInterval(activeTaskColorInterval);
-        },
-        { signal }
-    );
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -36,6 +36,7 @@ import {
 import {
     syncActivitiesUI,
     renderTodayActivities,
+    refreshTodayActivitySummary,
     handleActivityAwareFormSubmit,
     handleActivityListClick,
     handleActivityListSubmit,
@@ -261,7 +262,10 @@ async function initAndBootApp(roomCode) {
 
     initializePageEventListeners(appCallbacks, taskFormElement);
     initializeTaskTypeToggle();
-    initializeTimerUI({ refreshUI: refreshTaskDisplays });
+    initializeTimerUI({
+        refreshUI: refreshTaskDisplays,
+        refreshActivitySummary: () => refreshTodayActivitySummary(isActivitiesEnabled())
+    });
     startRealTimeClock();
     initializeUnscheduledTaskListEventListeners(unscheduledTaskEventCallbacks);
     initializeModalEventListeners(unscheduledTaskEventCallbacks);

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -462,10 +462,15 @@ function handleUnscheduledTaskListClick(event) {
     const taskCard = /** @type {HTMLElement} */ (target.closest('.task-card'));
 
     if (!taskCard || !globalUnscheduledTaskCallbacks) return;
+    if (target.closest('button[disabled]')) return;
 
     const taskId = taskCard.dataset.taskId;
 
-    if (target.closest('.btn-schedule-task')) {
+    if (target.closest('.btn-start-unscheduled-timer')) {
+        if (globalUnscheduledTaskCallbacks.onStartTimerFromUnscheduledTask && taskId) {
+            globalUnscheduledTaskCallbacks.onStartTimerFromUnscheduledTask(taskId);
+        }
+    } else if (target.closest('.btn-schedule-task')) {
         if (globalUnscheduledTaskCallbacks.onScheduleUnscheduledTask && taskId) {
             const taskName = taskCard.dataset.taskName || 'Task';
             const estDurationText = taskCard.dataset.taskEstDuration || 'N/A';

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -187,6 +187,8 @@ export function initializeTaskTypeToggle() {
 
         addTaskButton.className = `${FORM_SUBMIT_BUTTON_BASE_CLASSES} ${config.submitButtonClasses}`;
         addTaskButton.innerHTML = config.submitButtonHtml;
+        addTaskButton.dataset.defaultButtonHtml = config.submitButtonHtml;
+        addTaskButton.dataset.defaultButtonClasses = addTaskButton.className;
         descriptionInput.className = FORM_INPUT_BASE_CLASSES;
         descriptionInput.setAttribute('placeholder', config.descriptionPlaceholder);
         setInputTheme(config.inputTheme);

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -120,6 +120,7 @@ export function initializeTaskTypeToggle() {
     const timeInputs = document.getElementById('time-inputs');
     const priorityInput = document.getElementById('priority-input');
     const addTaskButton = document.querySelector('#task-form button[type="submit"]');
+    const startTimerButton = document.getElementById('start-timer-btn');
     const descriptionInput = document.querySelector('input[name="description"]');
     const startTimeInput = document.querySelector('input[name="start-time"]');
     const durationHoursInput = document.querySelector('input[name="duration-hours"]');
@@ -164,6 +165,9 @@ export function initializeTaskTypeToggle() {
         descriptionInput.className = FORM_INPUT_BASE_CLASSES;
         descriptionInput.setAttribute('placeholder', config.descriptionPlaceholder);
         setInputTheme(config.inputTheme);
+        if (startTimerButton instanceof HTMLElement) {
+            startTimerButton.classList.toggle('hidden', mode !== 'activity');
+        }
     };
 
     if (

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -114,6 +114,7 @@ export function startRealTimeClock() {
 }
 
 export function initializeTaskTypeToggle() {
+    const taskForm = document.getElementById('task-form');
     const scheduledRadio = document.getElementById('scheduled');
     const unscheduledRadio = document.getElementById('unscheduled');
     const activityRadio = document.getElementById('activity');
@@ -165,6 +166,9 @@ export function initializeTaskTypeToggle() {
         descriptionInput.className = FORM_INPUT_BASE_CLASSES;
         descriptionInput.setAttribute('placeholder', config.descriptionPlaceholder);
         setInputTheme(config.inputTheme);
+        if (taskForm instanceof HTMLElement) {
+            taskForm.classList.toggle('task-form--activity', mode === 'activity');
+        }
         if (startTimerButton instanceof HTMLElement) {
             startTimerButton.classList.toggle('hidden', mode !== 'activity');
         }

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -3,6 +3,7 @@ import { getTaskState, getSortedUnscheduledTasks, getSuggestedStartTime } from '
 import { isScheduledTask } from './tasks/validators.js';
 import { isActivitiesEnabled } from './settings-manager.js';
 import { renderTodayActivities } from './activities/ui-handlers.js';
+import { getSuggestedActivityStartTime } from './activities/manager.js';
 import {
     getTaskFormElement,
     computeEndTimePreview,
@@ -144,6 +145,29 @@ export function initializeTaskTypeToggle() {
         );
     };
 
+    const applyActivityStartTimeDefault = () => {
+        if (!(startTimeInput instanceof HTMLInputElement)) {
+            return;
+        }
+
+        const latestActivityEndTime = getSuggestedActivityStartTime();
+        if (!latestActivityEndTime) {
+            return;
+        }
+
+        const genericSuggestedTime = getSuggestedStartTime();
+        const shouldUseActivityDefault =
+            !startTimeInput.value ||
+            startTimeInput.value === genericSuggestedTime ||
+            startTimeAutoUpdate.isEnabled();
+
+        if (!shouldUseActivityDefault) {
+            return;
+        }
+
+        updateStartTimeField(latestActivityEndTime, true);
+    };
+
     const applyTaskFormMode = (mode) => {
         const config = TASK_FORM_MODE_CONFIG[mode];
         if (!config) {
@@ -171,6 +195,9 @@ export function initializeTaskTypeToggle() {
         }
         if (startTimerButton instanceof HTMLElement) {
             startTimerButton.classList.toggle('hidden', mode !== 'activity');
+        }
+        if (mode === 'activity') {
+            applyActivityStartTimeDefault();
         }
     };
 
@@ -574,7 +601,17 @@ export function refreshUI() {
     if (isActivitiesEnabled()) {
         renderTodayActivities(true);
     }
-    updateStartTimeField(getSuggestedStartTime(), true);
+    updateStartTimeField(getSuggestedFormStartTime(), true);
+}
+
+export function getSuggestedFormStartTime() {
+    const activityRadio = document.getElementById('activity');
+
+    if (activityRadio instanceof HTMLInputElement && activityRadio.checked) {
+        return getSuggestedActivityStartTime() || getSuggestedStartTime();
+    }
+
+    return getSuggestedStartTime();
 }
 
 // --- Start Time Field Management ---

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -285,6 +285,14 @@ export async function deleteActivity(id) {
 }
 
 /**
+ * Delete a single config document by id.
+ * @param {string} id - Config document id
+ */
+export async function deleteConfig(id) {
+    await deleteTypedDoc(id, DOC_TYPES.CONFIG, 'deleteConfig');
+}
+
+/**
  * Load all tasks from PouchDB.
  * Maps _id back to id and strips _rev before returning.
  * @returns {Promise<Object[]>} Array of task objects

--- a/public/js/tasks/form-utils.js
+++ b/public/js/tasks/form-utils.js
@@ -421,6 +421,7 @@ export function setupOverlapWarning(
 ) {
     const {
         excludeTaskId = null,
+        shouldWarn = () => true,
         defaultButtonHTML = buttonElement.innerHTML,
         defaultButtonClasses = buttonElement.className,
         overlapButtonHTML = defaultButtonHTML,
@@ -431,6 +432,18 @@ export function setupOverlapWarning(
     buttonElement.dataset.defaultButtonClasses = defaultButtonClasses;
 
     function updateWarning() {
+        const currentDefaultButtonHTML =
+            buttonElement.dataset.defaultButtonHtml || defaultButtonHTML;
+        const currentDefaultButtonClasses =
+            buttonElement.dataset.defaultButtonClasses || defaultButtonClasses;
+
+        if (!shouldWarn()) {
+            warningElement.textContent = '';
+            buttonElement.innerHTML = currentDefaultButtonHTML;
+            buttonElement.className = currentDefaultButtonClasses;
+            return;
+        }
+
         const result = computeOverlapPreview(
             startTimeInput.value,
             hoursInput.value,
@@ -445,8 +458,8 @@ export function setupOverlapWarning(
             buttonElement.className = overlapButtonClasses;
         } else {
             warningElement.textContent = '';
-            buttonElement.innerHTML = defaultButtonHTML;
-            buttonElement.className = defaultButtonClasses;
+            buttonElement.innerHTML = currentDefaultButtonHTML;
+            buttonElement.className = currentDefaultButtonClasses;
         }
     }
 

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -1180,6 +1180,21 @@ export function deleteUnscheduledTask(taskId) {
     return deleteTask(taskIndex, tasks[taskIndex].confirmingDelete);
 }
 
+export function consumeUnscheduledTask(taskId) {
+    const taskIndex = tasks.findIndex((t) => t.id === taskId && t.type === 'unscheduled');
+    if (taskIndex === -1) {
+        return { success: false, reason: 'Unscheduled task not found.' };
+    }
+
+    const taskToConsume = tasks[taskIndex];
+    tasks.splice(taskIndex, 1);
+    resetAllUIFlags();
+    invalidateTaskCaches();
+    deleteTaskFromStorage(taskToConsume.id);
+
+    return { success: true, task: taskToConsume };
+}
+
 export function deleteAllTasks() {
     if (tasks.length === 0) return { success: true, tasksDeleted: 0 };
     const num = tasks.length;

--- a/public/js/tasks/unscheduled-handlers.js
+++ b/public/js/tasks/unscheduled-handlers.js
@@ -18,6 +18,19 @@ import { refreshUI } from '../dom-renderer.js';
 import { onTaskEdited, onTaskDeleted, onTaskScheduled } from '../app-coordinator.js';
 import { calculateHoursAndMinutes, logger } from '../utils.js';
 import { getThemeForTaskId } from './confirmation-helpers.js';
+import { handleStartTimer } from '../activities/handlers.js';
+import { syncTimerFormState } from '../activities/timer-ui.js';
+
+function activateActivityMode() {
+    const activityRadio = document.getElementById('activity');
+    if (!(activityRadio instanceof HTMLInputElement) || activityRadio.checked) {
+        return;
+    }
+
+    activityRadio.checked = true;
+    activityRadio.dispatchEvent(new Event('change', { bubbles: true }));
+    syncTimerFormState();
+}
 
 export function handleScheduleUnscheduledTask(taskId) {
     const task = getTaskById(taskId);
@@ -33,6 +46,31 @@ export function handleScheduleUnscheduledTask(taskId) {
             getSuggestedStartTime()
         );
     } else logger.error(`Task to schedule not found: ${taskId}`);
+}
+
+export async function handleStartTimerFromUnscheduledTask(taskId) {
+    const task = getTaskById(taskId);
+    if (!task || task.type !== 'unscheduled') {
+        logger.error(`Unscheduled task not found for timer start: ${taskId}`);
+        return;
+    }
+
+    if (task.status === 'completed') {
+        showAlert('This task is already completed and cannot be started as a timer.', 'indigo');
+        return;
+    }
+
+    const result = await handleStartTimer({
+        description: task.description,
+        category: task.category || null,
+        source: 'auto',
+        sourceTaskId: task.id
+    });
+
+    if (result?.success) {
+        activateActivityMode();
+        refreshUI();
+    }
 }
 
 export function handleEditUnscheduledTask(taskId) {
@@ -146,6 +184,7 @@ export function handleToggleCompleteUnscheduledTask(taskId) {
 export function createUnscheduledTaskCallbacks() {
     return {
         onScheduleUnscheduledTask: handleScheduleUnscheduledTask,
+        onStartTimerFromUnscheduledTask: handleStartTimerFromUnscheduledTask,
         onEditUnscheduledTask: handleEditUnscheduledTask,
         onDeleteUnscheduledTask: handleDeleteUnscheduledTask,
         onConfirmScheduleTask: handleConfirmScheduleTask,

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -1,6 +1,7 @@
 import { calculateHoursAndMinutes, logger } from '../utils.js';
 import { toggleUnscheduledTaskInlineEdit } from './form-utils.js';
 import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
+import { getRunningActivity } from '../activities/manager.js';
 
 // --- DOM Element Getters ---
 export function getUnscheduledTaskListElement() {
@@ -66,12 +67,19 @@ function getDurationText(estDuration) {
  * @returns {string} HTML string for the display view
  */
 function createTaskDisplayHTML(task, priorityClasses, durationText, isCompleted) {
-    const completedClass = isCompleted ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer';
+    const runningActivity = getRunningActivity();
+    const isLinkedToRunningTimer = runningActivity?.sourceTaskId === task.id;
+    const isDisabled = isCompleted || isLinkedToRunningTimer;
+    const completedClass = isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer';
     const completedTitle = isCompleted ? 'Task already completed' : 'Toggle complete status';
     const checkIcon = isCompleted ? 'fa-check-square text-indigo-400' : 'fa-square text-slate-500';
     const textStrike = isCompleted ? 'line-through opacity-70' : '';
     const priorityLabel = task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
-    const disabledAttr = isCompleted ? 'disabled class="opacity-50 cursor-not-allowed"' : '';
+    const disabledAttr = isDisabled ? 'disabled' : '';
+    const disabledButtonClasses = isDisabled ? ' opacity-50 cursor-not-allowed' : '';
+    const inProgressBadge = isLinkedToRunningTimer
+        ? '<span class="unscheduled-in-progress-badge inline-flex items-center px-2 py-0.5 rounded-full text-[10px] tracking-normal bg-slate-700/70 text-sky-200 border border-slate-500/40">In progress</span>'
+        : '';
 
     return `
         <div class="flex items-start space-x-3 min-w-0 flex-1">
@@ -79,7 +87,7 @@ function createTaskDisplayHTML(task, priorityClasses, durationText, isCompleted)
                 <i class="fa-regular ${checkIcon} text-lg sm:text-xl"></i>
             </label>
             <div class="min-w-0 flex-1">
-                <div class="font-medium text-white ${textStrike} text-sm sm:text-base break-words flex items-center gap-2 flex-wrap">${task.description} ${renderCategoryBadge(task.category)}</div>
+                <div class="font-medium text-white ${textStrike} text-sm sm:text-base break-words flex items-center gap-2 flex-wrap">${task.description} ${renderCategoryBadge(task.category)} ${inProgressBadge}</div>
                 <div class="text-xs text-gray-400 mt-1.5 flex items-center flex-wrap gap-1.5 ${isCompleted ? 'opacity-70' : ''}">
                     <span class="priority-badge inline-flex items-center ${priorityClasses.bg} ${priorityClasses.text} px-1.5 sm:px-2 py-0.5 sm:py-1 rounded-full text-xs">
                         <i class="${priorityClasses.icon} mr-1 text-xs"></i>${priorityLabel} Priority
@@ -91,13 +99,16 @@ function createTaskDisplayHTML(task, priorityClasses, durationText, isCompleted)
             </div>
         </div>
         <div class="flex space-x-1 ml-auto">
-            <button class="text-gray-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-schedule-task" title="Schedule task" data-task-id="${task.id}" ${disabledAttr}>
+            <button class="text-gray-400 hover:text-sky-300 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-start-unscheduled-timer${disabledButtonClasses}" title="Start timer from task" data-task-id="${task.id}" ${disabledAttr}>
+                <i class="fa-solid fa-stopwatch text-sm sm:text-base"></i>
+            </button>
+            <button class="text-gray-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-schedule-task${disabledButtonClasses}" title="Schedule task" data-task-id="${task.id}" ${disabledAttr}>
                 <i class="fa-regular fa-calendar-plus text-sm sm:text-base"></i>
             </button>
-            <button class="text-gray-400 hover:text-amber-300 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-edit-unscheduled" title="Edit task" data-task-id="${task.id}">
+            <button class="text-gray-400 hover:text-amber-300 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-edit-unscheduled${disabledButtonClasses}" title="Edit task" data-task-id="${task.id}" ${disabledAttr}>
                 <i class="fa-solid fa-pen text-sm sm:text-base"></i>
             </button>
-            <button class="${task.confirmingDelete ? 'text-rose-400' : 'text-gray-400 hover:text-rose-500 hover:bg-gray-700 rounded-lg transition-colors'} btn-delete-unscheduled p-1.5 sm:p-2" title="Delete task" data-task-id="${task.id}">
+            <button class="${task.confirmingDelete ? 'text-rose-400' : 'text-gray-400 hover:text-rose-500 hover:bg-gray-700 rounded-lg transition-colors'} btn-delete-unscheduled p-1.5 sm:p-2${disabledButtonClasses}" title="Delete task" data-task-id="${task.id}" ${disabledAttr}>
                 <i class="fa-regular ${task.confirmingDelete ? 'fa-check-circle' : 'fa-trash-can'} text-sm sm:text-base"></i>
             </button>
         </div>
@@ -193,10 +204,11 @@ function createInlineEditFormHTML(task) {
 function createUnscheduledTaskCard(task) {
     const priorityClasses = getPriorityClasses(task.priority);
     const isCompleted = task.status === 'completed';
+    const isLinkedToRunningTimer = getRunningActivity()?.sourceTaskId === task.id;
     const durationText = getDurationText(task.estDuration);
 
     const taskCard = document.createElement('div');
-    taskCard.className = `task-card bg-gray-800 bg-opacity-60 ${priorityClasses.border} p-2 sm:p-4 rounded-lg shadow-lg flex flex-col gap-2`;
+    taskCard.className = `task-card bg-gray-800 bg-opacity-60 ${priorityClasses.border} p-2 sm:p-4 rounded-lg shadow-lg flex flex-col gap-2 ${isLinkedToRunningTimer ? 'opacity-70 pointer-events-none' : ''}`;
     taskCard.dataset.taskId = task.id;
     taskCard.dataset.taskName = task.description;
     taskCard.dataset.taskEstDuration = durationText;

--- a/public/layout-mockups.html
+++ b/public/layout-mockups.html
@@ -1,0 +1,495 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Fortudo Activity Layout Mockups</title>
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+        />
+        <style>
+            :root {
+                --page-bg: #162236;
+                --panel: rgba(29, 42, 64, 0.96);
+                --panel-border: rgba(89, 107, 136, 0.35);
+                --field: #3a4b64;
+                --field-border: #4d607d;
+                --text: #eef4ff;
+                --muted: #9ab0cf;
+                --teal: #11c5bb;
+                --sky: #1cb5ec;
+                --sky-soft: rgba(28, 181, 236, 0.18);
+                --button-dark: #31445f;
+            }
+
+            * {
+                box-sizing: border-box;
+            }
+
+            body {
+                margin: 0;
+                min-height: 100vh;
+                font-family: Georgia, 'Times New Roman', serif;
+                background:
+                    radial-gradient(circle at top left, rgba(28, 181, 236, 0.12), transparent 28%),
+                    radial-gradient(circle at 80% 20%, rgba(17, 197, 187, 0.08), transparent 22%),
+                    linear-gradient(180deg, #152034 0%, #17243a 100%);
+                color: var(--text);
+            }
+
+            .wrap {
+                width: min(1360px, calc(100% - 32px));
+                margin: 26px auto 48px;
+            }
+
+            .intro {
+                margin-bottom: 20px;
+                padding: 18px 22px;
+                border: 1px solid var(--panel-border);
+                border-radius: 18px;
+                background: rgba(22, 32, 50, 0.88);
+                box-shadow: 0 24px 60px rgba(7, 12, 22, 0.28);
+            }
+
+            .intro h1 {
+                margin: 0 0 8px;
+                font-size: clamp(28px, 4vw, 40px);
+                font-weight: 600;
+                letter-spacing: -0.02em;
+            }
+
+            .intro p {
+                margin: 0;
+                color: var(--muted);
+                font-size: 17px;
+                line-height: 1.45;
+            }
+
+            .grid {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 18px;
+            }
+
+            .option {
+                border: 1px solid var(--panel-border);
+                border-radius: 20px;
+                background: var(--panel);
+                overflow: hidden;
+                box-shadow: 0 26px 60px rgba(8, 13, 24, 0.32);
+            }
+
+            .option.featured-row {
+                grid-column: 1 / -1;
+            }
+
+            .option-head {
+                padding: 18px 18px 14px;
+                border-bottom: 1px solid rgba(89, 107, 136, 0.24);
+                background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+            }
+
+            .option-kicker {
+                margin-bottom: 6px;
+                font-size: 12px;
+                letter-spacing: 0.18em;
+                text-transform: uppercase;
+                color: rgba(154, 176, 207, 0.78);
+            }
+
+            .option h2 {
+                margin: 0 0 8px;
+                font-size: 28px;
+                font-weight: 500;
+            }
+
+            .option p {
+                margin: 0;
+                color: var(--muted);
+                line-height: 1.45;
+                font-size: 15px;
+            }
+
+            .phone {
+                padding: 20px;
+            }
+
+            .frame {
+                border: 1px solid rgba(91, 110, 142, 0.35);
+                border-radius: 18px;
+                background: #1e2b41;
+                padding: 16px;
+            }
+
+            .toggle-row {
+                display: flex;
+                gap: 18px;
+                align-items: center;
+                font-size: 17px;
+                margin-bottom: 16px;
+            }
+
+            .toggle-row span {
+                display: inline-flex;
+                align-items: center;
+                gap: 7px;
+                color: rgba(238, 244, 255, 0.92);
+            }
+
+            .toggle-row .active {
+                color: #ffffff;
+            }
+
+            .toggle-row i {
+                color: var(--sky);
+                font-size: 15px;
+            }
+
+            .field {
+                height: 56px;
+                border-radius: 12px;
+                background: var(--field);
+                border: 1px solid var(--field-border);
+                display: flex;
+                align-items: center;
+                padding: 0 18px;
+                color: rgba(238, 244, 255, 0.96);
+                font-size: 18px;
+                margin-bottom: 16px;
+            }
+
+            .field.muted {
+                color: rgba(238, 244, 255, 0.72);
+            }
+
+            .category {
+                position: relative;
+                padding-left: 40px;
+            }
+
+            .category::before {
+                content: '';
+                position: absolute;
+                left: 18px;
+                width: 14px;
+                height: 14px;
+                border-radius: 999px;
+                background: #6f839e;
+            }
+
+            .time-row {
+                display: grid;
+                gap: 12px;
+            }
+
+            .time-main {
+                display: grid;
+                grid-template-columns: 1.25fr 1.3fr;
+                gap: 12px;
+            }
+
+            .control {
+                height: 58px;
+                border-radius: 12px;
+                background: var(--field);
+                border: 1px solid var(--field-border);
+                display: flex;
+                align-items: center;
+                padding: 0 16px;
+                color: rgba(238, 244, 255, 0.94);
+                font-size: 17px;
+            }
+
+            .control i {
+                margin-right: 10px;
+                color: var(--teal);
+            }
+
+            .duration {
+                display: grid;
+                grid-template-columns: 1fr auto 1fr;
+                gap: 10px;
+                align-items: center;
+            }
+
+            .colon {
+                color: rgba(214, 224, 242, 0.78);
+                text-align: center;
+                font-size: 24px;
+            }
+
+            .action-stack {
+                display: grid;
+                gap: 12px;
+            }
+
+            .action-inline {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 12px;
+            }
+
+            .button {
+                height: 54px;
+                border-radius: 13px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 10px;
+                padding: 0 18px;
+                font-size: 18px;
+                white-space: nowrap;
+            }
+
+            .button.primary {
+                background: linear-gradient(90deg, #18aee7, #1ec0f1);
+                color: white;
+                box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+            }
+
+            .button.secondary {
+                background: var(--button-dark);
+                border: 1px solid rgba(108, 130, 164, 0.6);
+                color: white;
+            }
+
+            .button i {
+                color: inherit;
+            }
+
+            .option-note {
+                margin-top: 16px;
+                padding-top: 14px;
+                border-top: 1px solid rgba(89, 107, 136, 0.24);
+                color: var(--muted);
+                font-size: 14px;
+                line-height: 1.45;
+            }
+
+            .layout-one .time-row {
+                grid-template-columns: minmax(0, 1.7fr) 180px;
+                align-items: center;
+            }
+
+            .layout-two .action-stack {
+                grid-template-columns: 1fr 1fr;
+            }
+
+            .layout-three .time-row {
+                grid-template-columns: minmax(0, 1.35fr) minmax(220px, 0.95fr);
+                align-items: start;
+            }
+
+            .layout-three .action-stack {
+                gap: 10px;
+            }
+
+            .layout-three .button {
+                height: 56px;
+            }
+
+            .recommended {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+                margin-top: 10px;
+                padding: 6px 11px;
+                border-radius: 999px;
+                background: var(--sky-soft);
+                color: #8fe2ff;
+                font-size: 13px;
+                letter-spacing: 0.05em;
+                text-transform: uppercase;
+            }
+
+            @media (max-width: 980px) {
+                .grid {
+                    grid-template-columns: 1fr;
+                }
+
+                .option.featured-row {
+                    grid-column: auto;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrap">
+            <section class="intro">
+                <h1>Activity Form Layout Options</h1>
+                <p>
+                    Three browser mockups for the activity-mode action area. All keep the current
+                    Fortudo palette and control language; the difference is how tightly the time
+                    controls and actions are composed.
+                </p>
+            </section>
+
+            <section class="grid">
+                <article class="option layout-one">
+                    <div class="option-head">
+                        <div class="option-kicker">Approach 1</div>
+                        <h2>Stacked Actions</h2>
+                        <p>
+                            Time controls stay dominant on the left. The action buttons become a
+                            compact vertical control tower on medium widths.
+                        </p>
+                        <div class="recommended">
+                            <i class="fa-solid fa-star"></i>
+                            Recommended
+                        </div>
+                    </div>
+                    <div class="phone">
+                        <div class="frame">
+                            <div class="toggle-row">
+                                <span><i class="fa-regular fa-calendar-check"></i>Scheduled</span>
+                                <span><i class="fa-solid fa-list-ul"></i>Unscheduled</span>
+                                <span class="active"
+                                    ><i class="fa-regular fa-clock"></i>Activity</span
+                                >
+                            </div>
+                            <div class="field muted">What did you work on?</div>
+                            <div class="field category">No category</div>
+                            <div class="time-row">
+                                <div class="time-main">
+                                    <div class="control">
+                                        <i class="fa-regular fa-clock"></i>
+                                        03:00 PM
+                                    </div>
+                                    <div class="duration">
+                                        <div class="control">
+                                            <i class="fa-regular fa-hourglass"></i>
+                                            HH
+                                        </div>
+                                        <div class="colon">:</div>
+                                        <div class="control">MM</div>
+                                    </div>
+                                </div>
+                                <div class="action-stack">
+                                    <div class="button primary">
+                                        <i class="fa-regular fa-clock"></i>
+                                        Log Activity
+                                    </div>
+                                    <div class="button secondary">
+                                        <i class="fa-solid fa-play"></i>
+                                        Start Timer
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="option-note">
+                                Best balance of clarity and compactness. It makes the actions feel
+                                intentional instead of squeezed into the same strip.
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="option layout-two">
+                    <div class="option-head">
+                        <div class="option-kicker">Approach 2</div>
+                        <h2>Dedicated Action Row</h2>
+                        <p>
+                            Inputs occupy one row. Buttons get their own clean band underneath, with
+                            equal weight and no visual competition.
+                        </p>
+                    </div>
+                    <div class="phone">
+                        <div class="frame">
+                            <div class="toggle-row">
+                                <span><i class="fa-regular fa-calendar-check"></i>Scheduled</span>
+                                <span><i class="fa-solid fa-list-ul"></i>Unscheduled</span>
+                                <span class="active"
+                                    ><i class="fa-regular fa-clock"></i>Activity</span
+                                >
+                            </div>
+                            <div class="field muted">What did you work on?</div>
+                            <div class="field category">No category</div>
+                            <div class="time-main" style="margin-bottom: 12px">
+                                <div class="control">
+                                    <i class="fa-regular fa-clock"></i>
+                                    03:00 PM
+                                </div>
+                                <div class="duration">
+                                    <div class="control">
+                                        <i class="fa-regular fa-hourglass"></i>
+                                        HH
+                                    </div>
+                                    <div class="colon">:</div>
+                                    <div class="control">MM</div>
+                                </div>
+                            </div>
+                            <div class="action-stack">
+                                <div class="button primary">
+                                    <i class="fa-regular fa-clock"></i>
+                                    Log Activity
+                                </div>
+                                <div class="button secondary">
+                                    <i class="fa-solid fa-play"></i>
+                                    Start Timer
+                                </div>
+                            </div>
+                            <div class="option-note">
+                                Safest responsive behavior and easiest to scan, but it increases
+                                vertical height and makes the form feel more segmented.
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="option layout-three featured-row">
+                    <div class="option-head">
+                        <div class="option-kicker">Approach 3</div>
+                        <h2>Compressed Console</h2>
+                        <p>
+                            A denser right-side action module. The form reads more like a compact
+                            dashboard panel, with tighter control grouping.
+                        </p>
+                    </div>
+                    <div class="phone">
+                        <div class="frame">
+                            <div class="toggle-row">
+                                <span><i class="fa-regular fa-calendar-check"></i>Scheduled</span>
+                                <span><i class="fa-solid fa-list-ul"></i>Unscheduled</span>
+                                <span class="active"
+                                    ><i class="fa-regular fa-clock"></i>Activity</span
+                                >
+                            </div>
+                            <div class="field muted">What did you work on?</div>
+                            <div class="field category">No category</div>
+                            <div class="time-row">
+                                <div class="time-main">
+                                    <div class="control">
+                                        <i class="fa-regular fa-clock"></i>
+                                        03:00 PM
+                                    </div>
+                                    <div class="duration">
+                                        <div class="control">
+                                            <i class="fa-regular fa-hourglass"></i>
+                                            HH
+                                        </div>
+                                        <div class="colon">:</div>
+                                        <div class="control">MM</div>
+                                    </div>
+                                </div>
+                                <div class="action-stack">
+                                    <div class="button primary">
+                                        <i class="fa-regular fa-clock"></i>
+                                        Log Activity
+                                    </div>
+                                    <div class="button secondary">
+                                        <i class="fa-solid fa-play"></i>
+                                        Start Timer
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="option-note">
+                                Feels the most “tool-like” and efficient, but it risks looking
+                                cramped faster than the other two when the viewport tightens.
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            </section>
+        </div>
+    </body>
+</html>

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -1425,404 +1425,443 @@ def run_smoke(
                     fetch_remote_docs(couchdb_url, build_remote_db_name(hostname, room_code))
                 )
 
-            page.goto(preview_url, wait_until="load")
-            wait_for_app_ready(page)
-            wait_for_demo_start(demo=demo, headless=headless)
-            demo_step(page, "opening alpha room", step_pause_ms)
-            enter_room(page, rooms["alpha"])
-            clear_room_storage(page, rooms["alpha"])
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
+            def run_alpha_room_scenario() -> None:
+                demo_step(page, "opening alpha room", step_pause_ms)
+                enter_room(page, rooms["alpha"])
+                clear_room_storage(page, rooms["alpha"])
+                page.reload(wait_until="load")
+                wait_for_main_app(page)
 
-            demo_step(page, "adding fresh-room tasks", step_pause_ms)
-            add_scheduled_task(page, "Playwright scheduled task", "09:00", 30)
-            add_unscheduled_task(page, "Playwright unscheduled task", 15)
+                demo_step(page, "adding fresh-room tasks", step_pause_ms)
+                add_scheduled_task(page, "Playwright scheduled task", "09:00", 30)
+                add_unscheduled_task(page, "Playwright unscheduled task", 15)
 
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
+                page.reload(wait_until="load")
+                wait_for_main_app(page)
 
-            alpha_docs = read_docs(page, rooms["alpha"])
-            scheduled_doc = ensure_task_doc_present(
-                rooms["alpha"], "Playwright scheduled task", alpha_docs
-            )
-            unscheduled_doc = ensure_task_doc_present(
-                rooms["alpha"], "Playwright unscheduled task", alpha_docs
-            )
+                alpha_docs = read_docs(page, rooms["alpha"])
+                scheduled_doc = ensure_task_doc_present(
+                    rooms["alpha"], "Playwright scheduled task", alpha_docs
+                )
+                unscheduled_doc = ensure_task_doc_present(
+                    rooms["alpha"], "Playwright unscheduled task", alpha_docs
+                )
 
-            edit_form_selector = open_scheduled_edit_form(page, scheduled_doc["id"])
-            page.locator(f"{edit_form_selector} input[name='description']").fill(
-                "Playwright scheduled task edited"
-            )
-            page.locator(edit_form_selector).evaluate("(form) => form.requestSubmit()")
-            wait_until(
-                lambda: any(
-                    doc.get("id") == scheduled_doc["id"]
-                    and doc.get("description") == "Playwright scheduled task edited"
-                    for doc in list(map(normalize_doc, read_docs(page, rooms["alpha"])))
-                ),
-                "scheduled edit persistence",
-            )
+                edit_form_selector = open_scheduled_edit_form(page, scheduled_doc["id"])
+                page.locator(f"{edit_form_selector} input[name='description']").fill(
+                    "Playwright scheduled task edited"
+                )
+                page.locator(edit_form_selector).evaluate("(form) => form.requestSubmit()")
+                wait_until(
+                    lambda: any(
+                        doc.get("id") == scheduled_doc["id"]
+                        and doc.get("description") == "Playwright scheduled task edited"
+                        for doc in list(map(normalize_doc, read_docs(page, rooms["alpha"])))
+                    ),
+                    "scheduled edit persistence",
+                )
 
-            demo_step(page, "editing scheduled task and deleting unscheduled task", step_pause_ms)
-            delete_unscheduled_task_via_ui(page, unscheduled_doc["id"])
+                demo_step(page, "editing scheduled task and deleting unscheduled task", step_pause_ms)
+                delete_unscheduled_task_via_ui(page, unscheduled_doc["id"])
 
-            def fresh_room_storage_updated() -> bool:
-                docs = list(map(normalize_doc, read_docs(page, rooms["alpha"])))
-                return any(
-                    doc.get("description") == "Playwright scheduled task edited"
-                    and doc.get("docType") == "task"
-                    for doc in docs
-                ) and not any(doc.get("id") == unscheduled_doc["id"] for doc in docs)
+                def fresh_room_storage_updated() -> bool:
+                    docs = list(map(normalize_doc, read_docs(page, rooms["alpha"])))
+                    return any(
+                        doc.get("description") == "Playwright scheduled task edited"
+                        and doc.get("docType") == "task"
+                        for doc in docs
+                    ) and not any(doc.get("id") == unscheduled_doc["id"] for doc in docs)
 
-            try:
-                wait_until(fresh_room_storage_updated, "fresh-room storage update")
-            except TimeoutError as error:
-                snapshot = summarize_docs(read_docs(page, rooms["alpha"]))
-                raise TimeoutError(
-                    "Timed out waiting for fresh-room storage update.\n"
-                    f"{format_snapshot(snapshot)}"
-                ) from error
+                try:
+                    wait_until(fresh_room_storage_updated, "fresh-room storage update")
+                except TimeoutError as error:
+                    snapshot = summarize_docs(read_docs(page, rooms["alpha"]))
+                    raise TimeoutError(
+                        "Timed out waiting for fresh-room storage update.\n"
+                        f"{format_snapshot(snapshot)}"
+                    ) from error
 
-            alpha_summary = summarize_docs(read_docs(page, rooms["alpha"]))
-            if "Playwright scheduled task edited" not in [
-                doc.get("description") for doc in alpha_summary["tasks"]
-            ]:
-                raise ValueError(f"missing edited scheduled task.\n{format_snapshot(alpha_summary)}")
-            if couchdb_url:
-                request_manual_sync(page)
-                wait_for_sync_status_normal("taxonomy manual sync")
+                alpha_summary = summarize_docs(read_docs(page, rooms["alpha"]))
+                if "Playwright scheduled task edited" not in [
+                    doc.get("description") for doc in alpha_summary["tasks"]
+                ]:
+                    raise ValueError(
+                        f"missing edited scheduled task.\n{format_snapshot(alpha_summary)}"
+                    )
+                if couchdb_url:
+                    request_manual_sync(page)
+                    wait_for_sync_status_normal("taxonomy manual sync")
+                    wait_until(
+                        lambda: (
+                            lambda summary: any(
+                                doc.get("description") == "Playwright scheduled task edited"
+                                for doc in summary["tasks"]
+                            )
+                            and not any(
+                                doc.get("id") == unscheduled_doc["id"] for doc in summary["tasks"]
+                            )
+                        )(read_remote_summary(rooms["alpha"])),
+                        "alpha remote sync",
+                        timeout_s=25.0,
+                    )
+                    wait_for_sync_status_normal("alpha")
+
+            def run_legacy_room_scenario() -> None:
+                demo_step(page, "checking legacy migration room", step_pause_ms)
+                switch_room(page, rooms["legacy"])
+                clear_room_storage(page, rooms["legacy"])
+                seed_docs(
+                    page,
+                    rooms["legacy"],
+                    [
+                        {
+                            "_id": "sched-legacy",
+                            "type": "scheduled",
+                            "description": "Legacy scheduled task",
+                            "startDateTime": "2026-03-20T09:00:00",
+                            "endDateTime": "2026-03-20T09:30:00",
+                            "duration": 30,
+                            "status": "incomplete",
+                        },
+                        {
+                            "_id": "unsched-legacy",
+                            "type": "unscheduled",
+                            "description": "Legacy unscheduled task",
+                            "priority": "medium",
+                            "estDuration": 15,
+                            "status": "incomplete",
+                        },
+                    ],
+                )
+                page.reload(wait_until="load")
+                wait_for_main_app(page)
+
                 wait_until(
                     lambda: (
-                        lambda summary: any(
-                            doc.get("description") == "Playwright scheduled task edited"
-                            for doc in summary["tasks"]
+                        lambda docs: any(
+                            doc.get("id") == "sched-legacy" and doc.get("docType") == "task"
+                            for doc in docs
                         )
-                        and not any(doc.get("id") == unscheduled_doc["id"] for doc in summary["tasks"])
-                    )(read_remote_summary(rooms["alpha"])),
-                    "alpha remote sync",
-                    timeout_s=25.0,
+                        and any(
+                            doc.get("id") == "unsched-legacy" and doc.get("docType") == "task"
+                            for doc in docs
+                        )
+                    )(list(map(normalize_doc, read_docs(page, rooms["legacy"])))),
+                    "legacy migration",
                 )
-                wait_for_sync_status_normal("alpha")
-
-            demo_step(page, "checking legacy migration room", step_pause_ms)
-            switch_room(page, rooms["legacy"])
-            clear_room_storage(page, rooms["legacy"])
-            seed_docs(
-                page,
-                rooms["legacy"],
-                [
-                    {
-                        "_id": "sched-legacy",
-                        "type": "scheduled",
-                        "description": "Legacy scheduled task",
-                        "startDateTime": "2026-03-20T09:00:00",
-                        "endDateTime": "2026-03-20T09:30:00",
-                        "duration": 30,
-                        "status": "incomplete",
-                    },
-                    {
-                        "_id": "unsched-legacy",
-                        "type": "unscheduled",
-                        "description": "Legacy unscheduled task",
-                        "priority": "medium",
-                        "estDuration": 15,
-                        "status": "incomplete",
-                    },
-                ],
-            )
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
-
-            wait_until(
-                lambda: (
-                    lambda docs: any(
-                        doc.get("id") == "sched-legacy" and doc.get("docType") == "task"
-                        for doc in docs
+                assert_migrated_task_docs(
+                    summarize_docs(read_docs(page, rooms["legacy"])),
+                    ["sched-legacy", "unsched-legacy"],
+                )
+                if couchdb_url:
+                    wait_until(
+                        lambda: (
+                            lambda summary: format_doc_ids(summary["tasks"])
+                            == ["sched-legacy", "unsched-legacy"]
+                            and not summary["legacy_tasks"]
+                        )(read_remote_summary(rooms["legacy"])),
+                        "legacy remote sync",
+                        timeout_s=25.0,
                     )
-                    and any(
-                        doc.get("id") == "unsched-legacy" and doc.get("docType") == "task"
-                        for doc in docs
-                    )
-                )(list(map(normalize_doc, read_docs(page, rooms["legacy"])))),
-                "legacy migration",
-            )
-            assert_migrated_task_docs(
-                summarize_docs(read_docs(page, rooms["legacy"])),
-                ["sched-legacy", "unsched-legacy"],
-            )
-            if couchdb_url:
+                    wait_for_sync_status_normal("legacy")
+
+            def run_taxonomy_room_scenario() -> None:
+                demo_step(page, "checking phase 3 taxonomy and settings room", step_pause_ms)
+                switch_room(page, rooms["taxonomy"])
+                clear_room_storage(page, rooms["taxonomy"])
+                set_activities_enabled(page, True)
+                seed_docs(page, rooms["taxonomy"], [build_phase3_taxonomy_config_doc()])
+                page.reload(wait_until="load")
+                wait_for_main_app(page)
+
+                wait_until(
+                    lambda: page.locator("#category-dropdown-row").is_visible(),
+                    "activities-enabled category dropdown",
+                )
                 wait_until(
                     lambda: (
-                        lambda summary: format_doc_ids(summary["tasks"])
-                        == ["sched-legacy", "unsched-legacy"]
-                        and not summary["legacy_tasks"]
-                    )(read_remote_summary(rooms["legacy"])),
-                    "legacy remote sync",
-                    timeout_s=25.0,
-                )
-                wait_for_sync_status_normal("legacy")
-
-            demo_step(page, "checking phase 3 taxonomy and settings room", step_pause_ms)
-            switch_room(page, rooms["taxonomy"])
-            clear_room_storage(page, rooms["taxonomy"])
-            set_activities_enabled(page, True)
-            seed_docs(page, rooms["taxonomy"], [build_phase3_taxonomy_config_doc()])
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
-
-            wait_until(
-                lambda: page.locator("#category-dropdown-row").is_visible(),
-                "activities-enabled category dropdown",
-            )
-            wait_until(
-                lambda: (
-                    page.locator('#category-select option[value="work/project"]').text_content() or ""
-                )
-                == "› Project",
-                "visible nested project category option",
-            )
-
-            open_settings_modal(page)
-            wait_for_text_in_locator(
-                page,
-                "#settings-content",
-                "Work",
-                description="seeded taxonomy settings content",
-            )
-            wait_for_text_in_locator(
-                page,
-                "#settings-content",
-                "Family",
-                description="seeded family group content",
-            )
-            wait_until(
-                lambda: "settings-scroll-area"
-                in (page.locator("#settings-content").get_attribute("class") or ""),
-                "settings scroll shell class",
-            )
-
-            page.locator("#add-category-btn").click()
-            page.locator("#add-category-form").wait_for(state="visible", timeout=5000)
-            separator_text = (
-                page.locator("#add-category-form [data-category-path-separator]").text_content()
-                or ""
-            ).strip()
-            if separator_text != "/":
-                raise ValueError(f"unexpected add-category separator: {separator_text!r}")
-            group_placeholder = (
-                page.locator('#add-category-form select[name="parent-group"] option').first.text_content()
-                or ""
-            ).strip()
-            if group_placeholder != "Group":
-                raise ValueError(f"unexpected add-category group placeholder: {group_placeholder!r}")
-            category_placeholder = page.locator(
-                '#add-category-form input[name="category-label"]'
-            ).get_attribute("placeholder")
-            if category_placeholder != "Category name":
-                raise ValueError(
-                    f"unexpected add-category input placeholder: {category_placeholder!r}"
+                        page.locator('#category-select option[value="work/project"]').text_content()
+                        or ""
+                    )
+                    == "â€º Project",
+                    "visible nested project category option",
                 )
 
-            add_category_via_settings(page, "break", "Walk")
-            wait_until(
-                lambda: page.locator('[data-category-key="break/walk"]').count() == 1,
-                "new break walk category row",
-            )
-            wait_until(
-                lambda: page.locator('#category-select option[value="break/walk"]').count() == 1,
-                "live dropdown refresh for added category",
-            )
+                open_settings_modal(page)
+                wait_for_text_in_locator(
+                    page,
+                    "#settings-content",
+                    "Work",
+                    description="seeded taxonomy settings content",
+                )
+                wait_for_text_in_locator(
+                    page,
+                    "#settings-content",
+                    "Family",
+                    description="seeded family group content",
+                )
+                wait_until(
+                    lambda: "settings-scroll-area"
+                    in (page.locator("#settings-content").get_attribute("class") or ""),
+                    "settings scroll shell class",
+                )
 
-            update_group_family_via_settings(page, "work", "amber")
-            wait_until(
-                lambda: "#b45309"
-                in (
-                    page.locator(
-                        '[data-category-key="work/project"] .category-dot'
-                    ).get_attribute("style")
+                page.locator("#add-category-btn").click()
+                page.locator("#add-category-form").wait_for(state="visible", timeout=5000)
+                separator_text = (
+                    page.locator("#add-category-form [data-category-path-separator]").text_content()
                     or ""
-                ),
-                "linked work/project category recolor",
-            )
-            demo_note("taxonomy: added break/walk and recolored work family to amber")
-            assert_no_page_errors_yet("taxonomy category mutations")
-            close_settings_modal(page)
-
-            page.locator("#scheduled").check()
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("description")),
-                "Taxonomy scheduled group task",
-                description="taxonomy scheduled description",
-            )
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("start-time")),
-                "11:00",
-                description="taxonomy scheduled start",
-            )
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("duration-hours")),
-                "0",
-                description="taxonomy scheduled duration hours",
-            )
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("duration-minutes")),
-                "25",
-                description="taxonomy scheduled duration minutes",
-            )
-            page.locator("#category-select").select_option("family")
-            page.locator("#task-form button[type='submit']").click()
-
-            page.locator("#unscheduled").check()
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("description")),
-                "Taxonomy child category task",
-                description="taxonomy unscheduled description",
-            )
-            page.locator('input[name="priority"][value="medium"]').check(force=True)
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("est-duration-hours")),
-                "0",
-                description="taxonomy unscheduled duration hours",
-            )
-            fill_locator_value(
-                page,
-                page.locator(task_form_input_selector("est-duration-minutes")),
-                "15",
-                description="taxonomy unscheduled duration minutes",
-            )
-            page.locator("#category-select").select_option("work/project")
-            page.locator("#task-form button[type='submit']").click()
-
-            wait_until(
-                lambda: (
-                    lambda docs: any(
-                        doc.get("description") == "Taxonomy scheduled group task"
-                        and doc.get("category") == "family"
-                        for doc in docs
+                ).strip()
+                if separator_text != "/":
+                    raise ValueError(f"unexpected add-category separator: {separator_text!r}")
+                group_placeholder = (
+                    page.locator(
+                        '#add-category-form select[name="parent-group"] option'
+                    ).first.text_content()
+                    or ""
+                ).strip()
+                if group_placeholder != "Group":
+                    raise ValueError(
+                        f"unexpected add-category group placeholder: {group_placeholder!r}"
                     )
-                    and any(
-                        doc.get("description") == "Taxonomy child category task"
-                        and doc.get("category") == "work/project"
-                        for doc in docs
+                category_placeholder = page.locator(
+                    '#add-category-form input[name="category-label"]'
+                ).get_attribute("placeholder")
+                if category_placeholder != "Category name":
+                    raise ValueError(
+                        f"unexpected add-category input placeholder: {category_placeholder!r}"
                     )
-                )(list(map(normalize_doc, read_docs(page, rooms["taxonomy"])))),
-                "taxonomy task category persistence",
-            )
 
-            wait_until(
-                lambda: "Family" in (page.locator("#scheduled-task-list").text_content() or ""),
-                "scheduled group badge label",
-            )
-            wait_until(
-                lambda: "Project" in (page.locator("#unscheduled-task-list").text_content() or ""),
-                "unscheduled child badge label",
-            )
-            scheduled_badge_style = (
-                page.locator("#scheduled-task-list .category-badge").first.get_attribute("style")
-                or ""
-            )
-            unscheduled_badge_style = (
-                page.locator("#unscheduled-task-list .category-badge").first.get_attribute("style")
-                or ""
-            )
-            if "background-color: rgba(15, 23, 42, 0.9)" not in scheduled_badge_style:
-                raise ValueError(f"scheduled badge lost standardized background: {scheduled_badge_style}")
-            if "#4b5563" not in scheduled_badge_style:
-                raise ValueError(f"scheduled group badge lost gray accent: {scheduled_badge_style}")
-            if "background-color: rgba(15, 23, 42, 0.9)" not in unscheduled_badge_style:
-                raise ValueError(
-                    f"unscheduled badge lost standardized background: {unscheduled_badge_style}"
+                add_category_via_settings(page, "break", "Walk")
+                wait_until(
+                    lambda: page.locator('[data-category-key="break/walk"]').count() == 1,
+                    "new break walk category row",
                 )
-            if "#b45309" not in unscheduled_badge_style:
-                raise ValueError(f"unscheduled child badge did not reflect amber family: {unscheduled_badge_style}")
-            demo_note("taxonomy: scheduled and unscheduled tasks persisted with expected category badges")
-            assert_no_page_errors_yet("taxonomy task persistence")
+                wait_until(
+                    lambda: page.locator('#category-select option[value="break/walk"]').count() == 1,
+                    "live dropdown refresh for added category",
+                )
 
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
-            wait_for_text_in_locator(
-                page,
-                "#scheduled-task-list",
-                "Taxonomy scheduled group task",
-                description="taxonomy scheduled task after reload",
-            )
-            wait_for_text_in_locator(
-                page,
-                "#unscheduled-task-list",
-                "Taxonomy child category task",
-                description="taxonomy unscheduled task after reload",
-            )
+                update_group_family_via_settings(page, "work", "amber")
+                wait_until(
+                    lambda: "#b45309"
+                    in (
+                        page.locator(
+                            '[data-category-key="work/project"] .category-dot'
+                        ).get_attribute("style")
+                        or ""
+                    ),
+                    "linked work/project category recolor",
+                )
+                demo_note("taxonomy: added break/walk and recolored work family to amber")
+                assert_no_page_errors_yet("taxonomy category mutations")
+                close_settings_modal(page)
 
-            open_settings_modal(page)
-            wait_for_text_in_locator(
-                page,
-                "#settings-content",
-                "Walk",
-                description="persisted added category after reload",
-            )
-            page.locator('.btn-delete-group[data-key="family"]').click()
-            wait_for_toast_text(page, 'Group "family" is referenced by tasks')
-            page.locator('.btn-delete-category[data-key="work/project"]').click()
-            wait_for_toast_text(page, 'Category "work/project" is referenced by tasks')
-            close_settings_modal(page)
+                page.locator("#scheduled").check()
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("description")),
+                    "Taxonomy scheduled group task",
+                    description="taxonomy scheduled description",
+                )
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("start-time")),
+                    "11:00",
+                    description="taxonomy scheduled start",
+                )
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("duration-hours")),
+                    "0",
+                    description="taxonomy scheduled duration hours",
+                )
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("duration-minutes")),
+                    "25",
+                    description="taxonomy scheduled duration minutes",
+                )
+                page.locator("#category-select").select_option("family")
+                page.locator("#task-form button[type='submit']").click()
 
-            taxonomy_summary = summarize_docs(read_docs(page, rooms["taxonomy"]))
-            taxonomy_config = next(
-                (doc for doc in taxonomy_summary["configs"] if doc.get("id") == "config-categories"),
-                None,
-            )
-            if not taxonomy_config:
-                raise ValueError(
-                    f"taxonomy room missing config-categories doc.\n{format_snapshot(taxonomy_summary)}"
+                page.locator("#unscheduled").check()
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("description")),
+                    "Taxonomy child category task",
+                    description="taxonomy unscheduled description",
                 )
-            if not any(group.get("key") == "work" and group.get("colorFamily") == "amber" for group in taxonomy_config.get("groups", [])):
-                raise ValueError(
-                    f"taxonomy room did not persist work family edit.\n{format_snapshot(taxonomy_summary)}"
+                page.locator('input[name="priority"][value="medium"]').check(force=True)
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("est-duration-hours")),
+                    "0",
+                    description="taxonomy unscheduled duration hours",
                 )
-            if not any(category.get("key") == "break/walk" for category in taxonomy_config.get("categories", [])):
-                raise ValueError(
-                    f"taxonomy room did not persist compact add-category flow.\n{format_snapshot(taxonomy_summary)}"
+                fill_locator_value(
+                    page,
+                    page.locator(task_form_input_selector("est-duration-minutes")),
+                    "15",
+                    description="taxonomy unscheduled duration minutes",
                 )
-            demo_note("taxonomy: reload and settings persistence checks passed")
-            assert_no_page_errors_yet("taxonomy reload and settings persistence")
-            if couchdb_url:
+                page.locator("#category-select").select_option("work/project")
+                page.locator("#task-form button[type='submit']").click()
+
                 wait_until(
                     lambda: (
-                        lambda summary: any(
+                        lambda docs: any(
                             doc.get("description") == "Taxonomy scheduled group task"
                             and doc.get("category") == "family"
-                            for doc in summary["tasks"]
+                            for doc in docs
                         )
                         and any(
                             doc.get("description") == "Taxonomy child category task"
                             and doc.get("category") == "work/project"
-                            for doc in summary["tasks"]
+                            for doc in docs
                         )
-                        and any(
-                            doc.get("id") == "config-categories"
-                            and any(
-                                group.get("key") == "work"
-                                and group.get("colorFamily") == "amber"
-                                for group in doc.get("groups", [])
-                            )
-                            and any(
-                                category.get("key") == "break/walk"
-                                for category in doc.get("categories", [])
-                            )
-                            for doc in summary["configs"]
-                        )
-                    )(read_remote_summary(rooms["taxonomy"])),
-                    "taxonomy remote sync",
-                    timeout_s=60.0,
+                    )(list(map(normalize_doc, read_docs(page, rooms["taxonomy"])))),
+                    "taxonomy task category persistence",
                 )
-                wait_for_sync_status_normal("taxonomy")
 
+                wait_until(
+                    lambda: "Family" in (page.locator("#scheduled-task-list").text_content() or ""),
+                    "scheduled group badge label",
+                )
+                wait_until(
+                    lambda: "Project" in (page.locator("#unscheduled-task-list").text_content() or ""),
+                    "unscheduled child badge label",
+                )
+                scheduled_badge_style = (
+                    page.locator("#scheduled-task-list .category-badge").first.get_attribute("style")
+                    or ""
+                )
+                unscheduled_badge_style = (
+                    page.locator("#unscheduled-task-list .category-badge").first.get_attribute("style")
+                    or ""
+                )
+                if "background-color: rgba(15, 23, 42, 0.9)" not in scheduled_badge_style:
+                    raise ValueError(
+                        f"scheduled badge lost standardized background: {scheduled_badge_style}"
+                    )
+                if "#4b5563" not in scheduled_badge_style:
+                    raise ValueError(
+                        f"scheduled group badge lost gray accent: {scheduled_badge_style}"
+                    )
+                if "background-color: rgba(15, 23, 42, 0.9)" not in unscheduled_badge_style:
+                    raise ValueError(
+                        f"unscheduled badge lost standardized background: {unscheduled_badge_style}"
+                    )
+                if "#b45309" not in unscheduled_badge_style:
+                    raise ValueError(
+                        "unscheduled child badge did not reflect amber family: "
+                        f"{unscheduled_badge_style}"
+                    )
+                demo_note(
+                    "taxonomy: scheduled and unscheduled tasks persisted with expected category badges"
+                )
+                assert_no_page_errors_yet("taxonomy task persistence")
+
+                page.reload(wait_until="load")
+                wait_for_main_app(page)
+                wait_for_text_in_locator(
+                    page,
+                    "#scheduled-task-list",
+                    "Taxonomy scheduled group task",
+                    description="taxonomy scheduled task after reload",
+                )
+                wait_for_text_in_locator(
+                    page,
+                    "#unscheduled-task-list",
+                    "Taxonomy child category task",
+                    description="taxonomy unscheduled task after reload",
+                )
+
+                open_settings_modal(page)
+                wait_for_text_in_locator(
+                    page,
+                    "#settings-content",
+                    "Walk",
+                    description="persisted added category after reload",
+                )
+                page.locator('.btn-delete-group[data-key="family"]').click()
+                wait_for_toast_text(page, 'Group "family" is referenced by tasks')
+                page.locator('.btn-delete-category[data-key="work/project"]').click()
+                wait_for_toast_text(page, 'Category "work/project" is referenced by tasks')
+                close_settings_modal(page)
+
+                taxonomy_summary = summarize_docs(read_docs(page, rooms["taxonomy"]))
+                taxonomy_config = next(
+                    (
+                        doc
+                        for doc in taxonomy_summary["configs"]
+                        if doc.get("id") == "config-categories"
+                    ),
+                    None,
+                )
+                if not taxonomy_config:
+                    raise ValueError(
+                        "taxonomy room missing config-categories doc.\n"
+                        f"{format_snapshot(taxonomy_summary)}"
+                    )
+                if not any(
+                    group.get("key") == "work" and group.get("colorFamily") == "amber"
+                    for group in taxonomy_config.get("groups", [])
+                ):
+                    raise ValueError(
+                        "taxonomy room did not persist work family edit.\n"
+                        f"{format_snapshot(taxonomy_summary)}"
+                    )
+                if not any(
+                    category.get("key") == "break/walk"
+                    for category in taxonomy_config.get("categories", [])
+                ):
+                    raise ValueError(
+                        "taxonomy room did not persist compact add-category flow.\n"
+                        f"{format_snapshot(taxonomy_summary)}"
+                    )
+                demo_note("taxonomy: reload and settings persistence checks passed")
+                assert_no_page_errors_yet("taxonomy reload and settings persistence")
+                if couchdb_url:
+                    wait_until(
+                        lambda: (
+                            lambda summary: any(
+                                doc.get("description") == "Taxonomy scheduled group task"
+                                and doc.get("category") == "family"
+                                for doc in summary["tasks"]
+                            )
+                            and any(
+                                doc.get("description") == "Taxonomy child category task"
+                                and doc.get("category") == "work/project"
+                                for doc in summary["tasks"]
+                            )
+                            and any(
+                                doc.get("id") == "config-categories"
+                                and any(
+                                    group.get("key") == "work"
+                                    and group.get("colorFamily") == "amber"
+                                    for group in doc.get("groups", [])
+                                )
+                                and any(
+                                    category.get("key") == "break/walk"
+                                    for category in doc.get("categories", [])
+                                )
+                                for doc in summary["configs"]
+                            )
+                        )(read_remote_summary(rooms["taxonomy"])),
+                        "taxonomy remote sync",
+                        timeout_s=60.0,
+                    )
+                    wait_for_sync_status_normal("taxonomy")
+
+            page.goto(preview_url, wait_until="load")
+            wait_for_app_ready(page)
+            wait_for_demo_start(demo=demo, headless=headless)
+            run_alpha_room_scenario()
+
+            run_legacy_room_scenario()
+
+            run_taxonomy_room_scenario()
             demo_step(page, "checking activities room flows", step_pause_ms)
             switch_room(page, rooms["activities"])
             clear_room_storage(page, rooms["activities"])

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -8,7 +8,7 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.error import HTTPError
 from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
@@ -1298,6 +1298,591 @@ def wait_for_demo_start(
     input_fn("")
 
 
+def run_activities_room_scenario(
+    *,
+    page: Any,
+    rooms: dict[str, str],
+    step_pause_ms: int,
+    assert_no_page_errors_yet: Callable[[str], None],
+) -> None:
+    demo_step(page, "checking activities room flows", step_pause_ms)
+    switch_room(page, rooms["activities"])
+    clear_room_storage(page, rooms["activities"])
+    seed_docs(page, rooms["activities"], [build_phase3_taxonomy_config_doc()])
+    set_activities_enabled(page, True)
+    page.reload(wait_until="load")
+    wait_for_main_app(page)
+
+    add_activity(page, "Playwright manual activity", "13:00", 30)
+    manual_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright manual activity",
+    )
+    if manual_activity_doc.get("source") != "manual":
+        raise ValueError(
+            f"manual activity was not stored as manual.\n{json.dumps(manual_activity_doc, indent=2)}"
+        )
+    if manual_activity_doc.get("sourceTaskId") is not None:
+        raise ValueError(
+            f"manual activity unexpectedly linked to a source task.\n{json.dumps(manual_activity_doc, indent=2)}"
+        )
+    if manual_activity_doc.get("duration") != 30:
+        raise ValueError(
+            f"manual activity persisted wrong duration.\n{json.dumps(manual_activity_doc, indent=2)}"
+        )
+    wait_for_text_in_locator(
+        page,
+        "#activity-list",
+        "Playwright manual activity",
+        description="manual activity render",
+    )
+    demo_note("activities: manual activity add persisted and rendered")
+    assert_no_page_errors_yet("manual activity add")
+
+    queue_activity_smoke_failure(page, "manual-add", 1)
+    add_activity(page, "Playwright failed activity", "13:45", 15)
+    wait_for_activity_failure_alert(
+        page,
+        rooms["activities"],
+        "Playwright failed activity",
+    )
+    wait_for_text_in_locator(
+        page,
+        "#custom-alert-message",
+        "Could not log activity.",
+        description="manual activity failure alert",
+    )
+    failed_activity_description = page.locator(
+        task_form_input_selector("description")
+    ).input_value()
+    if failed_activity_description != "Playwright failed activity":
+        raise ValueError(
+            "manual activity failure cleared the form unexpectedly: "
+            f"{failed_activity_description!r}"
+        )
+    page.locator("#ok-custom-alert-modal").click()
+    page.locator("#custom-alert-modal").wait_for(state="hidden", timeout=10000)
+    if any(
+        doc.get("description") == "Playwright failed activity"
+        for doc in read_docs(page, rooms["activities"])
+    ):
+        raise ValueError("failed manual activity unexpectedly persisted")
+    demo_note("activities: manual add failure path preserved form state")
+    assert_no_page_errors_yet("manual add failure path")
+
+    add_active_scheduled_task(page, "Playwright auto-log success", 20)
+    success_task_doc = wait_for_task_doc(
+        page,
+        rooms["activities"],
+        "Playwright auto-log success",
+    )
+    complete_scheduled_task_via_ui(page, success_task_doc["id"])
+    success_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright auto-log success",
+    )
+    if success_activity_doc.get("source") != "auto":
+        raise ValueError(
+            f"successful auto-log activity had wrong source.\n{json.dumps(success_activity_doc, indent=2)}"
+        )
+    if success_activity_doc.get("sourceTaskId") != success_task_doc["id"]:
+        raise ValueError(
+            "successful auto-log activity did not keep the source task id.\n"
+            f"{json.dumps(success_activity_doc, indent=2)}"
+        )
+    wait_for_text_in_locator(
+        page,
+        "#activity-list",
+        "Playwright auto-log success",
+        description="successful auto-log activity render",
+    )
+    demo_note("activities: scheduled-task auto-log success verified")
+    assert_no_page_errors_yet("auto-log success")
+
+    add_active_scheduled_task(page, "Playwright auto-log failure", 20)
+    failing_task_doc = wait_for_task_doc(
+        page,
+        rooms["activities"],
+        "Playwright auto-log failure",
+    )
+    queue_activity_smoke_failure(page, "auto-log", 1)
+    complete_scheduled_task_via_ui(page, failing_task_doc["id"])
+    wait_for_toast_text(page, "Task completed, but activity auto-log failed.")
+    if any(
+        doc.get("docType") == "activity"
+        and doc.get("description") == "Playwright auto-log failure"
+        for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+    ):
+        raise ValueError("failed auto-log unexpectedly created an activity")
+    demo_note("activities: auto-log failure path surfaced toast without persisting activity")
+    assert_no_page_errors_yet("auto-log failure path")
+
+    add_unscheduled_task(page, "Playwright delete confirm task", 15)
+    delete_confirm_task_doc = wait_for_task_doc(
+        page,
+        rooms["activities"],
+        "Playwright delete confirm task",
+    )
+
+    add_activity(page, "Playwright editable activity", "15:30", 15)
+    editable_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright editable activity",
+    )
+    wait_for_activity_row_text(
+        page,
+        editable_activity_doc["id"],
+        "Playwright editable activity",
+    )
+    arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
+    page.locator(
+        f'[data-activity-id="{editable_activity_doc["id"]}"] .btn-edit-activity'
+    ).click()
+    page.locator(
+        f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"]'
+    ).wait_for(state="visible", timeout=10000)
+    current_modal_value = wait_for_input_value(
+        page,
+        f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] input[name="description"]',
+        "Playwright editable activity",
+        description="activity inline edit description preload",
+    )
+    if current_modal_value != "Playwright editable activity":
+        raise ValueError(
+            "activity inline edit lost the current description after rerender: "
+            f"{current_modal_value!r}"
+        )
+    fill_locator_value(
+        page,
+        page.locator(
+            f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] input[name="description"]'
+        ),
+        "Playwright editable activity updated",
+        description="activity inline edit description",
+    )
+    page.locator(
+        f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] .btn-save-activity-edit'
+    ).click()
+    page.locator(
+        f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"]'
+    ).wait_for(state="hidden", timeout=10000)
+    wait_until(
+        lambda: any(
+            doc.get("id") == editable_activity_doc["id"]
+            and doc.get("description") == "Playwright editable activity updated"
+            for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+        ),
+        "activity edit after delete-confirm rerender",
+    )
+    if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
+        raise ValueError("delete confirm state was not cleared by activity edit")
+    demo_note("activities: inline edit survived delete-confirm rerender state")
+    assert_no_page_errors_yet("activity inline edit")
+
+    add_activity(page, "Playwright delete activity", "16:00", 10)
+    deletable_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright delete activity",
+    )
+    wait_for_activity_row_text(
+        page,
+        deletable_activity_doc["id"],
+        "Playwright delete activity",
+    )
+    arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
+    page.locator(
+        f'[data-activity-id="{deletable_activity_doc["id"]}"] .btn-delete-activity'
+    ).click()
+    wait_until(
+        lambda: not any(
+            doc.get("id") == deletable_activity_doc["id"]
+            for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+        ),
+        "activity delete after delete-confirm rerender",
+    )
+    if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
+        raise ValueError("delete confirm state was not cleared by activity delete")
+    demo_note("activities: manual activity delete verified")
+    assert_no_page_errors_yet("manual activity delete")
+
+    try:
+        start_activity_timer(
+            page,
+            "Playwright timer start",
+            category="work/project",
+            room_code=rooms["activities"],
+        )
+    except Exception as error:
+        timer_start_state = page.evaluate(
+            """
+            () => ({
+                scheduledChecked: document.getElementById('scheduled')?.checked ?? null,
+                unscheduledChecked: document.getElementById('unscheduled')?.checked ?? null,
+                activityChecked: document.getElementById('activity')?.checked ?? null,
+                addTaskText: document.getElementById('add-task-btn')?.textContent ?? null,
+                startTimerHidden:
+                    document.getElementById('start-timer-btn')?.classList.contains('hidden') ??
+                    null,
+                formDescription:
+                    document.querySelector('#task-form input[name="description"]')?.value ??
+                    null,
+                formCategory:
+                    document.querySelector('#task-form select[name="category"]')?.value ??
+                    null,
+                formPlaceholder:
+                    document
+                        .querySelector('#task-form input[name="description"]')
+                        ?.getAttribute('placeholder') ?? null,
+                timerVisible:
+                    !(document.getElementById('timer-display')?.classList.contains('hidden') ??
+                    true),
+                timerDescription: document.getElementById('timer-description')?.value ?? null,
+                timerCategory: document.getElementById('timer-category')?.value ?? null,
+                alertVisible:
+                    !(document.getElementById('custom-alert-modal')?.classList.contains('hidden') ??
+                    true),
+                alertMessage:
+                    document.getElementById('custom-alert-message')?.textContent ?? null,
+                taskFormActivityClass:
+                    document.getElementById('task-form')?.classList.contains('task-form--activity') ??
+                    null
+            })
+            """
+        )
+        timer_start_docs = list(map(normalize_doc, read_docs(page, rooms["activities"])))
+        raise ValueError(
+            "Initial timer start failed.\n"
+            f"error={error!r}\n"
+            f"state={json.dumps(timer_start_state, indent=2)}\n"
+            f"docs={json.dumps(timer_start_docs, indent=2)}"
+        ) from error
+    running_timer_config = wait_for_running_activity_config(page, rooms["activities"])
+    if running_timer_config.get("description") != "Playwright timer start":
+        raise ValueError(
+            "running activity config stored wrong description after timer start.\n"
+            f"{json.dumps(running_timer_config, indent=2)}"
+        )
+    if running_timer_config.get("category") != "work/project":
+        raise ValueError(
+            "running activity config stored wrong category after timer start.\n"
+            f"{json.dumps(running_timer_config, indent=2)}"
+        )
+    if any(
+        doc.get("docType") == "activity"
+        and doc.get("description") == "Playwright timer start"
+        for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+    ):
+        raise ValueError("starting a timer unexpectedly created an activity doc immediately")
+    demo_note("activities: timer started and running config persisted")
+    assert_no_page_errors_yet("timer start")
+
+    fill_locator_value(
+        page,
+        page.locator("#timer-description"),
+        "Playwright timer edited",
+        description="timer description edit",
+    )
+    page.locator("#timer-description").evaluate(
+        "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+    )
+    wait_until(
+        lambda: next(
+            (
+                normalized.get("description") == "Playwright timer edited"
+                for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
+                if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+            ),
+            False,
+        ),
+        "timer description config update",
+        timeout_s=10.0,
+        interval_s=0.1,
+    )
+    page.locator("#timer-category").select_option("work/meeting")
+    wait_until(
+        lambda: next(
+            (
+                normalized.get("category") == "work/meeting"
+                for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
+                if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+            ),
+            False,
+        ),
+        "timer category config update",
+        timeout_s=10.0,
+        interval_s=0.1,
+    )
+    original_start_date_time = wait_for_running_activity_config(
+        page, rooms["activities"]
+    ).get("startDateTime")
+    timer_start_backdate = get_relative_browser_time(page, -60)
+    fill_locator_value(
+        page,
+        page.locator("#timer-start-time"),
+        timer_start_backdate,
+        description="timer start time edit",
+    )
+    page.locator("#timer-start-time").evaluate(
+        "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+    )
+    wait_until(
+        lambda: next(
+            (
+                normalized.get("startDateTime") != original_start_date_time
+                for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
+                if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+            ),
+            False,
+        ),
+        "timer start time config update",
+        timeout_s=10.0,
+        interval_s=0.1,
+    )
+    wait_for_input_value(
+        page,
+        "#timer-start-time",
+        timer_start_backdate,
+        description="timer start time field after backdate",
+    )
+
+    stop_activity_timer(page)
+    wait_until(
+        lambda: not any(
+            normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
+            for doc in read_docs(page, rooms["activities"])
+        ),
+        "running activity config cleared after stop",
+    )
+    stopped_timer_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright timer edited",
+    )
+    if stopped_timer_doc.get("source") != "timer":
+        raise ValueError(
+            f"stopped timer activity had wrong source.\n{json.dumps(stopped_timer_doc, indent=2)}"
+        )
+    if stopped_timer_doc.get("category") != "work/meeting":
+        raise ValueError(
+            f"stopped timer activity had wrong category.\n{json.dumps(stopped_timer_doc, indent=2)}"
+        )
+    if stopped_timer_doc.get("duration", 0) <= 0:
+        raise ValueError(
+            f"stopped timer activity did not record positive duration.\n{json.dumps(stopped_timer_doc, indent=2)}"
+        )
+    if stopped_timer_doc.get("sourceTaskId") is not None:
+        raise ValueError(
+            f"timer activity unexpectedly linked to a source task.\n{json.dumps(stopped_timer_doc, indent=2)}"
+        )
+    demo_note("activities: timer edits and stop-to-activity persistence verified")
+    assert_no_page_errors_yet("timer stop persistence")
+
+    start_activity_timer(
+        page,
+        "Playwright timer replace first",
+        category="work/project",
+        room_code=rooms["activities"],
+    )
+    replacement_timer_start = get_relative_browser_time(page, -30)
+    fill_locator_value(
+        page,
+        page.locator("#timer-start-time"),
+        replacement_timer_start,
+        description="replacement timer first start time",
+    )
+    page.locator("#timer-start-time").evaluate(
+        "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+    )
+    wait_for_input_value(
+        page,
+        "#timer-start-time",
+        replacement_timer_start,
+        description="replacement timer first start time applied",
+    )
+    start_activity_timer(
+        page,
+        "Playwright timer replace second",
+        category="work/comms",
+        room_code=rooms["activities"],
+    )
+    replacement_running_config = wait_for_running_activity_config(page, rooms["activities"])
+    if replacement_running_config.get("description") != "Playwright timer replace second":
+        raise ValueError(
+            "replacement timer did not become the new running timer.\n"
+            f"{json.dumps(replacement_running_config, indent=2)}"
+        )
+    replaced_timer_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright timer replace first",
+    )
+    if replaced_timer_doc.get("source") != "timer" or replaced_timer_doc.get("duration", 0) <= 0:
+        raise ValueError(
+            "replaced running timer did not persist as a positive-duration timer activity.\n"
+            f"{json.dumps(replaced_timer_doc, indent=2)}"
+        )
+    demo_note("activities: stop-on-start replacement flow verified")
+    assert_no_page_errors_yet("timer replacement flow")
+
+    page.reload(wait_until="load")
+    wait_for_main_app(page)
+    page.locator("#activity").check()
+    wait_for_running_timer_ui(page, "Playwright timer replace second")
+    restored_running_config = wait_for_running_activity_config(page, rooms["activities"])
+    if restored_running_config.get("description") != "Playwright timer replace second":
+        raise ValueError(
+            "running timer was not restored after reload.\n"
+            f"{json.dumps(restored_running_config, indent=2)}"
+        )
+    demo_note("activities: running timer restored after reload")
+    assert_no_page_errors_yet("timer reload restore")
+
+    overlap_timer_start = get_relative_browser_time(page, -15)
+    fill_locator_value(
+        page,
+        page.locator("#timer-start-time"),
+        overlap_timer_start,
+        description="overlap timer start time",
+    )
+    page.locator("#timer-start-time").evaluate(
+        "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+    )
+    wait_for_input_value(
+        page,
+        "#timer-start-time",
+        overlap_timer_start,
+        description="overlap timer start time applied",
+    )
+
+    add_active_scheduled_task(page, "Playwright overlap auto-stop", 20)
+    overlap_task_doc = wait_for_task_doc(
+        page,
+        rooms["activities"],
+        "Playwright overlap auto-stop",
+    )
+    complete_scheduled_task_via_ui(page, overlap_task_doc["id"])
+    overlap_auto_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright overlap auto-stop",
+    )
+    overlap_timer_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright timer replace second",
+    )
+    if overlap_auto_activity_doc.get("source") != "auto":
+        raise ValueError(
+            "overlap auto-log activity had wrong source.\n"
+            f"{json.dumps(overlap_auto_activity_doc, indent=2)}"
+        )
+    if overlap_timer_doc.get("source") != "timer":
+        raise ValueError(
+            "overlap auto-stop did not persist the running timer as a timer activity.\n"
+            f"{json.dumps(overlap_timer_doc, indent=2)}"
+        )
+    if any(
+        normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
+        for doc in read_docs(page, rooms["activities"])
+    ):
+        raise ValueError("overlap auto-stop left a running activity config behind")
+    wait_until(
+        lambda: not page.locator("#timer-display").is_visible(),
+        "timer display hidden after overlap auto-stop",
+    )
+    demo_note("activities: overlapping scheduled completion auto-stopped running timer")
+    assert_no_page_errors_yet("overlap auto-stop")
+
+    start_activity_timer(
+        page,
+        "Playwright boundary timer",
+        room_code=rooms["activities"],
+    )
+    boundary_running_config = wait_for_running_activity_config(page, rooms["activities"])
+    boundary_safe_start = get_relative_browser_time(page, 5)
+    fill_locator_value(
+        page,
+        page.locator("#timer-start-time"),
+        boundary_safe_start,
+        description="boundary timer future start time",
+    )
+    page.locator("#timer-start-time").evaluate(
+        "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+    )
+    wait_for_input_value(
+        page,
+        "#timer-start-time",
+        boundary_safe_start,
+        description="boundary timer future start time applied",
+    )
+    boundary_running_config = wait_for_running_activity_config(page, rooms["activities"])
+    add_active_scheduled_task(page, "Playwright boundary auto-log", 20)
+    boundary_task_doc = wait_for_task_doc(
+        page,
+        rooms["activities"],
+        "Playwright boundary auto-log",
+    )
+    complete_scheduled_task_via_ui(page, boundary_task_doc["id"])
+    boundary_auto_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright boundary auto-log",
+    )
+    if boundary_auto_activity_doc.get("source") != "auto":
+        raise ValueError(
+            "boundary auto-log activity had wrong source.\n"
+            f"{json.dumps(boundary_auto_activity_doc, indent=2)}"
+        )
+    boundary_running_config_after = wait_for_running_activity_config(
+        page,
+        rooms["activities"],
+    )
+    if boundary_running_config_after.get("description") != "Playwright boundary timer":
+        raise ValueError(
+            "boundary timer was unexpectedly replaced or stopped.\n"
+            f"{json.dumps(boundary_running_config_after, indent=2)}"
+        )
+    if boundary_running_config_after.get("startDateTime") != boundary_running_config.get(
+        "startDateTime"
+    ):
+        raise ValueError(
+            "boundary timer start time changed unexpectedly after non-overlap case.\n"
+            f"before={json.dumps(boundary_running_config, indent=2)}\n"
+            f"after={json.dumps(boundary_running_config_after, indent=2)}"
+        )
+    if any(
+        doc.get("docType") == "activity"
+        and doc.get("description") == "Playwright boundary timer"
+        for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+    ):
+        raise ValueError("boundary timer unexpectedly auto-stopped in a non-overlap case")
+    page.locator("#activity").check()
+    wait_for_running_timer_ui(page, "Playwright boundary timer")
+    boundary_stop_start = get_relative_browser_time(page, -1)
+    fill_locator_value(
+        page,
+        page.locator("#timer-start-time"),
+        boundary_stop_start,
+        description="boundary timer stop start time",
+    )
+    page.locator("#timer-start-time").evaluate(
+        "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+    )
+    wait_for_input_value(
+        page,
+        "#timer-start-time",
+        boundary_stop_start,
+        description="boundary timer stop start time applied",
+    )
+    stop_activity_timer(page)
+    wait_for_activity_doc(page, rooms["activities"], "Playwright boundary timer")
+    demo_note("activities: boundary non-overlap preserved the running timer until manual stop")
+    assert_no_page_errors_yet("boundary non-overlap")
+
 def run_smoke(
     preview_url: str,
     *,
@@ -1583,7 +2168,7 @@ def run_smoke(
                         page.locator('#category-select option[value="work/project"]').text_content()
                         or ""
                     )
-                    == "â€º Project",
+                    == "Ã¢â‚¬Âº Project",
                     "visible nested project category option",
                 )
 
@@ -1862,583 +2447,12 @@ def run_smoke(
             run_legacy_room_scenario()
 
             run_taxonomy_room_scenario()
-            demo_step(page, "checking activities room flows", step_pause_ms)
-            switch_room(page, rooms["activities"])
-            clear_room_storage(page, rooms["activities"])
-            seed_docs(page, rooms["activities"], [build_phase3_taxonomy_config_doc()])
-            set_activities_enabled(page, True)
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
-
-            add_activity(page, "Playwright manual activity", "13:00", 30)
-            manual_activity_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright manual activity",
+            run_activities_room_scenario(
+                page=page,
+                rooms=rooms,
+                step_pause_ms=step_pause_ms,
+                assert_no_page_errors_yet=assert_no_page_errors_yet,
             )
-            if manual_activity_doc.get("source") != "manual":
-                raise ValueError(
-                    f"manual activity was not stored as manual.\n{json.dumps(manual_activity_doc, indent=2)}"
-                )
-            if manual_activity_doc.get("sourceTaskId") is not None:
-                raise ValueError(
-                    f"manual activity unexpectedly linked to a source task.\n{json.dumps(manual_activity_doc, indent=2)}"
-                )
-            if manual_activity_doc.get("duration") != 30:
-                raise ValueError(
-                    f"manual activity persisted wrong duration.\n{json.dumps(manual_activity_doc, indent=2)}"
-                )
-            wait_for_text_in_locator(
-                page,
-                "#activity-list",
-                "Playwright manual activity",
-                description="manual activity render",
-            )
-            demo_note("activities: manual activity add persisted and rendered")
-            assert_no_page_errors_yet("manual activity add")
-
-            queue_activity_smoke_failure(page, "manual-add", 1)
-            add_activity(page, "Playwright failed activity", "13:45", 15)
-            wait_for_activity_failure_alert(
-                page,
-                rooms["activities"],
-                "Playwright failed activity",
-            )
-            wait_for_text_in_locator(
-                page,
-                "#custom-alert-message",
-                "Could not log activity.",
-                description="manual activity failure alert",
-            )
-            failed_activity_description = page.locator(
-                task_form_input_selector("description")
-            ).input_value()
-            if failed_activity_description != "Playwright failed activity":
-                raise ValueError(
-                    "manual activity failure cleared the form unexpectedly: "
-                    f"{failed_activity_description!r}"
-                )
-            page.locator("#ok-custom-alert-modal").click()
-            page.locator("#custom-alert-modal").wait_for(state="hidden", timeout=10000)
-            if any(
-                doc.get("description") == "Playwright failed activity"
-                for doc in read_docs(page, rooms["activities"])
-            ):
-                raise ValueError("failed manual activity unexpectedly persisted")
-            demo_note("activities: manual add failure path preserved form state")
-            assert_no_page_errors_yet("manual add failure path")
-
-            add_active_scheduled_task(page, "Playwright auto-log success", 20)
-            success_task_doc = wait_for_task_doc(
-                page,
-                rooms["activities"],
-                "Playwright auto-log success",
-            )
-            complete_scheduled_task_via_ui(page, success_task_doc["id"])
-            success_activity_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright auto-log success",
-            )
-            if success_activity_doc.get("source") != "auto":
-                raise ValueError(
-                    f"successful auto-log activity had wrong source.\n{json.dumps(success_activity_doc, indent=2)}"
-                )
-            if success_activity_doc.get("sourceTaskId") != success_task_doc["id"]:
-                raise ValueError(
-                    "successful auto-log activity did not keep the source task id.\n"
-                    f"{json.dumps(success_activity_doc, indent=2)}"
-                )
-            wait_for_text_in_locator(
-                page,
-                "#activity-list",
-                "Playwright auto-log success",
-                description="successful auto-log activity render",
-            )
-            demo_note("activities: scheduled-task auto-log success verified")
-            assert_no_page_errors_yet("auto-log success")
-
-            add_active_scheduled_task(page, "Playwright auto-log failure", 20)
-            failing_task_doc = wait_for_task_doc(
-                page,
-                rooms["activities"],
-                "Playwright auto-log failure",
-            )
-            queue_activity_smoke_failure(page, "auto-log", 1)
-            complete_scheduled_task_via_ui(page, failing_task_doc["id"])
-            wait_for_toast_text(page, "Task completed, but activity auto-log failed.")
-            if any(
-                doc.get("docType") == "activity"
-                and doc.get("description") == "Playwright auto-log failure"
-                for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-            ):
-                raise ValueError("failed auto-log unexpectedly created an activity")
-            demo_note("activities: auto-log failure path surfaced toast without persisting activity")
-            assert_no_page_errors_yet("auto-log failure path")
-
-            add_unscheduled_task(page, "Playwright delete confirm task", 15)
-            delete_confirm_task_doc = wait_for_task_doc(
-                page,
-                rooms["activities"],
-                "Playwright delete confirm task",
-            )
-
-            add_activity(page, "Playwright editable activity", "15:30", 15)
-            editable_activity_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright editable activity",
-            )
-            wait_for_activity_row_text(
-                page,
-                editable_activity_doc["id"],
-                "Playwright editable activity",
-            )
-            arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
-            page.locator(
-                f'[data-activity-id="{editable_activity_doc["id"]}"] .btn-edit-activity'
-            ).click()
-            page.locator(
-                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"]'
-            ).wait_for(state="visible", timeout=10000)
-            current_modal_value = wait_for_input_value(
-                page,
-                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] input[name="description"]',
-                "Playwright editable activity",
-                description="activity inline edit description preload",
-            )
-            if current_modal_value != "Playwright editable activity":
-                raise ValueError(
-                    "activity inline edit lost the current description after rerender: "
-                    f"{current_modal_value!r}"
-                )
-            fill_locator_value(
-                page,
-                page.locator(
-                    f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] input[name="description"]'
-                ),
-                "Playwright editable activity updated",
-                description="activity inline edit description",
-            )
-            page.locator(
-                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] .btn-save-activity-edit'
-            ).click()
-            page.locator(
-                f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"]'
-            ).wait_for(state="hidden", timeout=10000)
-            wait_until(
-                lambda: any(
-                    doc.get("id") == editable_activity_doc["id"]
-                    and doc.get("description") == "Playwright editable activity updated"
-                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-                ),
-                "activity edit after delete-confirm rerender",
-            )
-            if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
-                raise ValueError("delete confirm state was not cleared by activity edit")
-            demo_note("activities: inline edit survived delete-confirm rerender state")
-            assert_no_page_errors_yet("activity inline edit")
-
-            add_activity(page, "Playwright delete activity", "16:00", 10)
-            deletable_activity_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright delete activity",
-            )
-            wait_for_activity_row_text(
-                page,
-                deletable_activity_doc["id"],
-                "Playwright delete activity",
-            )
-            arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
-            page.locator(
-                f'[data-activity-id="{deletable_activity_doc["id"]}"] .btn-delete-activity'
-            ).click()
-            wait_until(
-                lambda: not any(
-                    doc.get("id") == deletable_activity_doc["id"]
-                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-                ),
-                "activity delete after delete-confirm rerender",
-            )
-            if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
-                raise ValueError("delete confirm state was not cleared by activity delete")
-            demo_note("activities: manual activity delete verified")
-            assert_no_page_errors_yet("manual activity delete")
-
-            try:
-                start_activity_timer(
-                    page,
-                    "Playwright timer start",
-                    category="work/project",
-                    room_code=rooms["activities"],
-                )
-            except Exception as error:
-                timer_start_state = page.evaluate(
-                    """
-                    () => ({
-                        scheduledChecked: document.getElementById('scheduled')?.checked ?? null,
-                        unscheduledChecked: document.getElementById('unscheduled')?.checked ?? null,
-                        activityChecked: document.getElementById('activity')?.checked ?? null,
-                        addTaskText: document.getElementById('add-task-btn')?.textContent ?? null,
-                        startTimerHidden:
-                            document.getElementById('start-timer-btn')?.classList.contains('hidden') ??
-                            null,
-                        formDescription:
-                            document.querySelector('#task-form input[name="description"]')?.value ??
-                            null,
-                        formCategory:
-                            document.querySelector('#task-form select[name="category"]')?.value ??
-                            null,
-                        formPlaceholder:
-                            document
-                                .querySelector('#task-form input[name="description"]')
-                                ?.getAttribute('placeholder') ?? null,
-                        timerVisible:
-                            !(document.getElementById('timer-display')?.classList.contains('hidden') ??
-                            true),
-                        timerDescription: document.getElementById('timer-description')?.value ?? null,
-                        timerCategory: document.getElementById('timer-category')?.value ?? null,
-                        alertVisible:
-                            !(document.getElementById('custom-alert-modal')?.classList.contains('hidden') ??
-                            true),
-                        alertMessage:
-                            document.getElementById('custom-alert-message')?.textContent ?? null,
-                        taskFormActivityClass:
-                            document.getElementById('task-form')?.classList.contains('task-form--activity') ??
-                            null
-                    })
-                    """
-                )
-                timer_start_docs = list(map(normalize_doc, read_docs(page, rooms["activities"])))
-                raise ValueError(
-                    "Initial timer start failed.\n"
-                    f"error={error!r}\n"
-                    f"state={json.dumps(timer_start_state, indent=2)}\n"
-                    f"docs={json.dumps(timer_start_docs, indent=2)}"
-                ) from error
-            running_timer_config = wait_for_running_activity_config(page, rooms["activities"])
-            if running_timer_config.get("description") != "Playwright timer start":
-                raise ValueError(
-                    "running activity config stored wrong description after timer start.\n"
-                    f"{json.dumps(running_timer_config, indent=2)}"
-                )
-            if running_timer_config.get("category") != "work/project":
-                raise ValueError(
-                    "running activity config stored wrong category after timer start.\n"
-                    f"{json.dumps(running_timer_config, indent=2)}"
-                )
-            if any(
-                doc.get("docType") == "activity"
-                and doc.get("description") == "Playwright timer start"
-                for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-            ):
-                raise ValueError("starting a timer unexpectedly created an activity doc immediately")
-            demo_note("activities: timer started and running config persisted")
-            assert_no_page_errors_yet("timer start")
-
-            fill_locator_value(
-                page,
-                page.locator("#timer-description"),
-                "Playwright timer edited",
-                description="timer description edit",
-            )
-            page.locator("#timer-description").evaluate(
-                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
-            )
-            wait_until(
-                lambda: next(
-                    (
-                        normalized.get("description") == "Playwright timer edited"
-                        for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
-                        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
-                    ),
-                    False,
-                ),
-                "timer description config update",
-                timeout_s=10.0,
-                interval_s=0.1,
-            )
-            page.locator("#timer-category").select_option("work/meeting")
-            wait_until(
-                lambda: next(
-                    (
-                        normalized.get("category") == "work/meeting"
-                        for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
-                        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
-                    ),
-                    False,
-                ),
-                "timer category config update",
-                timeout_s=10.0,
-                interval_s=0.1,
-            )
-            original_start_date_time = wait_for_running_activity_config(
-                page, rooms["activities"]
-            ).get("startDateTime")
-            timer_start_backdate = get_relative_browser_time(page, -60)
-            fill_locator_value(
-                page,
-                page.locator("#timer-start-time"),
-                timer_start_backdate,
-                description="timer start time edit",
-            )
-            page.locator("#timer-start-time").evaluate(
-                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
-            )
-            wait_until(
-                lambda: next(
-                    (
-                        normalized.get("startDateTime") != original_start_date_time
-                        for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
-                        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
-                    ),
-                    False,
-                ),
-                "timer start time config update",
-                timeout_s=10.0,
-                interval_s=0.1,
-            )
-            wait_for_input_value(
-                page,
-                "#timer-start-time",
-                timer_start_backdate,
-                description="timer start time field after backdate",
-            )
-
-            stop_activity_timer(page)
-            wait_until(
-                lambda: not any(
-                    normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
-                    for doc in read_docs(page, rooms["activities"])
-                ),
-                "running activity config cleared after stop",
-            )
-            stopped_timer_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright timer edited",
-            )
-            if stopped_timer_doc.get("source") != "timer":
-                raise ValueError(
-                    f"stopped timer activity had wrong source.\n{json.dumps(stopped_timer_doc, indent=2)}"
-                )
-            if stopped_timer_doc.get("category") != "work/meeting":
-                raise ValueError(
-                    f"stopped timer activity had wrong category.\n{json.dumps(stopped_timer_doc, indent=2)}"
-                )
-            if stopped_timer_doc.get("duration", 0) <= 0:
-                raise ValueError(
-                    f"stopped timer activity did not record positive duration.\n{json.dumps(stopped_timer_doc, indent=2)}"
-                )
-            if stopped_timer_doc.get("sourceTaskId") is not None:
-                raise ValueError(
-                    f"timer activity unexpectedly linked to a source task.\n{json.dumps(stopped_timer_doc, indent=2)}"
-                )
-            demo_note("activities: timer edits and stop-to-activity persistence verified")
-            assert_no_page_errors_yet("timer stop persistence")
-
-            start_activity_timer(
-                page,
-                "Playwright timer replace first",
-                category="work/project",
-                room_code=rooms["activities"],
-            )
-            replacement_timer_start = get_relative_browser_time(page, -30)
-            fill_locator_value(
-                page,
-                page.locator("#timer-start-time"),
-                replacement_timer_start,
-                description="replacement timer first start time",
-            )
-            page.locator("#timer-start-time").evaluate(
-                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
-            )
-            wait_for_input_value(
-                page,
-                "#timer-start-time",
-                replacement_timer_start,
-                description="replacement timer first start time applied",
-            )
-            start_activity_timer(
-                page,
-                "Playwright timer replace second",
-                category="work/comms",
-                room_code=rooms["activities"],
-            )
-            replacement_running_config = wait_for_running_activity_config(page, rooms["activities"])
-            if replacement_running_config.get("description") != "Playwright timer replace second":
-                raise ValueError(
-                    "replacement timer did not become the new running timer.\n"
-                    f"{json.dumps(replacement_running_config, indent=2)}"
-                )
-            replaced_timer_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright timer replace first",
-            )
-            if replaced_timer_doc.get("source") != "timer" or replaced_timer_doc.get("duration", 0) <= 0:
-                raise ValueError(
-                    "replaced running timer did not persist as a positive-duration timer activity.\n"
-                    f"{json.dumps(replaced_timer_doc, indent=2)}"
-                )
-            demo_note("activities: stop-on-start replacement flow verified")
-            assert_no_page_errors_yet("timer replacement flow")
-
-            page.reload(wait_until="load")
-            wait_for_main_app(page)
-            page.locator("#activity").check()
-            wait_for_running_timer_ui(page, "Playwright timer replace second")
-            restored_running_config = wait_for_running_activity_config(page, rooms["activities"])
-            if restored_running_config.get("description") != "Playwright timer replace second":
-                raise ValueError(
-                    "running timer was not restored after reload.\n"
-                    f"{json.dumps(restored_running_config, indent=2)}"
-                )
-            demo_note("activities: running timer restored after reload")
-            assert_no_page_errors_yet("timer reload restore")
-
-            overlap_timer_start = get_relative_browser_time(page, -15)
-            fill_locator_value(
-                page,
-                page.locator("#timer-start-time"),
-                overlap_timer_start,
-                description="overlap timer start time",
-            )
-            page.locator("#timer-start-time").evaluate(
-                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
-            )
-            wait_for_input_value(
-                page,
-                "#timer-start-time",
-                overlap_timer_start,
-                description="overlap timer start time applied",
-            )
-
-            add_active_scheduled_task(page, "Playwright overlap auto-stop", 20)
-            overlap_task_doc = wait_for_task_doc(
-                page,
-                rooms["activities"],
-                "Playwright overlap auto-stop",
-            )
-            complete_scheduled_task_via_ui(page, overlap_task_doc["id"])
-            overlap_auto_activity_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright overlap auto-stop",
-            )
-            overlap_timer_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright timer replace second",
-            )
-            if overlap_auto_activity_doc.get("source") != "auto":
-                raise ValueError(
-                    "overlap auto-log activity had wrong source.\n"
-                    f"{json.dumps(overlap_auto_activity_doc, indent=2)}"
-                )
-            if overlap_timer_doc.get("source") != "timer":
-                raise ValueError(
-                    "overlap auto-stop did not persist the running timer as a timer activity.\n"
-                    f"{json.dumps(overlap_timer_doc, indent=2)}"
-                )
-            if any(
-                normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
-                for doc in read_docs(page, rooms["activities"])
-            ):
-                raise ValueError("overlap auto-stop left a running activity config behind")
-            wait_until(
-                lambda: not page.locator("#timer-display").is_visible(),
-                "timer display hidden after overlap auto-stop",
-            )
-            demo_note("activities: overlapping scheduled completion auto-stopped running timer")
-            assert_no_page_errors_yet("overlap auto-stop")
-
-            start_activity_timer(
-                page,
-                "Playwright boundary timer",
-                room_code=rooms["activities"],
-            )
-            boundary_running_config = wait_for_running_activity_config(page, rooms["activities"])
-            boundary_safe_start = get_relative_browser_time(page, 5)
-            fill_locator_value(
-                page,
-                page.locator("#timer-start-time"),
-                boundary_safe_start,
-                description="boundary timer future start time",
-            )
-            page.locator("#timer-start-time").evaluate(
-                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
-            )
-            wait_for_input_value(
-                page,
-                "#timer-start-time",
-                boundary_safe_start,
-                description="boundary timer future start time applied",
-            )
-            boundary_running_config = wait_for_running_activity_config(page, rooms["activities"])
-            add_active_scheduled_task(page, "Playwright boundary auto-log", 20)
-            boundary_task_doc = wait_for_task_doc(
-                page,
-                rooms["activities"],
-                "Playwright boundary auto-log",
-            )
-            complete_scheduled_task_via_ui(page, boundary_task_doc["id"])
-            boundary_auto_activity_doc = wait_for_activity_doc(
-                page,
-                rooms["activities"],
-                "Playwright boundary auto-log",
-            )
-            if boundary_auto_activity_doc.get("source") != "auto":
-                raise ValueError(
-                    "boundary auto-log activity had wrong source.\n"
-                    f"{json.dumps(boundary_auto_activity_doc, indent=2)}"
-                )
-            boundary_running_config_after = wait_for_running_activity_config(
-                page,
-                rooms["activities"],
-            )
-            if boundary_running_config_after.get("description") != "Playwright boundary timer":
-                raise ValueError(
-                    "boundary timer was unexpectedly replaced or stopped.\n"
-                    f"{json.dumps(boundary_running_config_after, indent=2)}"
-                )
-            if boundary_running_config_after.get("startDateTime") != boundary_running_config.get(
-                "startDateTime"
-            ):
-                raise ValueError(
-                    "boundary timer start time changed unexpectedly after non-overlap case.\n"
-                    f"before={json.dumps(boundary_running_config, indent=2)}\n"
-                    f"after={json.dumps(boundary_running_config_after, indent=2)}"
-                )
-            if any(
-                doc.get("docType") == "activity"
-                and doc.get("description") == "Playwright boundary timer"
-                for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-            ):
-                raise ValueError("boundary timer unexpectedly auto-stopped in a non-overlap case")
-            page.locator("#activity").check()
-            wait_for_running_timer_ui(page, "Playwright boundary timer")
-            boundary_stop_start = get_relative_browser_time(page, -1)
-            fill_locator_value(
-                page,
-                page.locator("#timer-start-time"),
-                boundary_stop_start,
-                description="boundary timer stop start time",
-            )
-            page.locator("#timer-start-time").evaluate(
-                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
-            )
-            wait_for_input_value(
-                page,
-                "#timer-start-time",
-                boundary_stop_start,
-                description="boundary timer stop start time applied",
-            )
-            stop_activity_timer(page)
-            wait_for_activity_doc(page, rooms["activities"], "Playwright boundary timer")
-            demo_note("activities: boundary non-overlap preserved the running timer until manual stop")
-            assert_no_page_errors_yet("boundary non-overlap")
 
             browser_captured_errors = page.evaluate(
                 "() => window.__fortudoSmokeBrowserErrors || []"

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -15,6 +15,13 @@ from urllib.request import Request, urlopen
 
 COUCHDB_URL_RE = re.compile(r"COUCHDB_URL\s*=\s*(?:'([^']*)'|null)")
 ACTIVITY_SMOKE_FAILURES_KEY = "fortudo-smoke-activity-failures"
+RUNNING_ACTIVITY_CONFIG_ID = "config-running-activity"
+DEMO_LOGGING_ENABLED = False
+
+
+def configure_demo_logging(*, enabled: bool) -> None:
+    global DEMO_LOGGING_ENABLED
+    DEMO_LOGGING_ENABLED = enabled
 
 
 def normalize_doc(doc: dict[str, Any]) -> dict[str, Any]:
@@ -478,11 +485,131 @@ def add_activity(page: Any, description: str, start_time: str, duration_minutes:
     page.locator("#task-form button[type='submit']").click()
 
 
+def force_activity_mode(page: Any) -> None:
+    page.evaluate(
+        """
+        () => {
+            const scheduled = document.getElementById('scheduled');
+            const unscheduled = document.getElementById('unscheduled');
+            const activity = document.getElementById('activity');
+            if (!(activity instanceof HTMLInputElement)) {
+                return;
+            }
+
+            if (scheduled instanceof HTMLInputElement) {
+                scheduled.checked = false;
+            }
+            if (unscheduled instanceof HTMLInputElement) {
+                unscheduled.checked = false;
+            }
+
+            activity.checked = true;
+            activity.dispatchEvent(new Event('input', { bubbles: true }));
+            activity.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        """
+    )
+
+    wait_until(
+        lambda: not page.locator('#start-timer-btn').is_hidden()
+        and (
+            page.locator('#timer-display').is_visible()
+            or 'Log Activity' in (page.locator('#add-task-btn').text_content() or '')
+        ),
+        "activity mode sync",
+        timeout_s=10.0,
+        interval_s=0.1,
+    )
+
+
+def start_activity_timer(
+    page: Any,
+    description: str,
+    category: str | None = None,
+    *,
+    room_code: str | None = None,
+) -> None:
+    timer_display = page.locator("#timer-display")
+    if not timer_display.is_visible():
+        force_activity_mode(page)
+
+    if timer_display.is_visible():
+        if category is not None:
+            page.locator("#timer-category").select_option(category)
+        fill_locator_value(
+            page,
+            page.locator("#timer-description"),
+            description,
+            description="running timer description",
+        )
+        wait_for_input_value(
+            page,
+            "#timer-description",
+            description,
+            description="running timer description before start",
+        )
+    else:
+        if category is not None:
+            page.locator('#task-form select[name="category"]').select_option(category)
+        fill_locator_value(
+            page,
+            page.locator(task_form_input_selector("description")),
+            description,
+            description="timer start description",
+        )
+        wait_for_input_value(
+            page,
+            task_form_input_selector("description"),
+            description,
+            description="timer start description before click",
+        )
+
+    page.locator("#start-timer-btn").click()
+    if room_code:
+        wait_for_running_activity_config(
+            page,
+            room_code,
+            expected_description=description,
+            expected_category=category,
+        )
+    wait_for_running_timer_ui(page, description)
+
+
+def get_relative_browser_time(page: Any, minutes_delta: int) -> str:
+    value = page.evaluate(
+        """
+        (offsetMinutes) => {
+            const now = new Date();
+            const currentMinutes = now.getHours() * 60 + now.getMinutes();
+            const requestedMinutes = currentMinutes + Number(offsetMinutes || 0);
+            const clampedMinutes = Math.max(0, Math.min(1439, requestedMinutes));
+            const hours = String(Math.floor(clampedMinutes / 60)).padStart(2, '0');
+            const minutes = String(clampedMinutes % 60).padStart(2, '0');
+            return `${hours}:${minutes}`;
+        }
+        """,
+        minutes_delta,
+    )
+    if not value:
+        raise ValueError("Could not derive a browser-relative time value.")
+    return value
+
+
+def stop_activity_timer(
+    page: Any, *, timeout_s: float = 10.0, interval_s: float = 0.2
+) -> None:
+    page.locator("#timer-stop-btn").click()
+    wait_until(
+        lambda: not page.locator("#timer-display").is_visible(),
+        "timer display hidden after stop",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+
+
 def add_active_scheduled_task(page: Any, description: str, duration_minutes: int) -> None:
     page.locator("#scheduled").check()
-    start_time = page.locator(task_form_input_selector("start-time")).input_value()
-    if not start_time:
-        raise ValueError("Scheduled task form did not provide a suggested start time.")
+    start_time = get_relative_browser_time(page, -1)
 
     add_scheduled_task(page, description, start_time, duration_minutes)
 
@@ -497,6 +624,16 @@ def ensure_activity_doc_present(
     raise ValueError(f"Missing activity document for {room_code}: {description}")
 
 
+def get_running_activity_config(
+    room_code: str, docs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    for doc in docs:
+        normalized = normalize_doc(doc)
+        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID:
+            return normalized
+    raise ValueError(f"Missing running activity config for {room_code}")
+
+
 def wait_for_activity_doc(
     page: Any,
     room_code: str,
@@ -504,7 +641,7 @@ def wait_for_activity_doc(
     *,
     timeout_s: float = 15.0,
     interval_s: float = 0.2,
-) -> dict[str, Any]:
+    ) -> dict[str, Any]:
     return wait_until(
         lambda: next(
             (
@@ -516,6 +653,37 @@ def wait_for_activity_doc(
             False,
         ),
         f"activity persistence for {description!r}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
+
+
+def wait_for_running_activity_config(
+    page: Any,
+    room_code: str,
+    *,
+    expected_description: str | None = None,
+    expected_category: str | None = None,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.2,
+) -> dict[str, Any]:
+    return wait_until(
+        lambda: next(
+            (
+                normalized
+                for normalized in map(normalize_doc, read_docs(page, room_code))
+                if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+                and (
+                    expected_description is None
+                    or normalized.get("description") == expected_description
+                )
+                and (
+                    expected_category is None or normalized.get("category") == expected_category
+                )
+            ),
+            False,
+        ),
+        f"running activity config persistence for {room_code!r}",
         timeout_s=timeout_s,
         interval_s=interval_s,
     )
@@ -553,6 +721,24 @@ def wait_for_activity_failure_alert(
         )
     if outcome != "alert":
         raise TimeoutError(f"Timed out waiting for activity failure alert for {description!r}")
+
+
+def wait_for_running_timer_ui(
+    page: Any,
+    expected_description: str,
+    *,
+    timeout_s: float = 10.0,
+    interval_s: float = 0.2,
+) -> None:
+    wait_until(
+        lambda: (
+            page.locator("#timer-display").is_visible()
+            and page.locator("#timer-description").input_value() == expected_description
+        ),
+        f"running timer UI for {expected_description!r}",
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+    )
 
 
 def add_category_via_settings(page: Any, group_key: str, label: str) -> None:
@@ -1054,15 +1240,23 @@ def assert_no_runtime_errors(
     page_errors: list[str],
     request_failures: list[str],
     response_errors: list[tuple[int, str, str]],
+    browser_captured_errors: list[dict[str, Any]] | None = None,
 ) -> None:
     filtered_console_errors, filtered_request_failures, filtered_response_errors = (
         filter_runtime_errors(console_errors, request_failures, response_errors)
     )
-    if filtered_console_errors or page_errors or filtered_request_failures or filtered_response_errors:
+    if (
+        filtered_console_errors
+        or page_errors
+        or filtered_request_failures
+        or filtered_response_errors
+        or browser_captured_errors
+    ):
         raise ValueError(
             "Runtime errors detected.\n"
             f"Console errors: {json.dumps(filtered_console_errors[:10], indent=2)}\n"
             f"Page errors: {json.dumps(page_errors[:10], indent=2)}\n"
+            f"Browser captured errors: {json.dumps((browser_captured_errors or [])[:10], indent=2)}\n"
             f"Request failures: {json.dumps(filtered_request_failures[:10], indent=2)}\n"
             f"Response errors: {json.dumps(filtered_response_errors[:10], indent=2)}"
         )
@@ -1074,10 +1268,20 @@ def save_failure_screenshot(page: Any) -> None:
     page.screenshot(path=str(screenshot_dir / "playwright_preview_smoke_failure.png"), full_page=True)
 
 
+def format_demo_timestamp() -> str:
+    return time.strftime("%H:%M:%S")
+
+
+def demo_note(message: str) -> None:
+    if not DEMO_LOGGING_ENABLED:
+        return
+    print(f"[demo {format_demo_timestamp()}] {message}")
+
+
 def demo_step(page: Any, message: str, step_pause_ms: int) -> None:
     if step_pause_ms <= 0:
         return
-    print(f"[demo] {message}")
+    demo_note(message)
     page.wait_for_timeout(step_pause_ms)
 
 
@@ -1106,6 +1310,7 @@ def run_smoke(
 ) -> bool:
     from playwright.sync_api import sync_playwright
 
+    configure_demo_logging(enabled=demo and not headless)
     hostname = get_hostname_from_url(preview_url)
     rooms = create_scenario_rooms(create_run_scoped_prefix(hostname))
     couchdb_url = fetch_preview_couchdb_url(preview_url)
@@ -1114,7 +1319,7 @@ def run_smoke(
         reset_remote_preview_rooms(preview_url, hostname, rooms)
 
     console_errors: list[str] = []
-    page_errors: list[str] = []
+    page_errors: list[dict[str, Any]] = []
     request_failures: list[str] = []
     response_errors: list[tuple[int, str, str]] = []
 
@@ -1126,6 +1331,33 @@ def run_smoke(
         )
         browser = playwright.chromium.launch(**launch_options)
         context = browser.new_context(viewport={"width": 1440, "height": 960})
+        context.add_init_script(
+            """
+            window.__fortudoSmokeBrowserErrors = [];
+            const captureBrowserError = (payload) => {
+                window.__fortudoSmokeBrowserErrors.push(payload);
+            };
+            window.addEventListener('error', (event) => {
+                captureBrowserError({
+                    type: 'error',
+                    message: String(event.message || ''),
+                    source: String(event.filename || ''),
+                    line: Number(event.lineno || 0),
+                    column: Number(event.colno || 0),
+                    error: event.error ? String(event.error) : '',
+                    stack: event.error && event.error.stack ? String(event.error.stack) : '',
+                });
+            });
+            window.addEventListener('unhandledrejection', (event) => {
+                const reason = event.reason;
+                captureBrowserError({
+                    type: 'unhandledrejection',
+                    message: reason ? String(reason) : '',
+                    stack: reason && reason.stack ? String(reason.stack) : '',
+                });
+            });
+            """
+        )
         page = context.new_page()
 
         page.on(
@@ -1134,7 +1366,20 @@ def run_smoke(
             if message.type == "error"
             else None,
         )
-        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on(
+            "pageerror",
+            lambda error: page_errors.append(
+                {
+                    "type": type(error).__name__,
+                    "str": str(error),
+                    "repr": repr(error),
+                    "args": list(getattr(error, "args", [])),
+                    "name": getattr(error, "name", ""),
+                    "message": getattr(error, "message", ""),
+                    "stack": getattr(error, "stack", ""),
+                }
+            ),
+        )
         page.on(
             "requestfailed",
             lambda request: request_failures.append(
@@ -1151,6 +1396,12 @@ def run_smoke(
         )
 
         try:
+            def assert_no_page_errors_yet(label: str) -> None:
+                if page_errors:
+                    raise ValueError(
+                        f"Page errors surfaced by {label}.\n{json.dumps(page_errors, indent=2)}"
+                    )
+
             def wait_for_sync_status_normal(label: str) -> None:
                 if not couchdb_url:
                     return
@@ -1311,112 +1562,6 @@ def run_smoke(
                 )
                 wait_for_sync_status_normal("legacy")
 
-            demo_step(page, "checking cross-type isolation in alpha", step_pause_ms)
-            switch_room(page, rooms["alpha"])
-            wait_for_text_in_locator(
-                page,
-                "#scheduled-task-list",
-                "Playwright scheduled task edited",
-                description="alpha scheduled task reload",
-            )
-            seed_docs(
-                page,
-                rooms["alpha"],
-                [
-                    {"_id": "activity-smoke", "docType": "activity", "note": "keep me"},
-                    {"_id": "config-categories", "docType": "config", "categories": []},
-                ],
-            )
-
-            clear_all_tasks_via_ui(page)
-
-            wait_until(
-                lambda: (
-                    lambda docs: not any(
-                        doc.get("docType") == "task"
-                        or doc.get("type") in {"scheduled", "unscheduled"}
-                        for doc in docs
-                    )
-                    and any(doc.get("id") == "activity-smoke" for doc in docs)
-                    and any(doc.get("id") == "config-categories" for doc in docs)
-                )(list(map(normalize_doc, read_docs(page, rooms["alpha"])))),
-                "cross-type isolation persistence",
-            )
-            assert_non_task_docs_remain(
-                summarize_docs(read_docs(page, rooms["alpha"])),
-                {"activity_id": "activity-smoke", "config_id": "config-categories"},
-            )
-            if couchdb_url:
-                wait_until(
-                    lambda: (
-                        lambda summary: not summary["tasks"]
-                        and not summary["legacy_tasks"]
-                        and any(doc.get("id") == "activity-smoke" for doc in summary["activities"])
-                        and any(doc.get("id") == "config-categories" for doc in summary["configs"])
-                    )(read_remote_summary(rooms["alpha"])),
-                    "alpha remote clear-all sync",
-                    timeout_s=25.0,
-                )
-                wait_for_sync_status_normal("alpha clear-all")
-
-            demo_step(page, "checking beta room isolation", step_pause_ms)
-            dismiss_open_modals(page)
-            switch_room(page, rooms["beta"])
-            clear_room_storage(page, rooms["beta"])
-            beta_empty = summarize_docs(read_docs(page, rooms["beta"]))
-            if any(beta_empty[key] for key in beta_empty):
-                raise ValueError(f"beta room was not empty.\n{format_snapshot(beta_empty)}")
-
-            add_scheduled_task(page, "Playwright beta task", "10:00", 20)
-            wait_until(
-                lambda: any(
-                    doc.get("description") == "Playwright beta task"
-                    for doc in read_docs(page, rooms["beta"])
-                ),
-                "beta room task persistence",
-            )
-
-            beta_summary = summarize_docs(read_docs(page, rooms["beta"]))
-            if not any(
-                doc.get("description") == "Playwright beta task" for doc in beta_summary["tasks"]
-            ):
-                raise ValueError(f"beta room task missing.\n{format_snapshot(beta_summary)}")
-            if beta_summary["activities"] or beta_summary["configs"]:
-                raise ValueError(f"beta room leaked alpha docs.\n{format_snapshot(beta_summary)}")
-            if couchdb_url:
-                wait_until(
-                    lambda: (
-                        lambda summary: any(
-                            doc.get("description") == "Playwright beta task"
-                            for doc in summary["tasks"]
-                        )
-                        and not summary["activities"]
-                        and not summary["configs"]
-                    )(read_remote_summary(rooms["beta"])),
-                    "beta remote sync",
-                    timeout_s=25.0,
-                )
-                wait_for_sync_status_normal("beta")
-
-            demo_step(page, "returning to alpha for final sync verification", step_pause_ms)
-            switch_room(page, rooms["alpha"])
-            alpha_final = summarize_docs(read_docs(page, rooms["alpha"]))
-            if not any(doc.get("id") == "activity-smoke" for doc in alpha_final["activities"]):
-                raise ValueError(f"alpha room lost its activity doc.\n{format_snapshot(alpha_final)}")
-            if not any(doc.get("id") == "config-categories" for doc in alpha_final["configs"]):
-                raise ValueError(f"alpha room lost its config doc.\n{format_snapshot(alpha_final)}")
-            if any(
-                doc.get("description") == "Playwright beta task" for doc in alpha_final["tasks"]
-            ):
-                raise ValueError(f"alpha room picked up beta task data.\n{format_snapshot(alpha_final)}")
-            if couchdb_url:
-                alpha_remote_final = read_remote_summary(rooms["alpha"])
-                assert_non_task_docs_remain(
-                    alpha_remote_final,
-                    {"activity_id": "activity-smoke", "config_id": "config-categories"},
-                )
-                wait_for_sync_status_normal("alpha final")
-
             demo_step(page, "checking phase 3 taxonomy and settings room", step_pause_ms)
             switch_room(page, rooms["taxonomy"])
             clear_room_storage(page, rooms["taxonomy"])
@@ -1499,6 +1644,8 @@ def run_smoke(
                 ),
                 "linked work/project category recolor",
             )
+            demo_note("taxonomy: added break/walk and recolored work family to amber")
+            assert_no_page_errors_yet("taxonomy category mutations")
             close_settings_modal(page)
 
             page.locator("#scheduled").check()
@@ -1594,6 +1741,8 @@ def run_smoke(
                 )
             if "#b45309" not in unscheduled_badge_style:
                 raise ValueError(f"unscheduled child badge did not reflect amber family: {unscheduled_badge_style}")
+            demo_note("taxonomy: scheduled and unscheduled tasks persisted with expected category badges")
+            assert_no_page_errors_yet("taxonomy task persistence")
 
             page.reload(wait_until="load")
             wait_for_main_app(page)
@@ -1640,6 +1789,8 @@ def run_smoke(
                 raise ValueError(
                     f"taxonomy room did not persist compact add-category flow.\n{format_snapshot(taxonomy_summary)}"
                 )
+            demo_note("taxonomy: reload and settings persistence checks passed")
+            assert_no_page_errors_yet("taxonomy reload and settings persistence")
             if couchdb_url:
                 wait_until(
                     lambda: (
@@ -1675,24 +1826,37 @@ def run_smoke(
             demo_step(page, "checking activities room flows", step_pause_ms)
             switch_room(page, rooms["activities"])
             clear_room_storage(page, rooms["activities"])
+            seed_docs(page, rooms["activities"], [build_phase3_taxonomy_config_doc()])
             set_activities_enabled(page, True)
             page.reload(wait_until="load")
             wait_for_main_app(page)
 
             add_activity(page, "Playwright manual activity", "13:00", 30)
-            wait_until(
-                lambda: any(
-                    doc.get("description") == "Playwright manual activity"
-                    for doc in read_docs(page, rooms["activities"])
-                ),
-                "manual activity persistence",
+            manual_activity_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright manual activity",
             )
+            if manual_activity_doc.get("source") != "manual":
+                raise ValueError(
+                    f"manual activity was not stored as manual.\n{json.dumps(manual_activity_doc, indent=2)}"
+                )
+            if manual_activity_doc.get("sourceTaskId") is not None:
+                raise ValueError(
+                    f"manual activity unexpectedly linked to a source task.\n{json.dumps(manual_activity_doc, indent=2)}"
+                )
+            if manual_activity_doc.get("duration") != 30:
+                raise ValueError(
+                    f"manual activity persisted wrong duration.\n{json.dumps(manual_activity_doc, indent=2)}"
+                )
             wait_for_text_in_locator(
                 page,
                 "#activity-list",
                 "Playwright manual activity",
                 description="manual activity render",
             )
+            demo_note("activities: manual activity add persisted and rendered")
+            assert_no_page_errors_yet("manual activity add")
 
             queue_activity_smoke_failure(page, "manual-add", 1)
             add_activity(page, "Playwright failed activity", "13:45", 15)
@@ -1722,6 +1886,8 @@ def run_smoke(
                 for doc in read_docs(page, rooms["activities"])
             ):
                 raise ValueError("failed manual activity unexpectedly persisted")
+            demo_note("activities: manual add failure path preserved form state")
+            assert_no_page_errors_yet("manual add failure path")
 
             add_active_scheduled_task(page, "Playwright auto-log success", 20)
             success_task_doc = wait_for_task_doc(
@@ -1730,21 +1896,28 @@ def run_smoke(
                 "Playwright auto-log success",
             )
             complete_scheduled_task_via_ui(page, success_task_doc["id"])
-            wait_until(
-                lambda: any(
-                    doc.get("docType") == "activity"
-                    and doc.get("description") == "Playwright auto-log success"
-                    and doc.get("source") == "auto"
-                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-                ),
-                "successful auto-log activity persistence",
+            success_activity_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright auto-log success",
             )
+            if success_activity_doc.get("source") != "auto":
+                raise ValueError(
+                    f"successful auto-log activity had wrong source.\n{json.dumps(success_activity_doc, indent=2)}"
+                )
+            if success_activity_doc.get("sourceTaskId") != success_task_doc["id"]:
+                raise ValueError(
+                    "successful auto-log activity did not keep the source task id.\n"
+                    f"{json.dumps(success_activity_doc, indent=2)}"
+                )
             wait_for_text_in_locator(
                 page,
                 "#activity-list",
                 "Playwright auto-log success",
                 description="successful auto-log activity render",
             )
+            demo_note("activities: scheduled-task auto-log success verified")
+            assert_no_page_errors_yet("auto-log success")
 
             add_active_scheduled_task(page, "Playwright auto-log failure", 20)
             failing_task_doc = wait_for_task_doc(
@@ -1755,19 +1928,14 @@ def run_smoke(
             queue_activity_smoke_failure(page, "auto-log", 1)
             complete_scheduled_task_via_ui(page, failing_task_doc["id"])
             wait_for_toast_text(page, "Task completed, but activity auto-log failed.")
-            wait_until(
-                lambda: any(
-                    doc.get("id") == failing_task_doc["id"] and doc.get("status") == "completed"
-                    for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
-                ),
-                "failed auto-log task completion persistence",
-            )
             if any(
                 doc.get("docType") == "activity"
                 and doc.get("description") == "Playwright auto-log failure"
                 for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
             ):
                 raise ValueError("failed auto-log unexpectedly created an activity")
+            demo_note("activities: auto-log failure path surfaced toast without persisting activity")
+            assert_no_page_errors_yet("auto-log failure path")
 
             add_unscheduled_task(page, "Playwright delete confirm task", 15)
             delete_confirm_task_doc = wait_for_task_doc(
@@ -1829,6 +1997,8 @@ def run_smoke(
             )
             if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
                 raise ValueError("delete confirm state was not cleared by activity edit")
+            demo_note("activities: inline edit survived delete-confirm rerender state")
+            assert_no_page_errors_yet("activity inline edit")
 
             add_activity(page, "Playwright delete activity", "16:00", 10)
             deletable_activity_doc = wait_for_activity_doc(
@@ -1854,8 +2024,393 @@ def run_smoke(
             )
             if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
                 raise ValueError("delete confirm state was not cleared by activity delete")
+            demo_note("activities: manual activity delete verified")
+            assert_no_page_errors_yet("manual activity delete")
 
-            assert_no_runtime_errors(console_errors, page_errors, request_failures, response_errors)
+            try:
+                start_activity_timer(
+                    page,
+                    "Playwright timer start",
+                    category="work/project",
+                    room_code=rooms["activities"],
+                )
+            except Exception as error:
+                timer_start_state = page.evaluate(
+                    """
+                    () => ({
+                        scheduledChecked: document.getElementById('scheduled')?.checked ?? null,
+                        unscheduledChecked: document.getElementById('unscheduled')?.checked ?? null,
+                        activityChecked: document.getElementById('activity')?.checked ?? null,
+                        addTaskText: document.getElementById('add-task-btn')?.textContent ?? null,
+                        startTimerHidden:
+                            document.getElementById('start-timer-btn')?.classList.contains('hidden') ??
+                            null,
+                        formDescription:
+                            document.querySelector('#task-form input[name="description"]')?.value ??
+                            null,
+                        formCategory:
+                            document.querySelector('#task-form select[name="category"]')?.value ??
+                            null,
+                        formPlaceholder:
+                            document
+                                .querySelector('#task-form input[name="description"]')
+                                ?.getAttribute('placeholder') ?? null,
+                        timerVisible:
+                            !(document.getElementById('timer-display')?.classList.contains('hidden') ??
+                            true),
+                        timerDescription: document.getElementById('timer-description')?.value ?? null,
+                        timerCategory: document.getElementById('timer-category')?.value ?? null,
+                        alertVisible:
+                            !(document.getElementById('custom-alert-modal')?.classList.contains('hidden') ??
+                            true),
+                        alertMessage:
+                            document.getElementById('custom-alert-message')?.textContent ?? null,
+                        taskFormActivityClass:
+                            document.getElementById('task-form')?.classList.contains('task-form--activity') ??
+                            null
+                    })
+                    """
+                )
+                timer_start_docs = list(map(normalize_doc, read_docs(page, rooms["activities"])))
+                raise ValueError(
+                    "Initial timer start failed.\n"
+                    f"error={error!r}\n"
+                    f"state={json.dumps(timer_start_state, indent=2)}\n"
+                    f"docs={json.dumps(timer_start_docs, indent=2)}"
+                ) from error
+            running_timer_config = wait_for_running_activity_config(page, rooms["activities"])
+            if running_timer_config.get("description") != "Playwright timer start":
+                raise ValueError(
+                    "running activity config stored wrong description after timer start.\n"
+                    f"{json.dumps(running_timer_config, indent=2)}"
+                )
+            if running_timer_config.get("category") != "work/project":
+                raise ValueError(
+                    "running activity config stored wrong category after timer start.\n"
+                    f"{json.dumps(running_timer_config, indent=2)}"
+                )
+            if any(
+                doc.get("docType") == "activity"
+                and doc.get("description") == "Playwright timer start"
+                for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+            ):
+                raise ValueError("starting a timer unexpectedly created an activity doc immediately")
+            demo_note("activities: timer started and running config persisted")
+            assert_no_page_errors_yet("timer start")
+
+            fill_locator_value(
+                page,
+                page.locator("#timer-description"),
+                "Playwright timer edited",
+                description="timer description edit",
+            )
+            page.locator("#timer-description").evaluate(
+                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+            )
+            wait_until(
+                lambda: next(
+                    (
+                        normalized.get("description") == "Playwright timer edited"
+                        for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
+                        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+                    ),
+                    False,
+                ),
+                "timer description config update",
+                timeout_s=10.0,
+                interval_s=0.1,
+            )
+            page.locator("#timer-category").select_option("work/meeting")
+            wait_until(
+                lambda: next(
+                    (
+                        normalized.get("category") == "work/meeting"
+                        for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
+                        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+                    ),
+                    False,
+                ),
+                "timer category config update",
+                timeout_s=10.0,
+                interval_s=0.1,
+            )
+            original_start_date_time = wait_for_running_activity_config(
+                page, rooms["activities"]
+            ).get("startDateTime")
+            timer_start_backdate = get_relative_browser_time(page, -60)
+            fill_locator_value(
+                page,
+                page.locator("#timer-start-time"),
+                timer_start_backdate,
+                description="timer start time edit",
+            )
+            page.locator("#timer-start-time").evaluate(
+                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+            )
+            wait_until(
+                lambda: next(
+                    (
+                        normalized.get("startDateTime") != original_start_date_time
+                        for normalized in map(normalize_doc, read_docs(page, rooms["activities"]))
+                        if normalized.get("id") == RUNNING_ACTIVITY_CONFIG_ID
+                    ),
+                    False,
+                ),
+                "timer start time config update",
+                timeout_s=10.0,
+                interval_s=0.1,
+            )
+            wait_for_input_value(
+                page,
+                "#timer-start-time",
+                timer_start_backdate,
+                description="timer start time field after backdate",
+            )
+
+            stop_activity_timer(page)
+            wait_until(
+                lambda: not any(
+                    normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
+                    for doc in read_docs(page, rooms["activities"])
+                ),
+                "running activity config cleared after stop",
+            )
+            stopped_timer_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright timer edited",
+            )
+            if stopped_timer_doc.get("source") != "timer":
+                raise ValueError(
+                    f"stopped timer activity had wrong source.\n{json.dumps(stopped_timer_doc, indent=2)}"
+                )
+            if stopped_timer_doc.get("category") != "work/meeting":
+                raise ValueError(
+                    f"stopped timer activity had wrong category.\n{json.dumps(stopped_timer_doc, indent=2)}"
+                )
+            if stopped_timer_doc.get("duration", 0) <= 0:
+                raise ValueError(
+                    f"stopped timer activity did not record positive duration.\n{json.dumps(stopped_timer_doc, indent=2)}"
+                )
+            if stopped_timer_doc.get("sourceTaskId") is not None:
+                raise ValueError(
+                    f"timer activity unexpectedly linked to a source task.\n{json.dumps(stopped_timer_doc, indent=2)}"
+                )
+            demo_note("activities: timer edits and stop-to-activity persistence verified")
+            assert_no_page_errors_yet("timer stop persistence")
+
+            start_activity_timer(
+                page,
+                "Playwright timer replace first",
+                category="work/project",
+                room_code=rooms["activities"],
+            )
+            replacement_timer_start = get_relative_browser_time(page, -30)
+            fill_locator_value(
+                page,
+                page.locator("#timer-start-time"),
+                replacement_timer_start,
+                description="replacement timer first start time",
+            )
+            page.locator("#timer-start-time").evaluate(
+                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+            )
+            wait_for_input_value(
+                page,
+                "#timer-start-time",
+                replacement_timer_start,
+                description="replacement timer first start time applied",
+            )
+            start_activity_timer(
+                page,
+                "Playwright timer replace second",
+                category="work/comms",
+                room_code=rooms["activities"],
+            )
+            replacement_running_config = wait_for_running_activity_config(page, rooms["activities"])
+            if replacement_running_config.get("description") != "Playwright timer replace second":
+                raise ValueError(
+                    "replacement timer did not become the new running timer.\n"
+                    f"{json.dumps(replacement_running_config, indent=2)}"
+                )
+            replaced_timer_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright timer replace first",
+            )
+            if replaced_timer_doc.get("source") != "timer" or replaced_timer_doc.get("duration", 0) <= 0:
+                raise ValueError(
+                    "replaced running timer did not persist as a positive-duration timer activity.\n"
+                    f"{json.dumps(replaced_timer_doc, indent=2)}"
+                )
+            demo_note("activities: stop-on-start replacement flow verified")
+            assert_no_page_errors_yet("timer replacement flow")
+
+            page.reload(wait_until="load")
+            wait_for_main_app(page)
+            page.locator("#activity").check()
+            wait_for_running_timer_ui(page, "Playwright timer replace second")
+            restored_running_config = wait_for_running_activity_config(page, rooms["activities"])
+            if restored_running_config.get("description") != "Playwright timer replace second":
+                raise ValueError(
+                    "running timer was not restored after reload.\n"
+                    f"{json.dumps(restored_running_config, indent=2)}"
+                )
+            demo_note("activities: running timer restored after reload")
+            assert_no_page_errors_yet("timer reload restore")
+
+            overlap_timer_start = get_relative_browser_time(page, -15)
+            fill_locator_value(
+                page,
+                page.locator("#timer-start-time"),
+                overlap_timer_start,
+                description="overlap timer start time",
+            )
+            page.locator("#timer-start-time").evaluate(
+                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+            )
+            wait_for_input_value(
+                page,
+                "#timer-start-time",
+                overlap_timer_start,
+                description="overlap timer start time applied",
+            )
+
+            add_active_scheduled_task(page, "Playwright overlap auto-stop", 20)
+            overlap_task_doc = wait_for_task_doc(
+                page,
+                rooms["activities"],
+                "Playwright overlap auto-stop",
+            )
+            complete_scheduled_task_via_ui(page, overlap_task_doc["id"])
+            overlap_auto_activity_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright overlap auto-stop",
+            )
+            overlap_timer_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright timer replace second",
+            )
+            if overlap_auto_activity_doc.get("source") != "auto":
+                raise ValueError(
+                    "overlap auto-log activity had wrong source.\n"
+                    f"{json.dumps(overlap_auto_activity_doc, indent=2)}"
+                )
+            if overlap_timer_doc.get("source") != "timer":
+                raise ValueError(
+                    "overlap auto-stop did not persist the running timer as a timer activity.\n"
+                    f"{json.dumps(overlap_timer_doc, indent=2)}"
+                )
+            if any(
+                normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
+                for doc in read_docs(page, rooms["activities"])
+            ):
+                raise ValueError("overlap auto-stop left a running activity config behind")
+            wait_until(
+                lambda: not page.locator("#timer-display").is_visible(),
+                "timer display hidden after overlap auto-stop",
+            )
+            demo_note("activities: overlapping scheduled completion auto-stopped running timer")
+            assert_no_page_errors_yet("overlap auto-stop")
+
+            start_activity_timer(
+                page,
+                "Playwright boundary timer",
+                room_code=rooms["activities"],
+            )
+            boundary_running_config = wait_for_running_activity_config(page, rooms["activities"])
+            boundary_safe_start = get_relative_browser_time(page, 5)
+            fill_locator_value(
+                page,
+                page.locator("#timer-start-time"),
+                boundary_safe_start,
+                description="boundary timer future start time",
+            )
+            page.locator("#timer-start-time").evaluate(
+                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+            )
+            wait_for_input_value(
+                page,
+                "#timer-start-time",
+                boundary_safe_start,
+                description="boundary timer future start time applied",
+            )
+            boundary_running_config = wait_for_running_activity_config(page, rooms["activities"])
+            add_active_scheduled_task(page, "Playwright boundary auto-log", 20)
+            boundary_task_doc = wait_for_task_doc(
+                page,
+                rooms["activities"],
+                "Playwright boundary auto-log",
+            )
+            complete_scheduled_task_via_ui(page, boundary_task_doc["id"])
+            boundary_auto_activity_doc = wait_for_activity_doc(
+                page,
+                rooms["activities"],
+                "Playwright boundary auto-log",
+            )
+            if boundary_auto_activity_doc.get("source") != "auto":
+                raise ValueError(
+                    "boundary auto-log activity had wrong source.\n"
+                    f"{json.dumps(boundary_auto_activity_doc, indent=2)}"
+                )
+            boundary_running_config_after = wait_for_running_activity_config(
+                page,
+                rooms["activities"],
+            )
+            if boundary_running_config_after.get("description") != "Playwright boundary timer":
+                raise ValueError(
+                    "boundary timer was unexpectedly replaced or stopped.\n"
+                    f"{json.dumps(boundary_running_config_after, indent=2)}"
+                )
+            if boundary_running_config_after.get("startDateTime") != boundary_running_config.get(
+                "startDateTime"
+            ):
+                raise ValueError(
+                    "boundary timer start time changed unexpectedly after non-overlap case.\n"
+                    f"before={json.dumps(boundary_running_config, indent=2)}\n"
+                    f"after={json.dumps(boundary_running_config_after, indent=2)}"
+                )
+            if any(
+                doc.get("docType") == "activity"
+                and doc.get("description") == "Playwright boundary timer"
+                for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
+            ):
+                raise ValueError("boundary timer unexpectedly auto-stopped in a non-overlap case")
+            page.locator("#activity").check()
+            wait_for_running_timer_ui(page, "Playwright boundary timer")
+            boundary_stop_start = get_relative_browser_time(page, -1)
+            fill_locator_value(
+                page,
+                page.locator("#timer-start-time"),
+                boundary_stop_start,
+                description="boundary timer stop start time",
+            )
+            page.locator("#timer-start-time").evaluate(
+                "(node) => node.dispatchEvent(new Event('change', { bubbles: true }))"
+            )
+            wait_for_input_value(
+                page,
+                "#timer-start-time",
+                boundary_stop_start,
+                description="boundary timer stop start time applied",
+            )
+            stop_activity_timer(page)
+            wait_for_activity_doc(page, rooms["activities"], "Playwright boundary timer")
+            demo_note("activities: boundary non-overlap preserved the running timer until manual stop")
+            assert_no_page_errors_yet("boundary non-overlap")
+
+            browser_captured_errors = page.evaluate(
+                "() => window.__fortudoSmokeBrowserErrors || []"
+            )
+            assert_no_runtime_errors(
+                console_errors,
+                page_errors,
+                request_failures,
+                response_errors,
+                browser_captured_errors,
+            )
 
             if keep_open and not headless:
                 input("Smoke passed. Press Enter to close the browser...")

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -14,16 +14,21 @@ from scripts.playwright_preview_smoke import (
     build_remote_db_name,
     clear_all_tasks_via_ui,
     complete_scheduled_task_via_ui,
+    configure_demo_logging,
     compute_storage_room_code,
     create_run_scoped_prefix,
     create_scenario_rooms,
     delete_unscheduled_task_via_ui,
     derive_smoke_room_prefix,
+    demo_note,
+    demo_step,
     ensure_activity_doc_present,
     extract_couchdb_url,
     fetch_remote_docs,
     fill_locator_value,
     filter_runtime_errors,
+    get_running_activity_config,
+    get_relative_browser_time,
     get_hostname_from_url,
     get_unscheduled_delete_state,
     is_expected_sync_response_error,
@@ -32,11 +37,15 @@ from scripts.playwright_preview_smoke import (
     parse_cli_args,
     queue_activity_smoke_failure,
     request_manual_sync,
+    start_activity_timer,
+    stop_activity_timer,
     supports_activity_smoke_failure_host,
     summarize_docs,
     task_form_input_selector,
     wait_for_task_doc,
     wait_for_activity_doc,
+    wait_for_running_activity_config,
+    wait_for_running_timer_ui,
     wait_for_input_value,
     wait_for_activity_row_text,
     wait_for_activity_failure_alert,
@@ -282,6 +291,54 @@ class SnapshotAssertionTests(unittest.TestCase):
 
 
 class CliHelpersTests(unittest.TestCase):
+    def setUp(self):
+        configure_demo_logging(enabled=False)
+
+    @patch("scripts.playwright_preview_smoke.time.strftime")
+    def test_demo_step_prints_timestamped_message_and_waits(self, mock_strftime):
+        mock_strftime.return_value = "14:37:12"
+
+        page = FakePage({})
+        messages = []
+        configure_demo_logging(enabled=True)
+        with patch("builtins.print", messages.append):
+            demo_step(page, "checking activities room flows", 900)
+
+        self.assertEqual(messages, ["[demo 14:37:12] checking activities room flows"])
+        self.assertEqual(page.waits, [900])
+
+    @patch("scripts.playwright_preview_smoke.time.strftime")
+    def test_demo_step_skips_logging_when_pause_is_zero(self, mock_strftime):
+        page = FakePage({})
+        messages = []
+        with patch("builtins.print", messages.append):
+            demo_step(page, "should not print", 0)
+
+        self.assertEqual(messages, [])
+        self.assertEqual(page.waits, [])
+        mock_strftime.assert_not_called()
+
+    @patch("scripts.playwright_preview_smoke.time.strftime")
+    def test_demo_note_prints_timestamped_message(self, mock_strftime):
+        mock_strftime.return_value = "14:40:03"
+        messages = []
+        configure_demo_logging(enabled=True)
+
+        with patch("builtins.print", messages.append):
+            demo_note("activities: timer restored after reload")
+
+        self.assertEqual(messages, ["[demo 14:40:03] activities: timer restored after reload"])
+
+    @patch("scripts.playwright_preview_smoke.time.strftime")
+    def test_demo_note_skips_logging_when_demo_mode_is_disabled(self, mock_strftime):
+        messages = []
+
+        with patch("builtins.print", messages.append):
+            demo_note("activities: should stay quiet")
+
+        self.assertEqual(messages, [])
+        mock_strftime.assert_not_called()
+
     def test_activity_smoke_failure_hosts_allow_preview_and_local_only(self):
         self.assertTrue(supports_activity_smoke_failure_host("127.0.0.1"))
         self.assertTrue(supports_activity_smoke_failure_host("localhost"))
@@ -451,6 +508,9 @@ class FakeLocator:
     def is_visible(self):
         return self.visible
 
+    def is_hidden(self):
+        return not self.visible
+
     def wait_for(self, *, state, timeout):
         self.wait_calls += 1
         if state == "visible":
@@ -522,7 +582,7 @@ class FakePage:
     def wait_for_timeout(self, timeout_ms):
         self.waits.append(timeout_ms)
 
-    def evaluate(self, script, payload):
+    def evaluate(self, script, payload=None):
         self.evaluations.append((script, payload))
 
 
@@ -610,7 +670,7 @@ class PreviewWaitHelperTests(unittest.TestCase):
         self.assertEqual(duration_minutes.value, "30")
         self.assertEqual(submit_button.clicks, 1)
 
-    def test_add_active_scheduled_task_uses_current_suggested_start_time(self):
+    def test_add_active_scheduled_task_uses_current_browser_time(self):
         scheduled_radio = FakeLocator()
         description = FakeLocator()
         start_time = FakeLocator()
@@ -628,7 +688,7 @@ class PreviewWaitHelperTests(unittest.TestCase):
             }
         )
         scheduled_radio.check = lambda: setattr(scheduled_radio, "value", "checked")
-        start_time.value = "14:10"
+        page.evaluate = lambda _script, _payload=None: "14:10"
 
         add_active_scheduled_task(page, "Playwright active task", 20)
 
@@ -638,6 +698,120 @@ class PreviewWaitHelperTests(unittest.TestCase):
         self.assertEqual(duration_hours.value, "0")
         self.assertEqual(duration_minutes.value, "20")
         self.assertEqual(submit_button.clicks, 1)
+
+    def test_get_relative_browser_time_uses_browser_clock_offset(self):
+        page = FakePage({})
+        evaluations = []
+
+        def evaluate(script, payload=None):
+            evaluations.append((script, payload))
+            return "13:25"
+
+        page.evaluate = evaluate
+
+        result = get_relative_browser_time(page, -55)
+
+        self.assertEqual(result, "13:25")
+        self.assertEqual(evaluations, [(unittest.mock.ANY, -55)])
+
+    def test_start_activity_timer_uses_add_form_when_no_timer_is_running(self):
+        activity_radio = FakeLocator()
+        description = FakeLocator()
+        add_task_button = FakeLocator(text_values=["Log Activity"])
+        start_timer_button = FakeLocator()
+        timer_display = FakeLocator(visible=True)
+        timer_description = FakeLocator()
+        page = FakePage(
+            {
+                "#activity": activity_radio,
+                "#add-task-btn": add_task_button,
+                task_form_input_selector("description"): description,
+                "#start-timer-btn": start_timer_button,
+                "#timer-display": timer_display,
+                "#timer-description": timer_description,
+            }
+        )
+        page.evaluate = (
+            lambda script, payload=None: setattr(activity_radio, "value", "checked")
+            if "activity.checked = true" in script
+            else page.evaluations.append((script, payload))
+        )
+        timer_display.visible = False
+
+        original_click = start_timer_button.click
+
+        def click_and_show_timer():
+            original_click()
+            timer_display.visible = True
+            timer_description.value = description.value
+
+        start_timer_button.click = click_and_show_timer
+
+        start_activity_timer(page, "Focus timer")
+
+        self.assertEqual(activity_radio.value, "checked")
+        self.assertEqual(description.value, "Focus timer")
+        self.assertEqual(start_timer_button.clicks, 1)
+
+    def test_start_activity_timer_uses_timer_display_when_timer_is_running(self):
+        activity_radio = FakeLocator()
+        add_task_button = FakeLocator(text_values=["Add Task"])
+        start_timer_button = FakeLocator()
+        timer_display = FakeLocator(visible=True)
+        timer_description = FakeLocator()
+        page = FakePage(
+            {
+                "#activity": activity_radio,
+                "#add-task-btn": add_task_button,
+                "#start-timer-btn": start_timer_button,
+                "#timer-display": timer_display,
+                "#timer-description": timer_description,
+            }
+        )
+        page.evaluate = (
+            lambda script, payload=None: setattr(activity_radio, "value", "checked")
+            if "activity.checked = true" in script
+            else page.evaluations.append((script, payload))
+        )
+
+        start_activity_timer(page, "Replacement timer")
+
+        self.assertEqual(timer_description.value, "Replacement timer")
+        self.assertEqual(start_timer_button.clicks, 1)
+
+    def test_stop_activity_timer_clicks_stop_button_and_waits_for_form(self):
+        timer_display = FakeLocator(visible=True)
+        stop_button = FakeLocator()
+        page = FakePage({"#timer-display": timer_display, "#timer-stop-btn": stop_button})
+
+        original_click = stop_button.click
+
+        def click_and_hide_timer():
+            original_click()
+            timer_display.visible = False
+
+        stop_button.click = click_and_hide_timer
+
+        stop_activity_timer(page)
+
+        self.assertEqual(stop_button.clicks, 1)
+        self.assertFalse(timer_display.visible)
+
+    def test_get_running_activity_config_returns_matching_config_doc(self):
+        docs = [
+            {"_id": "config-categories", "docType": "config"},
+            {
+                "_id": "config-running-activity",
+                "docType": "config",
+                "description": "Focus timer",
+                "startDateTime": "2026-04-09T10:00:00.000Z",
+            },
+        ]
+
+        result = get_running_activity_config("room-a", docs)
+
+        self.assertEqual(result["id"], "config-running-activity")
+        self.assertEqual(result["description"], "Focus timer")
 
     def test_ensure_activity_doc_present_requires_activity_doc_type(self):
         docs = [
@@ -660,6 +834,62 @@ class PreviewWaitHelperTests(unittest.TestCase):
         result = wait_for_activity_doc(page, "room-a", "Focus block", timeout_s=0.05, interval_s=0)
 
         self.assertEqual(result["id"], "activity-1")
+
+    @patch("scripts.playwright_preview_smoke.read_docs")
+    def test_wait_for_running_activity_config_waits_until_config_persists(self, mock_read_docs):
+        mock_read_docs.side_effect = [
+            [],
+            [
+                {
+                    "_id": "config-running-activity",
+                    "docType": "config",
+                    "description": "Focus timer",
+                }
+            ],
+        ]
+        page = FakePage({})
+
+        result = wait_for_running_activity_config(
+            page, "room-a", timeout_s=0.05, interval_s=0
+        )
+
+        self.assertEqual(result["id"], "config-running-activity")
+
+    @patch("scripts.playwright_preview_smoke.read_docs")
+    def test_wait_for_running_activity_config_waits_until_matching_values_persist(
+        self, mock_read_docs
+    ):
+        mock_read_docs.side_effect = [
+            [
+                {
+                    "_id": "config-running-activity",
+                    "docType": "config",
+                    "description": "Current timer",
+                    "category": "work/project",
+                }
+            ],
+            [
+                {
+                    "_id": "config-running-activity",
+                    "docType": "config",
+                    "description": "Replacement timer",
+                    "category": "work/comms",
+                }
+            ],
+        ]
+        page = FakePage({})
+
+        result = wait_for_running_activity_config(
+            page,
+            "room-a",
+            expected_description="Replacement timer",
+            expected_category="work/comms",
+            timeout_s=0.05,
+            interval_s=0,
+        )
+
+        self.assertEqual(result["description"], "Replacement timer")
+        self.assertEqual(result["category"], "work/comms")
 
     @patch("scripts.playwright_preview_smoke.read_docs")
     def test_wait_for_task_doc_waits_until_task_persists(self, mock_read_docs):
@@ -714,6 +944,30 @@ class PreviewWaitHelperTests(unittest.TestCase):
         )
 
         self.assertEqual(result, "Focus block")
+
+    def test_wait_for_running_timer_ui_waits_for_visible_timer_and_description(self):
+        timer_display = FakeLocator(visible=False)
+        timer_description = FakeLocator()
+        page = FakePage({"#timer-display": timer_display, "#timer-description": timer_description})
+
+        original_is_visible = timer_display.is_visible
+        calls = {"count": 0}
+
+        def delayed_visible():
+            calls["count"] += 1
+            if calls["count"] >= 2:
+                timer_display.visible = True
+                timer_description.value = "Focus timer"
+            return original_is_visible()
+
+        timer_display.is_visible = delayed_visible
+
+        wait_for_running_timer_ui(
+            page,
+            "Focus timer",
+            timeout_s=0.05,
+            interval_s=0,
+        )
 
     def test_complete_scheduled_task_via_ui_clicks_task_checkbox(self):
         checkbox = FakeLocator()


### PR DESCRIPTION
## Summary
- add persistent activity timer state, start/stop flows, and timer UI wiring for activities
- auto-stop overlapping timers during task-completion auto-logging and restore running timers on boot
- add regression coverage for timer lifecycle, review fixes, and copied phase 4.5 plan docs

## Test Plan
- [x] npx.cmd jest __tests__/activity-app-integration.test.js __tests__/activity-handlers.test.js __tests__/activity-manager.test.js __tests__/activity-timer.test.js __tests__/app-coordinator.test.js __tests__/app.test.js --verbose --runInBand
- [x] npx.cmd jest __tests__/storage-config.test.js --verbose --runInBand
- [x] npm.cmd test -- --runInBand
- [x] npm.cmd run check