### PR TITLE
Add category editing parity for tasks

### DIFF
--- a/__tests__/category-form-utils.test.js
+++ b/__tests__/category-form-utils.test.js
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+    renderCategoryOptionsHtml,
+    renderCategorySelectRow,
+    populateCategorySelect,
+    validateCategoryKey,
+    syncCategoryColorDot
+} from '../public/js/category-form-utils.js';
+import { showAlert } from '../public/js/modal-manager.js';
+import { resolveCategoryKey } from '../public/js/taxonomy/taxonomy-selectors.js';
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    showAlert: jest.fn()
+}));
+
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    resolveCategoryKey: jest.fn()
+}));
+
+describe('category form utils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    test('renderCategoryOptionsHtml returns escaped flat options with selected value', () => {
+        const html = renderCategoryOptionsHtml(
+            [
+                { value: 'work', label: 'Work & Admin', indentLevel: 0 },
+                { value: 'work/deep', label: '<Deep Work>', indentLevel: 1 }
+            ],
+            'work/deep'
+        );
+
+        expect(html).toContain('<option value="work">Work &amp; Admin</option>');
+        expect(html).toContain(
+            '<option value="work/deep" selected>&rsaquo; &lt;Deep Work&gt;</option>'
+        );
+    });
+
+    test('renderCategorySelectRow returns shared dot and select markup', () => {
+        const html = renderCategorySelectRow({
+            selectName: 'category',
+            selectedValue: 'work/deep',
+            dotClass: 'activity-edit-category-dot',
+            selectClass: 'category-select-class',
+            dotStyle: 'background-color: #0ea5e9;',
+            options: [
+                { value: 'work', label: 'Work', indentLevel: 0 },
+                { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+            ]
+        });
+
+        document.body.innerHTML = html;
+
+        const row = document.querySelector('.category-select-row');
+        const dot = document.querySelector('.activity-edit-category-dot');
+        const select = document.querySelector('select[name="category"]');
+
+        expect(row).not.toBeNull();
+        expect(dot.getAttribute('style')).toBe('background-color: #0ea5e9;');
+        expect(select.className).toBe('category-select-class');
+        expect(select.value).toBe('work/deep');
+        expect(select.options[0].value).toBe('');
+        expect(select.querySelector('option[value="work/deep"]').textContent).toBe('› Deep Work');
+    });
+
+    test('populateCategorySelect preserves the default option and selected value', () => {
+        document.body.innerHTML = `
+            <select id="category-select">
+                <option value="">No category</option>
+            </select>
+        `;
+
+        const select = document.getElementById('category-select');
+        populateCategorySelect(
+            select,
+            [
+                { value: 'work', label: 'Work', indentLevel: 0 },
+                { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+            ],
+            'work/deep'
+        );
+
+        expect(select.options).toHaveLength(3);
+        expect(select.options[0].value).toBe('');
+        expect(select.value).toBe('work/deep');
+        expect(select.options[2].textContent).toBe('› Deep Work');
+    });
+
+    test('validateCategoryKey accepts empty and valid keys', () => {
+        resolveCategoryKey.mockImplementation((key) =>
+            key === 'work' ? { kind: 'group', record: { key, color: '#2563eb' } } : null
+        );
+
+        expect(validateCategoryKey('', 'teal')).toEqual({ valid: true, category: null });
+        expect(validateCategoryKey('work', 'teal')).toEqual({
+            valid: true,
+            category: 'work'
+        });
+    });
+
+    test('validateCategoryKey rejects stale keys with the provided theme', () => {
+        resolveCategoryKey.mockReturnValue(null);
+
+        expect(validateCategoryKey('missing', 'indigo')).toEqual({
+            valid: false,
+            category: null
+        });
+        expect(showAlert).toHaveBeenCalledWith(
+            'Selected category is no longer available.',
+            'indigo'
+        );
+    });
+
+    test('syncCategoryColorDot initializes and updates a specific dot/select pair', () => {
+        document.body.innerHTML = `
+            <span id="category-dot"></span>
+            <select id="category-select">
+                <option value="">No category</option>
+                <option value="work/deep">Deep Work</option>
+            </select>
+        `;
+
+        resolveCategoryKey.mockImplementation((key) =>
+            key === 'work/deep' ? { kind: 'category', record: { key, color: '#0ea5e9' } } : null
+        );
+
+        const select = document.getElementById('category-select');
+        const dot = document.getElementById('category-dot');
+        syncCategoryColorDot(select, dot);
+
+        expect(dot.style.backgroundColor).toBe('rgb(100, 116, 139)');
+
+        select.value = 'work/deep';
+        select.dispatchEvent(new Event('change'));
+
+        expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
+    });
+});

--- a/__tests__/form-utils.test.js
+++ b/__tests__/form-utils.test.js
@@ -7,6 +7,10 @@ import {
     getUnscheduledTaskInlineFormData,
     toggleUnscheduledTaskInlineEdit,
     extractTaskFormData,
+    renderCategoryOptionsHtml,
+    populateCategorySelect,
+    validateCategoryKey,
+    syncCategoryColorDot,
     populateCategoryDropdown,
     initializeCategoryDropdownListener,
     getTaskFormElement,
@@ -28,6 +32,10 @@ jest.mock('../public/js/modal-manager.js', () => ({
 }));
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    getSelectableCategoryOptions: jest.fn(() => [
+        { value: 'work', label: 'Work', indentLevel: 0 },
+        { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+    ]),
     resolveCategoryKey: jest.fn()
 }));
 
@@ -341,6 +349,94 @@ describe('Form Utils Tests', () => {
     });
 
     describe('category helpers', () => {
+        test('renderCategoryOptionsHtml returns escaped flat options with selected value', () => {
+            const html = renderCategoryOptionsHtml(
+                [
+                    { value: 'work', label: 'Work & Admin', indentLevel: 0 },
+                    { value: 'work/deep', label: '<Deep Work>', indentLevel: 1 }
+                ],
+                'work/deep'
+            );
+
+            expect(html).toContain('<option value="work">Work &amp; Admin</option>');
+            expect(html).toContain(
+                '<option value="work/deep" selected>&rsaquo; &lt;Deep Work&gt;</option>'
+            );
+        });
+
+        test('populateCategorySelect preserves the default option and selected value', () => {
+            document.body.innerHTML = `
+                <select id="category-select">
+                    <option value="">No category</option>
+                </select>
+            `;
+
+            const select = document.getElementById('category-select');
+            populateCategorySelect(
+                select,
+                [
+                    { value: 'work', label: 'Work', indentLevel: 0 },
+                    { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+                ],
+                'work/deep'
+            );
+
+            expect(select.options).toHaveLength(3);
+            expect(select.options[0].value).toBe('');
+            expect(select.value).toBe('work/deep');
+            expect(select.options[2].textContent).toBe('› Deep Work');
+        });
+
+        test('validateCategoryKey accepts empty and valid keys', () => {
+            resolveCategoryKey.mockImplementation((key) =>
+                key === 'work' ? { kind: 'group', record: { key, color: '#2563eb' } } : null
+            );
+
+            expect(validateCategoryKey('', 'teal')).toEqual({ valid: true, category: null });
+            expect(validateCategoryKey('work', 'teal')).toEqual({
+                valid: true,
+                category: 'work'
+            });
+        });
+
+        test('validateCategoryKey rejects stale keys with the provided theme', () => {
+            resolveCategoryKey.mockReturnValue(null);
+
+            expect(validateCategoryKey('missing', 'indigo')).toEqual({
+                valid: false,
+                category: null
+            });
+            expect(showAlert).toHaveBeenCalledWith(
+                'Selected category is no longer available.',
+                'indigo'
+            );
+        });
+
+        test('syncCategoryColorDot initializes and updates a specific dot/select pair', () => {
+            document.body.innerHTML = `
+                <span id="category-dot"></span>
+                <select id="category-select">
+                    <option value="">No category</option>
+                    <option value="work/deep">Deep Work</option>
+                </select>
+            `;
+
+            resolveCategoryKey.mockImplementation((key) =>
+                key === 'work/deep' ? { kind: 'category', record: { key, color: '#0ea5e9' } } : null
+            );
+
+            const select = document.getElementById('category-select');
+            const dot = document.getElementById('category-dot');
+            syncCategoryColorDot(select, dot);
+
+            expect(dot.style.backgroundColor).toBe('rgb(100, 116, 139)');
+
+            select.value = 'work/deep';
+            select.dispatchEvent(new Event('change'));
+
+            expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
+        });
+
         test('populateCategoryDropdown renders a group option followed by indented children', () => {
             document.body.innerHTML = `
                 <select id="category-select">
@@ -466,6 +562,10 @@ describe('Form Utils Tests', () => {
                     <div class="inline-edit-unscheduled-form hidden">
                         <form>
                             <input type="text" name="inline-edit-description" value="" />
+                            <span class="unscheduled-edit-category-dot"></span>
+                            <select name="inline-edit-category">
+                                <option value="">No category</option>
+                            </select>
                             <input type="number" name="inline-edit-est-duration-hours" value="" />
                             <input type="number" name="inline-edit-est-duration-minutes" value="" />
                             <input type="radio" name="inline-edit-priority" value="high" ${checkedHigh} />
@@ -523,6 +623,33 @@ describe('Form Utils Tests', () => {
                 expect(minutesInput.value).toBe('30');
             });
 
+            test('populates category select and color dot from task data', () => {
+                createUnscheduledTaskCard('task-1', 'Original', 'medium', 60);
+                resolveCategoryKey.mockImplementation((key) =>
+                    key === 'work/deep'
+                        ? { kind: 'category', record: { key, color: '#0ea5e9' } }
+                        : null
+                );
+
+                populateUnscheduledTaskInlineEditForm('task-1', {
+                    description: 'Updated task',
+                    priority: 'medium',
+                    estDuration: 60,
+                    category: 'work/deep'
+                });
+
+                const categorySelect = document.querySelector(
+                    'select[name="inline-edit-category"]'
+                );
+                const categoryDot = document.querySelector('.unscheduled-edit-category-dot');
+
+                expect(categorySelect.value).toBe('work/deep');
+                expect(categorySelect.querySelector('option[value="work/deep"]').textContent).toBe(
+                    '› Deep Work'
+                );
+                expect(categoryDot.style.backgroundColor).toBe('rgb(14, 165, 233)');
+            });
+
             test('does not throw when task card not found', () => {
                 createUnscheduledTaskCard('task-1', 'Original', 'medium', 60);
                 expect(() => {
@@ -561,8 +688,61 @@ describe('Form Utils Tests', () => {
                 expect(result).toEqual({
                     description: 'Updated description',
                     priority: 'high',
-                    estDuration: 150
+                    estDuration: 150,
+                    category: null
                 });
+            });
+
+            test('extracts selected category from inline edit form', () => {
+                createUnscheduledTaskCard('task-1', 'Original', 'medium', 60);
+                resolveCategoryKey.mockImplementation((key) =>
+                    key === 'work/deep'
+                        ? { kind: 'category', record: { key, color: '#0ea5e9' } }
+                        : null
+                );
+
+                document.querySelector('input[name="inline-edit-description"]').value = 'Updated';
+                document.querySelector('input[name="inline-edit-est-duration-hours"]').value = '1';
+                document.querySelector('input[name="inline-edit-est-duration-minutes"]').value =
+                    '0';
+                document.querySelector('select[name="inline-edit-category"]').innerHTML = `
+                    <option value="">No category</option>
+                    <option value="work/deep">Deep Work</option>
+                `;
+                document.querySelector('select[name="inline-edit-category"]').value = 'work/deep';
+
+                const result = getUnscheduledTaskInlineFormData('task-1');
+
+                expect(result).toEqual({
+                    description: 'Updated',
+                    priority: 'medium',
+                    estDuration: 60,
+                    category: 'work/deep'
+                });
+            });
+
+            test('rejects stale inline edit category keys', () => {
+                createUnscheduledTaskCard('task-1', 'Original', 'medium', 60);
+                resolveCategoryKey.mockReturnValue(null);
+
+                document.querySelector('input[name="inline-edit-description"]').value = 'Updated';
+                document.querySelector('input[name="inline-edit-est-duration-hours"]').value = '1';
+                document.querySelector('input[name="inline-edit-est-duration-minutes"]').value =
+                    '0';
+                document.querySelector('select[name="inline-edit-category"]').innerHTML = `
+                    <option value="">No category</option>
+                    <option value="missing/category">Missing</option>
+                `;
+                document.querySelector('select[name="inline-edit-category"]').value =
+                    'missing/category';
+
+                const result = getUnscheduledTaskInlineFormData('task-1');
+
+                expect(result).toBeNull();
+                expect(showAlert).toHaveBeenCalledWith(
+                    'Selected category is no longer available.',
+                    'indigo'
+                );
             });
 
             test('returns null and shows alert when description is empty', () => {
@@ -616,7 +796,8 @@ describe('Form Utils Tests', () => {
                 expect(result).toEqual({
                     description: 'No estimate',
                     priority: 'medium',
-                    estDuration: 0
+                    estDuration: 0,
+                    category: null
                 });
             });
 

--- a/__tests__/form-utils.test.js
+++ b/__tests__/form-utils.test.js
@@ -7,10 +7,6 @@ import {
     getUnscheduledTaskInlineFormData,
     toggleUnscheduledTaskInlineEdit,
     extractTaskFormData,
-    renderCategoryOptionsHtml,
-    populateCategorySelect,
-    validateCategoryKey,
-    syncCategoryColorDot,
     populateCategoryDropdown,
     initializeCategoryDropdownListener,
     getTaskFormElement,
@@ -348,95 +344,7 @@ describe('Form Utils Tests', () => {
         });
     });
 
-    describe('category helpers', () => {
-        test('renderCategoryOptionsHtml returns escaped flat options with selected value', () => {
-            const html = renderCategoryOptionsHtml(
-                [
-                    { value: 'work', label: 'Work & Admin', indentLevel: 0 },
-                    { value: 'work/deep', label: '<Deep Work>', indentLevel: 1 }
-                ],
-                'work/deep'
-            );
-
-            expect(html).toContain('<option value="work">Work &amp; Admin</option>');
-            expect(html).toContain(
-                '<option value="work/deep" selected>&rsaquo; &lt;Deep Work&gt;</option>'
-            );
-        });
-
-        test('populateCategorySelect preserves the default option and selected value', () => {
-            document.body.innerHTML = `
-                <select id="category-select">
-                    <option value="">No category</option>
-                </select>
-            `;
-
-            const select = document.getElementById('category-select');
-            populateCategorySelect(
-                select,
-                [
-                    { value: 'work', label: 'Work', indentLevel: 0 },
-                    { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
-                ],
-                'work/deep'
-            );
-
-            expect(select.options).toHaveLength(3);
-            expect(select.options[0].value).toBe('');
-            expect(select.value).toBe('work/deep');
-            expect(select.options[2].textContent).toBe('› Deep Work');
-        });
-
-        test('validateCategoryKey accepts empty and valid keys', () => {
-            resolveCategoryKey.mockImplementation((key) =>
-                key === 'work' ? { kind: 'group', record: { key, color: '#2563eb' } } : null
-            );
-
-            expect(validateCategoryKey('', 'teal')).toEqual({ valid: true, category: null });
-            expect(validateCategoryKey('work', 'teal')).toEqual({
-                valid: true,
-                category: 'work'
-            });
-        });
-
-        test('validateCategoryKey rejects stale keys with the provided theme', () => {
-            resolveCategoryKey.mockReturnValue(null);
-
-            expect(validateCategoryKey('missing', 'indigo')).toEqual({
-                valid: false,
-                category: null
-            });
-            expect(showAlert).toHaveBeenCalledWith(
-                'Selected category is no longer available.',
-                'indigo'
-            );
-        });
-
-        test('syncCategoryColorDot initializes and updates a specific dot/select pair', () => {
-            document.body.innerHTML = `
-                <span id="category-dot"></span>
-                <select id="category-select">
-                    <option value="">No category</option>
-                    <option value="work/deep">Deep Work</option>
-                </select>
-            `;
-
-            resolveCategoryKey.mockImplementation((key) =>
-                key === 'work/deep' ? { kind: 'category', record: { key, color: '#0ea5e9' } } : null
-            );
-
-            const select = document.getElementById('category-select');
-            const dot = document.getElementById('category-dot');
-            syncCategoryColorDot(select, dot);
-
-            expect(dot.style.backgroundColor).toBe('rgb(100, 116, 139)');
-
-            select.value = 'work/deep';
-            select.dispatchEvent(new Event('change'));
-
-            expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
-        });
-
+    describe('category dropdown integration', () => {
         test('populateCategoryDropdown renders a group option followed by indented children', () => {
             document.body.innerHTML = `
                 <select id="category-select">

--- a/__tests__/scheduled-task-handlers.test.js
+++ b/__tests__/scheduled-task-handlers.test.js
@@ -137,7 +137,7 @@ describe('Scheduled Task Handlers', () => {
                 startTime: '09:00',
                 duration: 60
             });
-            updateTaskState([task]);
+            updateTaskState([{ ...task, category: 'work/deep' }]);
 
             handleLockTask(task.id, 0);
 
@@ -283,6 +283,38 @@ describe('Scheduled Task Handlers', () => {
                 })
             });
             expect(refreshUI).not.toHaveBeenCalled();
+        });
+
+        test('clears category when scheduled edit form selects no category', async () => {
+            const task = createTaskWithDateTime({
+                description: 'Before',
+                startTime: '09:00',
+                duration: 60,
+                editing: true
+            });
+            updateTaskState([{ ...task, category: 'work/deep' }]);
+            extractTaskFormData.mockReturnValue({
+                description: 'After',
+                startTime: '10:00',
+                duration: 45,
+                taskType: 'scheduled'
+            });
+
+            const formElement = document.createElement('form');
+            formElement.innerHTML = `
+                <select name="category">
+                    <option value="" selected>No category</option>
+                </select>
+            `;
+
+            await handleSaveTaskEdit(task.id, formElement, 0);
+
+            expect(onTaskEdited).toHaveBeenCalledWith({
+                task: expect.objectContaining({
+                    id: task.id,
+                    category: null
+                })
+            });
         });
 
         test('routes a confirmed reschedule edit through the coordinator based on the confirmed result', async () => {

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -3,6 +3,15 @@
  */
 
 jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    getSelectableCategoryOptions: jest.fn(() => [
+        { value: 'work', label: 'Work', indentLevel: 0 },
+        { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+    ]),
+    resolveCategoryKey: jest.fn((key) =>
+        key === 'work/deep'
+            ? { kind: 'category', record: { key, label: 'Deep Work', color: '#0ea5e9' } }
+            : null
+    ),
     renderCategoryBadge: jest.fn((categoryKey) =>
         categoryKey ? `<span class="category-badge">${categoryKey}</span>` : ''
     )
@@ -461,6 +470,40 @@ describe('Scheduled Task Renderer Tests', () => {
             const hintEl = list.querySelector('.edit-end-time-hint');
             expect(hintEl).not.toBeNull();
             expect(hintEl.textContent).toContain('AM');
+        });
+
+        test('renders category select for editing task with current category selected', () => {
+            const tasks = [
+                {
+                    ...createTask('1', '10:00', 90, { editing: true, date: today }),
+                    category: 'work/deep'
+                }
+            ];
+
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            const select = document.querySelector('form[id^="edit-task-"] select[name="category"]');
+            const dot = document.querySelector('.scheduled-edit-category-dot');
+            expect(select).not.toBeNull();
+            expect(select.value).toBe('work/deep');
+            expect(select.querySelector('option[value="work/deep"]').textContent).toBe(
+                '› Deep Work'
+            );
+            expect(dot).not.toBeNull();
+            expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
+        });
+
+        test('updates scheduled edit category color dot when category changes', () => {
+            const tasks = [createTask('1', '10:00', 90, { editing: true, date: today })];
+
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            const select = document.querySelector('form[id^="edit-task-"] select[name="category"]');
+            const dot = document.querySelector('.scheduled-edit-category-dot');
+            select.value = 'work/deep';
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+
+            expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
         });
     });
 });

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -928,6 +928,40 @@ describe('Task Management Functions (task-manager.js)', () => {
             expect(mockPutTask).toHaveBeenCalled();
         });
 
+        test('updates a scheduled task category when edit data includes category', () => {
+            const updatedData = {
+                description: 'Task 1 Updated',
+                startTime: '09:00',
+                duration: 30,
+                category: 'work/deep'
+            };
+
+            const result = updateTask(0, updatedData);
+
+            expect(result.success).toBe(true);
+            expect(getTaskState()[0].category).toBe('work/deep');
+            expect(mockPutTask).toHaveBeenCalledWith(
+                expect.objectContaining({ category: 'work/deep' })
+            );
+        });
+
+        test('clears a scheduled task category when edit data includes null category', () => {
+            const [task1, task2] = getTaskState();
+            updateTaskState([{ ...task1, category: 'work/deep' }, task2]);
+            mockPutTask.mockClear();
+
+            const result = updateTask(0, {
+                description: 'Task 1 Updated',
+                startTime: '09:00',
+                duration: 30,
+                category: null
+            });
+
+            expect(result.success).toBe(true);
+            expect(getTaskState()[0].category).toBeNull();
+            expect(mockPutTask).toHaveBeenCalledWith(expect.objectContaining({ category: null }));
+        });
+
         test('should require confirmation if updating a task creates an overlap', () => {
             const updatedData = { description: 'Task 1 Updated', startTime: '09:30', duration: 60 }; // Now 09:30 - 10:30, overlaps Task 2
             const result = updateTask(0, updatedData);
@@ -2373,6 +2407,54 @@ describe('Task Management Functions (task-manager.js)', () => {
             expect(tasks[0].description).toBe('Updated');
             expect(tasks[0].priority).toBe('high');
             expect(tasks[0].estDuration).toBe(60);
+        });
+
+        test('updates unscheduled task category', () => {
+            const task = {
+                id: 'unsched-1',
+                type: 'unscheduled',
+                description: 'Original',
+                priority: 'low',
+                estDuration: 30,
+                status: 'incomplete',
+                isEditingInline: true,
+                category: null
+            };
+            updateTaskState([task]);
+
+            const result = updateUnscheduledTask('unsched-1', {
+                description: 'Updated',
+                priority: 'high',
+                estDuration: 60,
+                category: 'work/deep'
+            });
+
+            expect(result.success).toBe(true);
+            expect(getTaskState()[0].category).toBe('work/deep');
+        });
+
+        test('clears unscheduled task category', () => {
+            const task = {
+                id: 'unsched-1',
+                type: 'unscheduled',
+                description: 'Original',
+                priority: 'low',
+                estDuration: 30,
+                status: 'incomplete',
+                isEditingInline: true,
+                category: 'work/deep'
+            };
+            updateTaskState([task]);
+
+            const result = updateUnscheduledTask('unsched-1', {
+                description: 'Updated',
+                priority: 'high',
+                estDuration: 60,
+                category: null
+            });
+
+            expect(result.success).toBe(true);
+            expect(getTaskState()[0].category).toBeNull();
         });
 
         test('returns failure for non-existent task', () => {

--- a/__tests__/unscheduled-task-renderer.test.js
+++ b/__tests__/unscheduled-task-renderer.test.js
@@ -6,6 +6,21 @@ jest.mock('../public/js/activities/manager.js', () => ({
     getRunningActivity: jest.fn(() => null)
 }));
 
+jest.mock('../public/js/taxonomy/taxonomy-selectors.js', () => ({
+    getSelectableCategoryOptions: jest.fn(() => [
+        { value: 'work', label: 'Work', indentLevel: 0 },
+        { value: 'work/deep', label: 'Deep Work', indentLevel: 1 }
+    ]),
+    resolveCategoryKey: jest.fn((key) =>
+        key === 'work/deep'
+            ? { kind: 'category', record: { key, label: 'Deep Work', color: '#0ea5e9' } }
+            : null
+    ),
+    renderCategoryBadge: jest.fn((categoryKey) =>
+        categoryKey ? `<span class="category-badge">${categoryKey}</span>` : ''
+    )
+}));
+
 import { renderUnscheduledTasks } from '../public/js/tasks/unscheduled-renderer.js';
 import { getRunningActivity } from '../public/js/activities/manager.js';
 
@@ -78,5 +93,31 @@ describe('unscheduled task renderer', () => {
         expect(document.querySelector('.btn-delete-unscheduled').hasAttribute('disabled')).toBe(
             true
         );
+    });
+
+    test('renders category select and color dot for inline editing task', () => {
+        renderUnscheduledTasks(
+            [
+                {
+                    id: 'unsched-3',
+                    type: 'unscheduled',
+                    description: 'Inbox zero',
+                    priority: 'medium',
+                    estDuration: 30,
+                    status: 'incomplete',
+                    isEditingInline: true,
+                    category: 'work/deep'
+                }
+            ],
+            {},
+            jest.fn()
+        );
+
+        const select = document.querySelector('select[name="inline-edit-category"]');
+        const dot = document.querySelector('.unscheduled-edit-category-dot');
+        expect(select).not.toBeNull();
+        expect(select.value).toBe('work/deep');
+        expect(select.querySelector('option[value="work/deep"]').textContent).toBe('› Deep Work');
+        expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
     });
 });

--- a/docs/plans/2026-03-16-fortudo-activities-design.md
+++ b/docs/plans/2026-03-16-fortudo-activities-design.md
@@ -111,11 +111,13 @@ Ephemeral config doc representing a live timer. Created on timer start, deleted 
     id: 'config-running-activity',
     description: String,
     category: String | null,
-    startDateTime: String  // ISO datetime, real wall-clock time
+    startDateTime: String,  // ISO datetime, real wall-clock time
+    source: 'timer' | 'auto',
+    sourceTaskId: String | null
 }
 ```
 
-When the timer stops, this config doc is deleted and a normal activity document is created with `source: 'timer'`, computed `endDateTime` and `duration`.
+When the timer stops, this config doc is deleted and a normal activity document is created with the timer's source metadata, computed `endDateTime`, and `duration`.
 
 Shared field names between tasks and activities: `description`, `startDateTime`, `endDateTime`, `duration`, `category`.
 
@@ -204,9 +206,14 @@ public/js/
 |   |-- handlers.js               # activity add/edit/delete handlers
 |   |-- form-utils.js             # activity form extraction (add + edit)
 |   |-- ui-handlers.js            # activity UI orchestration (form routing, list clicks, edit state, timer display)
+|   |-- app-wiring.js             # activity-specific app callback and listener setup
+|   |-- running-activity-repository.js # config doc persistence for running timer state
+|   |-- summary.js                # activity category summary selectors/model
+|   |-- timer-ui.js               # live timer display, elapsed counter, and timer form synchronization
 |   |-- smoke-hooks.js            # testability hooks for forcing activity failures in preview/smoke
 |   `-- insights-renderer.js      # (Phase 5) insights dashboard, timeline, charts
 |-- app.js                        # boot sequence, DOM setup, storage + room wiring
+|-- app-lifecycle.js              # room/session lifecycle, midnight checks, and session-scoped refresh
 |-- app-coordinator.js            # runtime post-mutation orchestration
 |-- storage.js                    # PouchDB persistence layer
 |-- dom-renderer.js               # page-level rendering and event wiring
@@ -269,13 +276,13 @@ Bridges the gap between Fortudo's retrospective logging and the real-time start/
 
 **Backdating:** The start time on the timer display is editable via a time picker. Use case: you forgot to start the timer 20 minutes ago.
 
-**Boot restoration:** If a `config-running-activity` doc exists on load, the timer state is silently restored and the elapsed counter resumes from the persisted `startDateTime`. The user stays on whichever tab they land on, but the activity tab gets a brief UI highlight (pulse, badge, or similar) to signal that a timer is running. Navigating to the activity tab shows the timer display.
+**Boot restoration:** If a `config-running-activity` doc exists on load, the timer state is silently restored and the elapsed counter resumes from the persisted `startDateTime`. The implementation switches the form back into Activity mode when a running timer is restored so the active timer is immediately visible.
 
 **Stop triggers:**
 
 1. **Explicit stop** -- user clicks "Stop" button
 2. **Stop-on-start** -- starting a new timer auto-stops the running one (no confirmation). The stopped timer's `endDateTime` is set to now, its activity is created, then the new timer starts. Sequential execution to avoid two config docs existing simultaneously.
-3. **Task completion with overlap** -- when auto-logging fires in `onTaskCompleted`, if the auto-logged activity's time range overlaps with the running timer's active range (`startDateTime` through now), the timer is stopped with `endDateTime` set to the auto-log's `startDateTime`. If no overlap, the timer keeps running. **Guard:** if the early-completion time adjustment shifts the auto-log's `startDateTime` to before the timer's own `startDateTime`, clamp the timer's `endDateTime` to its `startDateTime` (producing a zero-duration activity) rather than creating a negative duration. The zero-duration activity is still saved per the "always create" edge case decision.
+3. **Task completion with overlap** -- when auto-logging fires in `onTaskCompleted`, if the auto-logged activity's time range overlaps with the running timer's active range (`startDateTime` through now), the timer is stopped with `endDateTime` set to the auto-log's `startDateTime`. If no overlap, the timer keeps running. **Guard:** if the early-completion time adjustment shifts the auto-log's `startDateTime` to before the timer's own `startDateTime`, clamp the timer stop boundary to the timer's `startDateTime` rather than creating a negative duration. Completed activity saves enforce a one-minute minimum duration, so the stored timer activity remains valid for the activity log and summary views.
 
 **Early task completion adjustment:** When `createActivityFromTask` runs and the task's planned `startDateTime` is in the future, the auto-log times are adjusted: `endDateTime` = now, `startDateTime` = now minus the task's `duration`. This ensures auto-logged activities reflect when the work actually happened rather than when it was planned.
 
@@ -284,7 +291,9 @@ Bridges the gap between Fortudo's retrospective logging and the real-time start/
 **Timer state management** in `activities/manager.js`:
 
 - `startTimer({ description, category })` -- writes config doc, returns running state
+- `startTimerReplacingCurrent(timerData)` -- stop-on-start flow that converts the current timer into an activity before starting the next timer
 - `stopTimer()` -- reads config doc, computes duration, creates activity, deletes config doc
+- `stopTimerAt(endDateTime)` -- stops the timer at a supplied boundary for auto-log overlap and midnight rollover handling
 - `getRunningActivity()` -- synchronous read from in-memory cache (same pattern as `isActivitiesEnabled()`)
 - `updateRunningActivity({ description, category, startDateTime })` -- updates config doc (for backdating or mid-timer changes)
 - `loadRunningActivity()` -- called during boot, populates in-memory cache
@@ -305,7 +314,7 @@ Accessed via a tab toggle in the header ("Tasks" / "Insights"). The toggle switc
    - Category breakdown bars
 
 2. **Activity Log**
-   - Chronological list of today's activities
+   - Newest-first list of today's activities
    - Each entry shows description, category badge, time range, and duration
    - All entries (manual and auto-logged) are editable and deletable via inline editing
    - Auto entries show a source task link with provenance metadata; editing creates a modified copy retaining `sourceTaskId`
@@ -391,7 +400,7 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 
 1. **Timer state as PouchDB config doc, not activity doc.** A running timer is ephemeral coordinator state, not a first-class activity. It becomes an activity only when stopped. This keeps the activity schema clean (no `status: 'running'` partial documents) and avoids confusing insights queries. The config doc syncs across devices and survives page reloads.
 
-2. **No new files.** Timer logic extends `activities/manager.js` (state, start/stop/update) and `activities/ui-handlers.js` (timer display, elapsed counter, form transitions). The timer is a feature of activity management, not a separate module.
+2. **Focused timer extraction.** Timer state still belongs to activity management, but the implementation extracted persistence and UI mechanics into focused helpers: `activities/running-activity-repository.js` owns the `config-running-activity` config doc, and `activities/timer-ui.js` owns elapsed display, timer form synchronization, debug snapshots, and server-clock correction. `activities/manager.js` remains the source of truth for timer state transitions.
 
 3. **Overlap check uses real time ranges, not assumptions.** The auto-log's time range may be shifted (early completion adjustment), may be in the past (task was earlier), or may be in the future (planned for later). The overlap check compares the running timer's active range (`startDateTime` through now) against the auto-log's actual time range. Only true overlaps trigger a timer stop.
 
@@ -465,44 +474,62 @@ Lazy loading: activity modules can be imported eagerly but gated by `isActivitie
 - Added empty states for activity views
 - Both manual and auto-logged activities are editable; auto entries retain provenance metadata (`sourceTaskId`) through edits
 
-### Next Planned Work
+### Completed Live Timer Work
 
 **Phase 4.5: Live activity timer**
 
-- Add timer state management to `activities/manager.js`: `startTimer`, `stopTimer`, `getRunningActivity`, `updateRunningActivity`, `loadRunningActivity`
-- Add `config-running-activity` PouchDB config doc persistence with in-memory cache
-- Add timer display UI to `activities/ui-handlers.js`: elapsed counter, stop button, editable fields (description, category, start time), form-to-timer and timer-to-form transitions
-- Add side-by-side "Log Activity" / "Start Timer" buttons on the activity form
-- Add stop-on-start behavior (starting a new timer auto-stops the running one)
-- Add early task completion time adjustment in `createActivityFromTask` (shift auto-log window to end at now when task was scheduled in the future)
-- Extend `onTaskCompleted` auto-log chain in coordinator: overlap detection with running timer, auto-stop at auto-log's `startDateTime` when ranges intersect
-- Add boot restoration of running timer from persisted config doc
-- Verify `deleteConfig` exists in `storage.js` or add it
+- Added running timer state management in `activities/manager.js`: `startTimer`, `startTimerReplacingCurrent`, `stopTimer`, `stopTimerAt`, `getRunningActivity`, `updateRunningActivity`, and `loadRunningActivity`
+- Added `config-running-activity` PouchDB config persistence through `activities/running-activity-repository.js`
+- Added timer display UI in `activities/timer-ui.js`: elapsed counter, stop button, editable description/category/start time, form-to-timer transitions, and timer field persistence
+- Added side-by-side "Log Activity" / "Start Timer" actions for the activity form
+- Added stop-on-start behavior through `startTimerReplacingCurrent`
+- Added early task completion time adjustment in `createActivityFromTask`
+- Extended `onTaskCompleted` auto-log chaining so overlapping scheduled-task auto-logs stop the running timer at the auto-log boundary
+- Added boot restoration of persisted running timer state and activity-mode resynchronization
+- Added midnight rollover handling in `app-lifecycle.js` so a running timer is stopped at the local day boundary
+- Added server-clock-corrected elapsed display and timer debug snapshots for diagnosing device clock skew
+- Added category summary bars for today's activities, including parent-group aggregation, expandable child breakdowns, count badges, and live running-timer inclusion
+- Added newest-first activity log ordering, delete confirmation for activities, duplicate edit-save guards, and category dots on activity forms
+
+### Next Planned Work
 
 **Phase 4.7: Category editing parity**
 
-- Keep full-field inline editing on activities, including category changes
-- Add category editing to scheduled task inline edit forms
-- Add category editing to unscheduled task inline edit forms
-- Align task and activity edit layouts so category editing no longer exists only on activities
-- Add renderer, form-utils, handler, app, and smoke coverage for task category edit flows
+- Keep scheduled, unscheduled, and activity edit forms owned by their current feature modules; do not introduce a generic edit-form abstraction.
+- Add narrow shared category form helpers for the stable seams only: option HTML/population, category validation, and color-dot synchronization for a specific select/dot pair.
+- Add category editing to scheduled task inline edit forms, preserving existing start-time, duration, end-time hint, overlap warning, and reschedule-confirmation behavior.
+- Add category editing to unscheduled task inline edit forms, preserving existing priority, estimated-duration, completed-task, and in-progress timer behavior.
+- Continue supporting full-field inline editing on activities, including category changes; migrate activity inline category rendering to the shared helper only if it stays mechanical and low-risk.
+- Update scheduled and unscheduled task save paths so category changes persist through `updateTask` and `updateUnscheduledTask`.
+- Reject stale or deleted category keys on save with the existing themed alert behavior and without mutating the task.
+- Add renderer, form-utils, manager/handler, app, and smoke coverage for task category edit flows.
+- Acceptance coverage: scheduled category render/save/reject paths, scheduled overlap behavior with category edits, unscheduled category render/save/reject paths, edited unscheduled category flowing into "start timer from task," and unchanged activity category edit behavior.
 
 **Phase 5: Insights view**
 
 - Add header tab toggle for Tasks / Insights
 - Add two-row plan-vs-actual timeline
-- Add activity log list with edit/delete for manual entries
-- Add category breakdown bars and summary stats
+- Promote the existing newest-first Activity Log into the Insights view rather than rebuilding it from scratch
+- Reuse and refine the existing parent-group activity summary bars, including expandable child breakdowns and count badges
+- Ensure today's actual totals and summary bars include the live running-timer snapshot when a timer is active
+- Make the plan-vs-actual timeline handle in-progress activity ranges, midnight-clamped timer stops, and restored timer state
 - Add trends section
 - Add keyboard shortcut for tab toggle if it still feels worthwhile
+- Treat restored timers, stop-on-start, unscheduled task timer promotion, and overlap auto-stop as Phase 5 acceptance coverage rather than deferring all activity E2E coverage to polish
 
 **Phase 6: Polish and E2E**
 
-- Add E2E coverage for activity flows
+- Expand E2E coverage for remaining activity flows and cross-device/sync confidence after Phase 5 acceptance coverage is in place
 - Add a one-time "What's new?" prompt on initial app load after Activities ships, highlighting activity logging, timer capture, and insights
-- Rename orchestration modules to clarify responsibilities, e.g. distinguish the room/session lifecycle coordinator from the post-mutation coordinator (`app-lifecycle.js` / `app-coordinator.js`)
+- Review orchestration module naming and docs so `app-lifecycle.js` clearly owns room/session lifecycle and day-boundary timers, while `app-coordinator.js` owns post-mutation side effects
 - Finalize activity accent color
 - Add transitions and micro-interactions
 - Adapt timeline UX for mobile
 - Add onboarding tooltips on first Activities enable
 - Evaluate Chart.js only if the hand-rolled visuals are too plain
+
+**Operational hardening follow-up**
+
+- Preserve the timer debug snapshot seam and server-clock offset handling for future elapsed-time work
+- Add focused regression coverage whenever a feature touches elapsed counters, midnight boundaries, restored timer state, or cross-device running-timer sync
+- Keep lifecycle behavior session-scoped so room switches and in-flight sync cannot mutate the wrong room's activity/timer UI

--- a/docs/superpowers/plans/2026-04-27-phase-4-7-category-editing-parity.md
+++ b/docs/superpowers/plans/2026-04-27-phase-4-7-category-editing-parity.md
@@ -1,0 +1,82 @@
+# Phase 4.7 Category Editing Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add category editing to scheduled and unscheduled task edit forms while preserving existing task edit behavior.
+
+**Architecture:** Keep each edit form owned by its current feature module. Extract only the stable taxonomy form seams into focused helpers: option rendering/population, category validation, and per-select color-dot synchronization. Scheduled and unscheduled save paths carry `category` through their existing manager updates.
+
+**Tech Stack:** Vanilla JavaScript ES modules, Jest/jsdom tests, PouchDB-backed task state, existing taxonomy selector modules.
+
+---
+
+### Task 1: Shared Category Form Helpers
+
+**Files:**
+- Modify: `public/js/tasks/form-utils.js`
+- Test: `__tests__/form-utils.test.js`
+
+- [ ] Add tests for reusable category option HTML, select population, validation, and dot sync against the current taxonomy fixtures.
+- [ ] Run `npx.cmd jest __tests__/form-utils.test.js --runInBand` and verify the new tests fail before implementation.
+- [ ] Add focused helpers in `public/js/tasks/form-utils.js`: `renderCategoryOptionsHtml`, `populateCategorySelect`, `validateCategoryKey`, and `syncCategoryColorDot`.
+- [ ] Keep existing `populateCategoryDropdown` and `initializeCategoryDropdownListener` behavior by delegating to the new helpers.
+- [ ] Re-run `npx.cmd jest __tests__/form-utils.test.js --runInBand` and verify it passes.
+
+### Task 2: Scheduled Task Category Editing
+
+**Files:**
+- Modify: `public/js/tasks/scheduled-renderer.js`
+- Modify: `public/js/tasks/scheduled-handlers.js`
+- Modify: `public/js/tasks/manager.js`
+- Modify: `public/js/tasks/form-utils.js`
+- Test: `__tests__/task-management.test.js`
+- Test: `__tests__/dom-interaction.test.js`
+
+- [ ] Add failing tests proving scheduled edit forms render the current category, save a changed category, reject stale category keys, and still surface overlap/reschedule UI when category is edited.
+- [ ] Run targeted scheduled tests and verify the new assertions fail.
+- [ ] Add a category select and colored dot to `renderEditTaskHTML`.
+- [ ] Update scheduled edit form extraction so the selected category is included and stale category keys are rejected with the existing task-themed alert.
+- [ ] Update `updateTask` and confirmation paths so scheduled task category persists through normal saves and overlap-confirmed saves.
+- [ ] Wire category-dot sync for scheduled edit forms after render.
+- [ ] Re-run targeted scheduled tests and verify they pass.
+
+### Task 3: Unscheduled Task Category Editing
+
+**Files:**
+- Modify: `public/js/tasks/unscheduled-renderer.js`
+- Modify: `public/js/tasks/form-utils.js`
+- Modify: `public/js/tasks/manager.js`
+- Test: `__tests__/unscheduled-task-renderer.test.js`
+- Test: `__tests__/unscheduled-task-handlers.test.js`
+
+- [ ] Add failing tests proving unscheduled edit forms render the current category, save a changed category, reject stale category keys, and preserve completed/in-progress timer behavior.
+- [ ] Add a regression test proving "start timer from task" uses the edited unscheduled category.
+- [ ] Run targeted unscheduled tests and verify the new assertions fail.
+- [ ] Add a category select and colored dot to the unscheduled inline edit form.
+- [ ] Populate and extract category in unscheduled inline edit form helpers.
+- [ ] Update `updateUnscheduledTask` so category persists.
+- [ ] Wire category-dot sync for unscheduled edit forms after render/toggle.
+- [ ] Re-run targeted unscheduled tests and verify they pass.
+
+### Task 4: Activity Helper Migration And Regression
+
+**Files:**
+- Modify: `public/js/activities/renderer.js`
+- Modify: `public/js/activities/ui-handlers.js`
+- Test: `__tests__/activity-renderer.test.js`
+- Test: `__tests__/activity-handlers.test.js`
+
+- [ ] If mechanical, migrate activity inline category option rendering/dot sync to the shared helper.
+- [ ] Add or preserve regression tests proving activity category editing behavior is unchanged.
+- [ ] Run activity tests and verify they pass.
+
+### Task 5: Final Verification
+
+**Files:**
+- Modify: `docs/plans/2026-03-16-fortudo-activities-design.md`
+- Create: `docs/superpowers/plans/2026-04-27-phase-4-7-category-editing-parity.md`
+
+- [ ] Run `npm.cmd run check`.
+- [ ] Run `npm.cmd test`.
+- [ ] Run `npx.cmd prettier --check docs\plans\2026-03-16-fortudo-activities-design.md docs\superpowers\plans\2026-04-27-phase-4-7-category-editing-parity.md`.
+- [ ] Review `git diff` to ensure only Phase 4.7-related code/docs changed.

--- a/public/js/activities/form-utils.js
+++ b/public/js/activities/form-utils.js
@@ -5,7 +5,7 @@ import {
     timeToDateTime
 } from '../utils.js';
 import { showAlert } from '../modal-manager.js';
-import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
+import { validateCategoryKey } from '../tasks/form-utils.js';
 
 function extractActivityFields(formElement, options = {}) {
     const formData = new FormData(formElement);
@@ -32,8 +32,8 @@ function extractActivityFields(formElement, options = {}) {
         return null;
     }
 
-    if (categoryKey && !resolveCategoryKey(categoryKey)) {
-        showAlert('Selected category is no longer available.', 'sky');
+    const categoryResult = validateCategoryKey(categoryKey, 'sky');
+    if (!categoryResult.valid) {
         return null;
     }
 
@@ -43,7 +43,7 @@ function extractActivityFields(formElement, options = {}) {
 
     return {
         description,
-        category: categoryKey || null,
+        category: categoryResult.category,
         startDateTime,
         endDateTime,
         duration: durationResult.duration

--- a/public/js/activities/form-utils.js
+++ b/public/js/activities/form-utils.js
@@ -5,7 +5,7 @@ import {
     timeToDateTime
 } from '../utils.js';
 import { showAlert } from '../modal-manager.js';
-import { validateCategoryKey } from '../tasks/form-utils.js';
+import { validateCategoryKey } from '../category-form-utils.js';
 
 function extractActivityFields(formElement, options = {}) {
     const formData = new FormData(formElement);

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -9,7 +9,7 @@ import {
     convertTo12HourTime,
     extractDateFromDateTime
 } from '../utils.js';
-import { computeEndTimePreview } from '../tasks/form-utils.js';
+import { computeEndTimePreview, renderCategoryOptionsHtml } from '../tasks/form-utils.js';
 import { buildActivitySummaryModel } from './summary.js';
 
 function escapeHtml(value) {
@@ -25,20 +25,6 @@ function formatTimeRange(startDateTime, endDateTime) {
     const startTime = extractTimeFromDateTime(new Date(startDateTime));
     const endTime = extractTimeFromDateTime(new Date(endDateTime));
     return `${convertTo12HourTime(startTime)} - ${convertTo12HourTime(endTime)}`;
-}
-
-function renderCategoryOptions(selectedCategory) {
-    const options = getSelectableCategoryOptions();
-    const baseOption = '<option value="">No category</option>';
-    const renderedOptions = options
-        .map((option) => {
-            const indent = option.indentLevel > 0 ? '&nbsp;&nbsp;' : '';
-            const selected = option.value === selectedCategory ? ' selected' : '';
-            return `<option value="${escapeHtml(option.value)}"${selected}>${indent}${escapeHtml(option.label)}</option>`;
-        })
-        .join('');
-
-    return `${baseOption}${renderedOptions}`;
 }
 
 function getSummarySwatchStyle(summaryItem) {
@@ -204,6 +190,10 @@ function renderInlineEditActivityItem(activity) {
     const activityDate = extractDateFromDateTime(new Date(activity.startDateTime));
     const resolvedCategory = activity.category ? resolveCategoryKey(activity.category) : null;
     const categoryColor = resolvedCategory?.record?.color || '#64748b';
+    const categoryOptionsHtml = renderCategoryOptionsHtml(
+        getSelectableCategoryOptions(),
+        activity.category || ''
+    );
     const endTimeHint = computeEndTimePreview(
         displayStartTime,
         durationHours.toString(),
@@ -231,7 +221,8 @@ function renderInlineEditActivityItem(activity) {
                 <div class="flex items-center gap-2">
                 <span class="activity-edit-category-dot w-3 h-3 rounded-full shrink-0" style="background-color: ${escapeHtml(categoryColor)};"></span>
                 <select name="category" class="bg-slate-700 px-3 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
-                    ${renderCategoryOptions(activity.category)}
+                    <option value="">No category</option>
+                    ${categoryOptionsHtml}
                 </select>
                 </div>
             </div>

--- a/public/js/activities/renderer.js
+++ b/public/js/activities/renderer.js
@@ -9,7 +9,8 @@ import {
     convertTo12HourTime,
     extractDateFromDateTime
 } from '../utils.js';
-import { computeEndTimePreview, renderCategoryOptionsHtml } from '../tasks/form-utils.js';
+import { renderCategorySelectRow } from '../category-form-utils.js';
+import { computeEndTimePreview } from '../tasks/form-utils.js';
 import { buildActivitySummaryModel } from './summary.js';
 
 function escapeHtml(value) {
@@ -190,10 +191,15 @@ function renderInlineEditActivityItem(activity) {
     const activityDate = extractDateFromDateTime(new Date(activity.startDateTime));
     const resolvedCategory = activity.category ? resolveCategoryKey(activity.category) : null;
     const categoryColor = resolvedCategory?.record?.color || '#64748b';
-    const categoryOptionsHtml = renderCategoryOptionsHtml(
-        getSelectableCategoryOptions(),
-        activity.category || ''
-    );
+    const categoryRowHtml = renderCategorySelectRow({
+        selectName: 'category',
+        selectedValue: activity.category || '',
+        options: getSelectableCategoryOptions(),
+        dotClass: 'activity-edit-category-dot',
+        selectClass:
+            'bg-slate-700 px-3 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100',
+        dotStyle: `background-color: ${categoryColor};`
+    });
     const endTimeHint = computeEndTimePreview(
         displayStartTime,
         durationHours.toString(),
@@ -218,13 +224,7 @@ function renderInlineEditActivityItem(activity) {
                     class="bg-slate-700 pl-10 pr-4 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100" required>
             </div>
             <div class="sm:flex-1 sm:min-w-[13rem]">
-                <div class="flex items-center gap-2">
-                <span class="activity-edit-category-dot w-3 h-3 rounded-full shrink-0" style="background-color: ${escapeHtml(categoryColor)};"></span>
-                <select name="category" class="bg-slate-700 px-3 py-2.5 rounded-lg w-full border border-slate-600 focus:outline-none focus:border-sky-400 transition-all text-slate-100">
-                    <option value="">No category</option>
-                    ${categoryOptionsHtml}
-                </select>
-                </div>
+                ${categoryRowHtml}
             </div>
         </div>
         <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:pb-5">

--- a/public/js/category-form-utils.js
+++ b/public/js/category-form-utils.js
@@ -1,0 +1,101 @@
+import { showAlert } from './modal-manager.js';
+import { resolveCategoryKey } from './taxonomy/taxonomy-selectors.js';
+
+const DEFAULT_CATEGORY_DOT_COLOR = '#64748b';
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+export function renderCategoryOptionsHtml(options, selectedValue = '') {
+    return options
+        .map((optionData) => {
+            const label =
+                optionData.indentLevel > 0
+                    ? `${'&rsaquo; '.repeat(optionData.indentLevel)}${escapeHtml(optionData.label)}`
+                    : escapeHtml(optionData.label);
+            const selected = optionData.value === selectedValue ? ' selected' : '';
+            return `<option value="${escapeHtml(optionData.value)}"${selected}>${label}</option>`;
+        })
+        .join('');
+}
+
+export function renderCategorySelectRow({
+    selectName,
+    selectedValue = '',
+    options,
+    dotClass,
+    selectClass,
+    rowClass = 'category-select-row flex items-center gap-2',
+    dotStyle = ''
+}) {
+    const styleAttribute = dotStyle ? ` style="${escapeHtml(dotStyle)}"` : '';
+    const optionsHtml = renderCategoryOptionsHtml(options, selectedValue);
+
+    return `<div class="${escapeHtml(rowClass)}">
+        <span class="${escapeHtml(dotClass)} w-3 h-3 rounded-full shrink-0" aria-hidden="true"${styleAttribute}></span>
+        <select name="${escapeHtml(selectName)}" class="${escapeHtml(selectClass)}">
+            <option value="">No category</option>
+            ${optionsHtml}
+        </select>
+    </div>`;
+}
+
+export function populateCategorySelect(
+    selectElement,
+    options,
+    selectedValue = selectElement.value
+) {
+    while (selectElement.options.length > 1) {
+        selectElement.remove(1);
+    }
+
+    for (const optionData of options) {
+        const option = document.createElement('option');
+        option.value = optionData.value;
+        const indentPrefix = '\u203A '.repeat(optionData.indentLevel);
+        option.textContent = `${indentPrefix}${optionData.label}`;
+        selectElement.appendChild(option);
+    }
+
+    if (
+        selectedValue &&
+        Array.from(selectElement.options).some((option) => option.value === selectedValue)
+    ) {
+        selectElement.value = selectedValue;
+    }
+}
+
+export function validateCategoryKey(categoryKey, theme) {
+    if (!categoryKey) {
+        return { valid: true, category: null };
+    }
+
+    if (!resolveCategoryKey(categoryKey)) {
+        showAlert('Selected category is no longer available.', theme);
+        return { valid: false, category: null };
+    }
+
+    return { valid: true, category: categoryKey };
+}
+
+export function syncCategoryColorDot(selectElement, dotElement) {
+    if (!(selectElement instanceof HTMLSelectElement) || !(dotElement instanceof HTMLElement)) {
+        return;
+    }
+
+    const updateIndicator = () => {
+        const resolved = resolveCategoryKey(selectElement.value);
+        dotElement.style.backgroundColor = resolved
+            ? resolved.record.color
+            : DEFAULT_CATEGORY_DOT_COLOR;
+    };
+
+    selectElement.addEventListener('change', updateIndicator);
+    updateIndicator();
+}

--- a/public/js/tasks/form-utils.js
+++ b/public/js/tasks/form-utils.js
@@ -10,9 +10,23 @@ import {
 } from '../utils.js';
 import { showAlert } from '../modal-manager.js';
 import { checkOverlap } from '../reschedule-engine.js';
-import { resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
+import {
+    getSelectableCategoryOptions,
+    resolveCategoryKey
+} from '../taxonomy/taxonomy-selectors.js';
+
+const DEFAULT_CATEGORY_DOT_COLOR = '#64748b';
 
 // --- Inline Edit Functions for Unscheduled Tasks ---
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
 
 /**
  * Populates the inline edit form for an unscheduled task with existing task data
@@ -41,6 +55,8 @@ export function populateUnscheduledTaskInlineEditForm(taskId, taskData) {
     const hoursInput = form.querySelector('input[name="inline-edit-est-duration-hours"]');
     const minutesInput = form.querySelector('input[name="inline-edit-est-duration-minutes"]');
     const priorityRadios = form.querySelectorAll('input[name="inline-edit-priority"]');
+    const categorySelect = form.querySelector('select[name="inline-edit-category"]');
+    const categoryDot = form.querySelector('.unscheduled-edit-category-dot');
 
     if (descriptionInput instanceof HTMLInputElement) descriptionInput.value = taskData.description;
     else logger.warn('Description input not found for inline edit form', form);
@@ -56,6 +72,15 @@ export function populateUnscheduledTaskInlineEditForm(taskId, taskData) {
             radio.checked = radio.value === taskData.priority;
         }
     });
+
+    if (categorySelect instanceof HTMLSelectElement) {
+        populateCategorySelect(
+            categorySelect,
+            getSelectableCategoryOptions(),
+            taskData.category || ''
+        );
+    }
+    syncCategoryColorDot(categorySelect, categoryDot);
 }
 
 /**
@@ -87,6 +112,7 @@ export function getUnscheduledTaskInlineFormData(taskId) {
     const selectedPriorityElement = form.querySelector(
         'input[name="inline-edit-priority"]:checked'
     );
+    const categorySelect = form.querySelector('select[name="inline-edit-category"]');
 
     const description =
         descriptionInput instanceof HTMLInputElement ? descriptionInput.value.trim() : '';
@@ -110,8 +136,18 @@ export function getUnscheduledTaskInlineFormData(taskId) {
         selectedPriorityElement instanceof HTMLInputElement
             ? selectedPriorityElement.value
             : 'medium';
+    const categoryValue = categorySelect instanceof HTMLSelectElement ? categorySelect.value : '';
+    const categoryResult = validateCategoryKey(categoryValue, 'indigo');
+    if (!categoryResult.valid) {
+        return null;
+    }
 
-    return { description, priority, estDuration: durationResult.duration };
+    return {
+        description,
+        priority,
+        estDuration: durationResult.duration,
+        category: categoryResult.category
+    };
 }
 
 /**
@@ -167,13 +203,15 @@ export function extractTaskFormData(formElement) {
     }
 
     let taskData = { description, taskType };
-    const categoryKey = formData.get('category')?.toString() || null;
-    if (categoryKey) {
-        if (!resolveCategoryKey(categoryKey)) {
-            showAlert('Selected category is no longer available.', getThemeForTaskType(taskType));
-            return null;
-        }
-        taskData.category = categoryKey;
+    const categoryResult = validateCategoryKey(
+        formData.get('category')?.toString() || '',
+        getThemeForTaskType(taskType)
+    );
+    if (!categoryResult.valid) {
+        return null;
+    }
+    if (categoryResult.category) {
+        taskData.category = categoryResult.category;
     }
 
     if (taskType === 'scheduled') {
@@ -227,8 +265,27 @@ export function getTaskFormElement() {
  * @param {Array<{value: string, label: string, indentLevel: number}>} options
  */
 export function populateCategoryDropdown(selectElement, options) {
-    const currentValue = selectElement.value;
+    populateCategorySelect(selectElement, options, selectElement.value);
+}
 
+export function renderCategoryOptionsHtml(options, selectedValue = '') {
+    return options
+        .map((optionData) => {
+            const label =
+                optionData.indentLevel > 0
+                    ? `${'&rsaquo; '.repeat(optionData.indentLevel)}${escapeHtml(optionData.label)}`
+                    : escapeHtml(optionData.label);
+            const selected = optionData.value === selectedValue ? ' selected' : '';
+            return `<option value="${escapeHtml(optionData.value)}"${selected}>${label}</option>`;
+        })
+        .join('');
+}
+
+export function populateCategorySelect(
+    selectElement,
+    options,
+    selectedValue = selectElement.value
+) {
     while (selectElement.options.length > 1) {
         selectElement.remove(1);
     }
@@ -236,19 +293,46 @@ export function populateCategoryDropdown(selectElement, options) {
     for (const optionData of options) {
         const option = document.createElement('option');
         option.value = optionData.value;
-        option.textContent =
-            optionData.indentLevel > 0
-                ? `${'› '.repeat(optionData.indentLevel)}${optionData.label}`
-                : optionData.label;
+        const indentPrefix = '\u203A '.repeat(optionData.indentLevel);
+        option.textContent = `${indentPrefix}${optionData.label}`;
         selectElement.appendChild(option);
     }
 
     if (
-        currentValue &&
-        Array.from(selectElement.options).some((option) => option.value === currentValue)
+        selectedValue &&
+        Array.from(selectElement.options).some((option) => option.value === selectedValue)
     ) {
-        selectElement.value = currentValue;
+        selectElement.value = selectedValue;
     }
+}
+
+export function validateCategoryKey(categoryKey, theme) {
+    if (!categoryKey) {
+        return { valid: true, category: null };
+    }
+
+    if (!resolveCategoryKey(categoryKey)) {
+        showAlert('Selected category is no longer available.', theme);
+        return { valid: false, category: null };
+    }
+
+    return { valid: true, category: categoryKey };
+}
+
+export function syncCategoryColorDot(selectElement, dotElement) {
+    if (!(selectElement instanceof HTMLSelectElement) || !(dotElement instanceof HTMLElement)) {
+        return;
+    }
+
+    const updateIndicator = () => {
+        const resolved = resolveCategoryKey(selectElement.value);
+        dotElement.style.backgroundColor = resolved
+            ? resolved.record.color
+            : DEFAULT_CATEGORY_DOT_COLOR;
+    };
+
+    selectElement.addEventListener('change', updateIndicator);
+    updateIndicator();
 }
 
 /**
@@ -261,13 +345,7 @@ export function initializeCategoryDropdownListener() {
         return;
     }
 
-    const updateIndicator = () => {
-        const resolved = resolveCategoryKey(select.value);
-        dot.style.backgroundColor = resolved ? resolved.record.color : '#64748b';
-    };
-
-    select.addEventListener('change', updateIndicator);
-    updateIndicator();
+    syncCategoryColorDot(select, dot);
 }
 
 // --- End Time Preview Functions ---

--- a/public/js/tasks/form-utils.js
+++ b/public/js/tasks/form-utils.js
@@ -10,23 +10,14 @@ import {
 } from '../utils.js';
 import { showAlert } from '../modal-manager.js';
 import { checkOverlap } from '../reschedule-engine.js';
+import { getSelectableCategoryOptions } from '../taxonomy/taxonomy-selectors.js';
 import {
-    getSelectableCategoryOptions,
-    resolveCategoryKey
-} from '../taxonomy/taxonomy-selectors.js';
-
-const DEFAULT_CATEGORY_DOT_COLOR = '#64748b';
+    populateCategorySelect,
+    syncCategoryColorDot,
+    validateCategoryKey
+} from '../category-form-utils.js';
 
 // --- Inline Edit Functions for Unscheduled Tasks ---
-
-function escapeHtml(value) {
-    return String(value ?? '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-}
 
 /**
  * Populates the inline edit form for an unscheduled task with existing task data
@@ -266,73 +257,6 @@ export function getTaskFormElement() {
  */
 export function populateCategoryDropdown(selectElement, options) {
     populateCategorySelect(selectElement, options, selectElement.value);
-}
-
-export function renderCategoryOptionsHtml(options, selectedValue = '') {
-    return options
-        .map((optionData) => {
-            const label =
-                optionData.indentLevel > 0
-                    ? `${'&rsaquo; '.repeat(optionData.indentLevel)}${escapeHtml(optionData.label)}`
-                    : escapeHtml(optionData.label);
-            const selected = optionData.value === selectedValue ? ' selected' : '';
-            return `<option value="${escapeHtml(optionData.value)}"${selected}>${label}</option>`;
-        })
-        .join('');
-}
-
-export function populateCategorySelect(
-    selectElement,
-    options,
-    selectedValue = selectElement.value
-) {
-    while (selectElement.options.length > 1) {
-        selectElement.remove(1);
-    }
-
-    for (const optionData of options) {
-        const option = document.createElement('option');
-        option.value = optionData.value;
-        const indentPrefix = '\u203A '.repeat(optionData.indentLevel);
-        option.textContent = `${indentPrefix}${optionData.label}`;
-        selectElement.appendChild(option);
-    }
-
-    if (
-        selectedValue &&
-        Array.from(selectElement.options).some((option) => option.value === selectedValue)
-    ) {
-        selectElement.value = selectedValue;
-    }
-}
-
-export function validateCategoryKey(categoryKey, theme) {
-    if (!categoryKey) {
-        return { valid: true, category: null };
-    }
-
-    if (!resolveCategoryKey(categoryKey)) {
-        showAlert('Selected category is no longer available.', theme);
-        return { valid: false, category: null };
-    }
-
-    return { valid: true, category: categoryKey };
-}
-
-export function syncCategoryColorDot(selectElement, dotElement) {
-    if (!(selectElement instanceof HTMLSelectElement) || !(dotElement instanceof HTMLElement)) {
-        return;
-    }
-
-    const updateIndicator = () => {
-        const resolved = resolveCategoryKey(selectElement.value);
-        dotElement.style.backgroundColor = resolved
-            ? resolved.record.color
-            : DEFAULT_CATEGORY_DOT_COLOR;
-    };
-
-    selectElement.addEventListener('change', updateIndicator);
-    updateIndicator();
 }
 
 /**

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -723,6 +723,7 @@ export function updateTask(index, taskData) {
         return { success: false, reason: 'Invalid task index.' };
     }
     const existingTask = tasks[index];
+    const hasCategoryUpdate = Object.prototype.hasOwnProperty.call(taskData, 'category');
     let updatedProposedDetails = {
         description:
             taskData.description !== undefined ? taskData.description : existingTask.description,
@@ -731,7 +732,8 @@ export function updateTask(index, taskData) {
         id: existingTask.id,
         editing: false,
         confirmingDelete: existingTask.confirmingDelete,
-        locked: taskData.locked !== undefined ? taskData.locked : existingTask.locked
+        locked: taskData.locked !== undefined ? taskData.locked : existingTask.locked,
+        category: hasCategoryUpdate ? taskData.category || null : existingTask.category || null
     };
 
     let wasShiftedByLocked = false;
@@ -873,6 +875,9 @@ export function updateUnscheduledTask(taskId, newData) {
     taskToUpdate.description = newData.description;
     taskToUpdate.priority = newData.priority;
     taskToUpdate.estDuration = newData.estDuration;
+    if (Object.prototype.hasOwnProperty.call(newData, 'category')) {
+        taskToUpdate.category = newData.category || null;
+    }
 
     finalizeTaskModification(taskToUpdate);
     return { success: true, task: taskToUpdate };

--- a/public/js/tasks/scheduled-handlers.js
+++ b/public/js/tasks/scheduled-handlers.js
@@ -152,6 +152,13 @@ export async function handleSaveTaskEdit(taskId, formElement, _taskIndex) {
     if (!taskData) {
         return;
     }
+    const categorySelect = formElement.querySelector('select[name="category"]');
+    if (
+        categorySelect instanceof HTMLSelectElement &&
+        !Object.prototype.hasOwnProperty.call(taskData, 'category')
+    ) {
+        taskData.category = null;
+    }
 
     const taskToSave = getTaskById(taskId);
     if (!taskToSave || taskToSave.type !== 'scheduled') {

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -10,9 +10,14 @@ import { findScheduleGaps } from '../reschedule-engine.js';
 import {
     computeEndTimePreview,
     computeOverlapPreview,
-    formatOverlapWarning
+    formatOverlapWarning,
+    renderCategoryOptionsHtml,
+    syncCategoryColorDot
 } from './form-utils.js';
-import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
+import {
+    getSelectableCategoryOptions,
+    renderCategoryBadge
+} from '../taxonomy/taxonomy-selectors.js';
 
 // --- DOM Element Getters ---
 export function getScheduledTaskListElement() {
@@ -41,6 +46,10 @@ export function renderEditTaskHTML(task, index) {
         : '';
     const durationHours = task.duration ? Math.floor(task.duration / 60) : 0;
     const durationMinutes = task.duration ? task.duration % 60 : 0;
+    const categoryOptionsHtml = renderCategoryOptionsHtml(
+        getSelectableCategoryOptions(),
+        task.category || ''
+    );
 
     return `
         <form id="edit-task-${task.id}" data-task-id="${task.id}" data-task-index="${index}" autocomplete="off" class="p-4 rounded-lg border border-gray-700 bg-gray-800 bg-opacity-70 shadow-lg text-left space-y-4">
@@ -51,6 +60,16 @@ export function renderEditTaskHTML(task, index) {
                 <i class="fa-regular fa-pen-to-square absolute left-3 top-1/2 transform -translate-y-1/2 text-teal-400"></i>
                 <input type="text" name="description" value="${task.description}" placeholder="What needs to be done?"
                     class="bg-gray-700 pl-10 pr-4 py-2.5 rounded-lg w-full focus:ring-2 focus:ring-teal-400 focus:outline-none transition-all" required>
+            </div>
+
+            <!-- Category Row -->
+            <div class="flex items-center gap-2">
+                <span class="scheduled-edit-category-dot w-3 h-3 rounded-full shrink-0" aria-hidden="true"></span>
+                <select name="category"
+                    class="bg-gray-700 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-teal-400 focus:outline-none transition-all">
+                    <option value="">No category</option>
+                    ${categoryOptionsHtml}
+                </select>
             </div>
 
             <!-- Time, Duration, and Buttons Row -->
@@ -292,6 +311,8 @@ export function renderTasks(
         const startInput = form.querySelector('input[name="start-time"]');
         const hoursInput = form.querySelector('input[name="duration-hours"]');
         const minutesInput = form.querySelector('input[name="duration-minutes"]');
+        const categorySelect = form.querySelector('select[name="category"]');
+        const categoryDot = form.querySelector('.scheduled-edit-category-dot');
 
         if (
             !(startInput instanceof HTMLInputElement) ||
@@ -337,6 +358,8 @@ export function renderTasks(
                     .replace(/hover:to-teal-300/g, 'hover:to-amber-300');
             }
         }
+
+        syncCategoryColorDot(categorySelect, categoryDot);
     });
 
     return updatedCallbacks;

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -10,10 +10,9 @@ import { findScheduleGaps } from '../reschedule-engine.js';
 import {
     computeEndTimePreview,
     computeOverlapPreview,
-    formatOverlapWarning,
-    renderCategoryOptionsHtml,
-    syncCategoryColorDot
+    formatOverlapWarning
 } from './form-utils.js';
+import { renderCategorySelectRow, syncCategoryColorDot } from '../category-form-utils.js';
 import {
     getSelectableCategoryOptions,
     renderCategoryBadge
@@ -46,10 +45,14 @@ export function renderEditTaskHTML(task, index) {
         : '';
     const durationHours = task.duration ? Math.floor(task.duration / 60) : 0;
     const durationMinutes = task.duration ? task.duration % 60 : 0;
-    const categoryOptionsHtml = renderCategoryOptionsHtml(
-        getSelectableCategoryOptions(),
-        task.category || ''
-    );
+    const categoryRowHtml = renderCategorySelectRow({
+        selectName: 'category',
+        selectedValue: task.category || '',
+        options: getSelectableCategoryOptions(),
+        dotClass: 'scheduled-edit-category-dot',
+        selectClass:
+            'bg-gray-700 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-teal-400 focus:outline-none transition-all'
+    });
 
     return `
         <form id="edit-task-${task.id}" data-task-id="${task.id}" data-task-index="${index}" autocomplete="off" class="p-4 rounded-lg border border-gray-700 bg-gray-800 bg-opacity-70 shadow-lg text-left space-y-4">
@@ -63,14 +66,7 @@ export function renderEditTaskHTML(task, index) {
             </div>
 
             <!-- Category Row -->
-            <div class="flex items-center gap-2">
-                <span class="scheduled-edit-category-dot w-3 h-3 rounded-full shrink-0" aria-hidden="true"></span>
-                <select name="category"
-                    class="bg-gray-700 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-teal-400 focus:outline-none transition-all">
-                    <option value="">No category</option>
-                    ${categoryOptionsHtml}
-                </select>
-            </div>
+            ${categoryRowHtml}
 
             <!-- Time, Duration, and Buttons Row -->
             <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-4 sm:pb-5">

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -1,6 +1,9 @@
 import { calculateHoursAndMinutes, logger } from '../utils.js';
-import { toggleUnscheduledTaskInlineEdit } from './form-utils.js';
-import { renderCategoryBadge } from '../taxonomy/taxonomy-selectors.js';
+import { renderCategoryOptionsHtml, toggleUnscheduledTaskInlineEdit } from './form-utils.js';
+import {
+    getSelectableCategoryOptions,
+    renderCategoryBadge
+} from '../taxonomy/taxonomy-selectors.js';
 import { getRunningActivity } from '../activities/manager.js';
 
 // --- DOM Element Getters ---
@@ -124,6 +127,10 @@ function createInlineEditFormHTML(task) {
     const checkedHigh = task.priority === 'high' ? 'checked' : '';
     const checkedMed = task.priority === 'medium' ? 'checked' : '';
     const checkedLow = task.priority === 'low' ? 'checked' : '';
+    const categoryOptionsHtml = renderCategoryOptionsHtml(
+        getSelectableCategoryOptions(),
+        task.category || ''
+    );
 
     return `
         <form class="space-y-3">
@@ -133,6 +140,16 @@ function createInlineEditFormHTML(task) {
                 <input type="text" id="inline-edit-description-${task.id}" name="inline-edit-description"
                     placeholder="What needs to be done?"
                     class="task-edit-description bg-gray-700 pl-9 pr-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-indigo-300 focus:outline-none transition-all text-sm sm:text-base" required>
+            </div>
+
+            <!-- Category Row -->
+            <div class="flex items-center gap-2">
+                <span class="unscheduled-edit-category-dot w-3 h-3 rounded-full shrink-0" aria-hidden="true"></span>
+                <select name="inline-edit-category"
+                    class="bg-gray-700 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-indigo-300 focus:outline-none transition-all text-sm sm:text-base">
+                    <option value="">No category</option>
+                    ${categoryOptionsHtml}
+                </select>
             </div>
 
             <!-- Priority, Duration, and Buttons Row -->

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -1,5 +1,6 @@
 import { calculateHoursAndMinutes, logger } from '../utils.js';
-import { renderCategoryOptionsHtml, toggleUnscheduledTaskInlineEdit } from './form-utils.js';
+import { toggleUnscheduledTaskInlineEdit } from './form-utils.js';
+import { renderCategorySelectRow } from '../category-form-utils.js';
 import {
     getSelectableCategoryOptions,
     renderCategoryBadge
@@ -127,10 +128,14 @@ function createInlineEditFormHTML(task) {
     const checkedHigh = task.priority === 'high' ? 'checked' : '';
     const checkedMed = task.priority === 'medium' ? 'checked' : '';
     const checkedLow = task.priority === 'low' ? 'checked' : '';
-    const categoryOptionsHtml = renderCategoryOptionsHtml(
-        getSelectableCategoryOptions(),
-        task.category || ''
-    );
+    const categoryRowHtml = renderCategorySelectRow({
+        selectName: 'inline-edit-category',
+        selectedValue: task.category || '',
+        options: getSelectableCategoryOptions(),
+        dotClass: 'unscheduled-edit-category-dot',
+        selectClass:
+            'bg-gray-700 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-indigo-300 focus:outline-none transition-all text-sm sm:text-base'
+    });
 
     return `
         <form class="space-y-3">
@@ -143,14 +148,7 @@ function createInlineEditFormHTML(task) {
             </div>
 
             <!-- Category Row -->
-            <div class="flex items-center gap-2">
-                <span class="unscheduled-edit-category-dot w-3 h-3 rounded-full shrink-0" aria-hidden="true"></span>
-                <select name="inline-edit-category"
-                    class="bg-gray-700 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-indigo-300 focus:outline-none transition-all text-sm sm:text-base">
-                    <option value="">No category</option>
-                    ${categoryOptionsHtml}
-                </select>
-            </div>
+            ${categoryRowHtml}
 
             <!-- Priority, Duration, and Buttons Row -->
             <div class="flex flex-col sm:flex-row gap-3">

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -1464,6 +1464,9 @@ def run_activities_room_scenario(
         description="activity inline edit description",
     )
     page.locator(
+        f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] select[name="category"]'
+    ).select_option("work/project")
+    page.locator(
         f'form.activity-inline-edit-form[data-activity-id="{editable_activity_doc["id"]}"] .btn-save-activity-edit'
     ).click()
     page.locator(
@@ -1473,9 +1476,10 @@ def run_activities_room_scenario(
         lambda: any(
             doc.get("id") == editable_activity_doc["id"]
             and doc.get("description") == "Playwright editable activity updated"
+            and doc.get("category") == "work/project"
             for doc in map(normalize_doc, read_docs(page, rooms["activities"]))
         ),
-        "activity edit after delete-confirm rerender",
+        "activity edit category after delete-confirm rerender",
     )
     if get_unscheduled_delete_state(page, delete_confirm_task_doc["id"]) != "idle":
         raise ValueError("delete confirm state was not cleared by activity edit")
@@ -1494,9 +1498,21 @@ def run_activities_room_scenario(
         "Playwright delete activity",
     )
     arm_unscheduled_delete_confirm(page, delete_confirm_task_doc["id"])
-    page.locator(
+    delete_activity_button = page.locator(
         f'[data-activity-id="{deletable_activity_doc["id"]}"] .btn-delete-activity'
-    ).click()
+    )
+    delete_activity_button.click()
+    wait_until(
+        lambda: "fa-check-circle"
+        in (
+            page.locator(
+                f'[data-activity-id="{deletable_activity_doc["id"]}"] .btn-delete-activity i'
+            ).get_attribute("class")
+            or ""
+        ),
+        "activity delete confirmation arm",
+    )
+    delete_activity_button.click()
     wait_until(
         lambda: not any(
             doc.get("id") == deletable_activity_doc["id"]
@@ -2168,7 +2184,7 @@ def run_smoke(
                         page.locator('#category-select option[value="work/project"]').text_content()
                         or ""
                     )
-                    == "Ã¢â‚¬Âº Project",
+                    == "› Project",
                     "visible nested project category option",
                 )
 
@@ -2375,6 +2391,67 @@ def run_smoke(
                 wait_for_toast_text(page, 'Category "work/project" is referenced by tasks')
                 close_settings_modal(page)
 
+                scheduled_taxonomy_doc = wait_for_task_doc(
+                    page,
+                    rooms["taxonomy"],
+                    "Taxonomy scheduled group task",
+                )
+                scheduled_edit_form_selector = open_scheduled_edit_form(
+                    page, scheduled_taxonomy_doc["id"]
+                )
+                page.locator(
+                    f'{scheduled_edit_form_selector} select[name="category"]'
+                ).select_option("work/meeting")
+                page.locator(scheduled_edit_form_selector).evaluate(
+                    "(form) => form.requestSubmit()"
+                )
+                page.locator(scheduled_edit_form_selector).wait_for(
+                    state="hidden", timeout=10000
+                )
+
+                unscheduled_taxonomy_doc = wait_for_task_doc(
+                    page,
+                    rooms["taxonomy"],
+                    "Taxonomy child category task",
+                )
+                unscheduled_card_selector = (
+                    f'.task-card[data-task-id="{unscheduled_taxonomy_doc["id"]}"]'
+                )
+                page.locator(f"{unscheduled_card_selector} .btn-edit-unscheduled").click()
+                page.locator(
+                    f'{unscheduled_card_selector} select[name="inline-edit-category"]'
+                ).wait_for(state="visible", timeout=10000)
+                page.locator(
+                    f'{unscheduled_card_selector} select[name="inline-edit-category"]'
+                ).select_option("break/walk")
+                page.locator(f"{unscheduled_card_selector} .btn-save-inline-edit").click()
+
+                wait_until(
+                    lambda: (
+                        lambda docs: any(
+                            doc.get("description") == "Taxonomy scheduled group task"
+                            and doc.get("category") == "work/meeting"
+                            for doc in docs
+                        )
+                        and any(
+                            doc.get("description") == "Taxonomy child category task"
+                            and doc.get("category") == "break/walk"
+                            for doc in docs
+                        )
+                    )(list(map(normalize_doc, read_docs(page, rooms["taxonomy"])))),
+                    "taxonomy task edit category persistence",
+                )
+                wait_until(
+                    lambda: "Meeting" in (page.locator("#scheduled-task-list").text_content() or ""),
+                    "scheduled edited category badge label",
+                )
+                wait_until(
+                    lambda: "Walk" in (page.locator("#unscheduled-task-list").text_content() or ""),
+                    "unscheduled edited category badge label",
+                )
+                demo_note("taxonomy: scheduled and unscheduled category edits persisted")
+                assert_no_page_errors_yet("taxonomy task category edits")
+
                 taxonomy_summary = summarize_docs(read_docs(page, rooms["taxonomy"]))
                 taxonomy_config = next(
                     (
@@ -2412,12 +2489,12 @@ def run_smoke(
                         lambda: (
                             lambda summary: any(
                                 doc.get("description") == "Taxonomy scheduled group task"
-                                and doc.get("category") == "family"
+                                and doc.get("category") == "work/meeting"
                                 for doc in summary["tasks"]
                             )
                             and any(
                                 doc.get("description") == "Taxonomy child category task"
-                                and doc.get("category") == "work/project"
+                                and doc.get("category") == "break/walk"
                                 for doc in summary["tasks"]
                             )
                             and any(

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -535,18 +535,18 @@ def start_activity_timer(
 
     if timer_display.is_visible():
         if category is not None:
-            page.locator("#timer-category").select_option(category)
+            page.locator("#next-activity-category").select_option(category)
         fill_locator_value(
             page,
-            page.locator("#timer-description"),
+            page.locator("#next-activity-description"),
             description,
-            description="running timer description",
+            description="next timer description",
         )
         wait_for_input_value(
             page,
-            "#timer-description",
+            "#next-activity-description",
             description,
-            description="running timer description before start",
+            description="next timer description before start",
         )
     else:
         if category is not None:
@@ -605,6 +605,11 @@ def stop_activity_timer(
         timeout_s=timeout_s,
         interval_s=interval_s,
     )
+
+
+def start_timer_from_unscheduled_task(page: Any, task_id: str, expected_description: str) -> None:
+    page.locator(f'.task-card[data-task-id="{task_id}"] .btn-start-unscheduled-timer').click()
+    wait_for_running_timer_ui(page, expected_description)
 
 
 def add_active_scheduled_task(page: Any, description: str, duration_minutes: int) -> None:
@@ -969,7 +974,13 @@ def add_scheduled_task(page: Any, description: str, start_time: str, duration_mi
     page.locator("#task-form button[type='submit']").click()
 
 
-def add_unscheduled_task(page: Any, description: str, est_minutes: int, priority: str = "medium") -> None:
+def add_unscheduled_task(
+    page: Any,
+    description: str,
+    est_minutes: int,
+    priority: str = "medium",
+    category: str | None = None,
+) -> None:
     page.locator("#unscheduled").check()
     fill_locator_value(
         page,
@@ -990,6 +1001,8 @@ def add_unscheduled_task(page: Any, description: str, est_minutes: int, priority
         str(est_minutes % 60),
         description="unscheduled task duration minutes",
     )
+    if category is not None:
+        page.locator("#category-select").select_option(category)
     page.locator("#task-form button[type='submit']").click()
 
 
@@ -1418,6 +1431,75 @@ def run_activities_room_scenario(
         raise ValueError("failed auto-log unexpectedly created an activity")
     demo_note("activities: auto-log failure path surfaced toast without persisting activity")
     assert_no_page_errors_yet("auto-log failure path")
+
+    add_unscheduled_task(
+        page,
+        "Playwright linked timer task",
+        25,
+        category="work/project",
+    )
+    linked_timer_task_doc = wait_for_task_doc(
+        page,
+        rooms["activities"],
+        "Playwright linked timer task",
+    )
+    start_timer_from_unscheduled_task(
+        page,
+        linked_timer_task_doc["id"],
+        "Playwright linked timer task",
+    )
+    linked_running_config = wait_for_running_activity_config(
+        page,
+        rooms["activities"],
+        expected_description="Playwright linked timer task",
+        expected_category="work/project",
+    )
+    if linked_running_config.get("source") != "auto":
+        raise ValueError(
+            "unscheduled timer did not persist the auto source.\n"
+            f"{json.dumps(linked_running_config, indent=2)}"
+        )
+    if linked_running_config.get("sourceTaskId") != linked_timer_task_doc["id"]:
+        raise ValueError(
+            "unscheduled timer did not keep the source task id.\n"
+            f"{json.dumps(linked_running_config, indent=2)}"
+        )
+    wait_for_text_in_locator(
+        page,
+        "#unscheduled-task-list",
+        "In progress",
+        description="unscheduled linked timer in-progress badge",
+    )
+    stop_activity_timer(page)
+    wait_until(
+        lambda: not any(
+            normalize_doc(doc).get("id") == RUNNING_ACTIVITY_CONFIG_ID
+            for doc in read_docs(page, rooms["activities"])
+        ),
+        "linked running activity config cleared after stop",
+    )
+    linked_timer_activity_doc = wait_for_activity_doc(
+        page,
+        rooms["activities"],
+        "Playwright linked timer task",
+    )
+    if linked_timer_activity_doc.get("source") != "auto":
+        raise ValueError(
+            "stopped unscheduled timer had wrong source.\n"
+            f"{json.dumps(linked_timer_activity_doc, indent=2)}"
+        )
+    if linked_timer_activity_doc.get("sourceTaskId") != linked_timer_task_doc["id"]:
+        raise ValueError(
+            "stopped unscheduled timer did not keep the source task id.\n"
+            f"{json.dumps(linked_timer_activity_doc, indent=2)}"
+        )
+    if linked_timer_activity_doc.get("category") != "work/project":
+        raise ValueError(
+            "stopped unscheduled timer did not inherit the task category.\n"
+            f"{json.dumps(linked_timer_activity_doc, indent=2)}"
+        )
+    demo_note("activities: unscheduled task start-timer bridge verified")
+    assert_no_page_errors_yet("unscheduled start timer bridge")
 
     add_unscheduled_task(page, "Playwright delete confirm task", 15)
     delete_confirm_task_doc = wait_for_task_doc(

--- a/test_playwright_preview_smoke.py
+++ b/test_playwright_preview_smoke.py
@@ -38,6 +38,7 @@ from scripts.playwright_preview_smoke import (
     queue_activity_smoke_failure,
     request_manual_sync,
     start_activity_timer,
+    start_timer_from_unscheduled_task,
     stop_activity_timer,
     supports_activity_smoke_failure_host,
     summarize_docs,
@@ -670,6 +671,39 @@ class PreviewWaitHelperTests(unittest.TestCase):
         self.assertEqual(duration_minutes.value, "30")
         self.assertEqual(submit_button.clicks, 1)
 
+    def test_add_unscheduled_task_can_set_category(self):
+        from scripts.playwright_preview_smoke import add_unscheduled_task
+
+        unscheduled_radio = FakeLocator()
+        description = FakeLocator()
+        priority = FakeLocator()
+        duration_hours = FakeLocator()
+        duration_minutes = FakeLocator()
+        category = FakeLocator()
+        submit_button = FakeLocator()
+        page = FakePage(
+            {
+                "#unscheduled": unscheduled_radio,
+                task_form_input_selector("description"): description,
+                'input[name="priority"][value="medium"]': priority,
+                task_form_input_selector("est-duration-hours"): duration_hours,
+                task_form_input_selector("est-duration-minutes"): duration_minutes,
+                "#category-select": category,
+                "#task-form button[type='submit']": submit_button,
+            }
+        )
+        unscheduled_radio.check = lambda: setattr(unscheduled_radio, "value", "checked")
+        priority.check = lambda force=False: setattr(priority, "value", "checked")
+
+        add_unscheduled_task(page, "Linked timer task", 45, category="work/project")
+
+        self.assertEqual(unscheduled_radio.value, "checked")
+        self.assertEqual(description.value, "Linked timer task")
+        self.assertEqual(duration_hours.value, "0")
+        self.assertEqual(duration_minutes.value, "45")
+        self.assertEqual(category.value, "work/project")
+        self.assertEqual(submit_button.clicks, 1)
+
     def test_add_active_scheduled_task_uses_current_browser_time(self):
         scheduled_radio = FakeLocator()
         description = FakeLocator()
@@ -753,12 +787,14 @@ class PreviewWaitHelperTests(unittest.TestCase):
         self.assertEqual(description.value, "Focus timer")
         self.assertEqual(start_timer_button.clicks, 1)
 
-    def test_start_activity_timer_uses_timer_display_when_timer_is_running(self):
+    def test_start_activity_timer_uses_next_activity_draft_when_timer_is_running(self):
         activity_radio = FakeLocator()
         add_task_button = FakeLocator(text_values=["Add Task"])
         start_timer_button = FakeLocator()
         timer_display = FakeLocator(visible=True)
         timer_description = FakeLocator()
+        next_description = FakeLocator()
+        next_category = FakeLocator()
         page = FakePage(
             {
                 "#activity": activity_radio,
@@ -766,6 +802,8 @@ class PreviewWaitHelperTests(unittest.TestCase):
                 "#start-timer-btn": start_timer_button,
                 "#timer-display": timer_display,
                 "#timer-description": timer_description,
+                "#next-activity-description": next_description,
+                "#next-activity-category": next_category,
             }
         )
         page.evaluate = (
@@ -773,11 +811,45 @@ class PreviewWaitHelperTests(unittest.TestCase):
             if "activity.checked = true" in script
             else page.evaluations.append((script, payload))
         )
+        original_click = start_timer_button.click
 
-        start_activity_timer(page, "Replacement timer")
+        def click_and_replace_timer():
+            original_click()
+            timer_description.value = next_description.value
 
-        self.assertEqual(timer_description.value, "Replacement timer")
+        start_timer_button.click = click_and_replace_timer
+
+        start_activity_timer(page, "Replacement timer", category="work/project")
+
+        self.assertEqual(next_description.value, "Replacement timer")
+        self.assertEqual(next_category.value, "work/project")
         self.assertEqual(start_timer_button.clicks, 1)
+
+    def test_start_timer_from_unscheduled_task_clicks_task_timer_action_and_waits_for_ui(self):
+        task_id = "unsched-123"
+        start_button = FakeLocator()
+        timer_display = FakeLocator(visible=True)
+        timer_description = FakeLocator()
+        page = FakePage(
+            {
+                f'.task-card[data-task-id="{task_id}"] .btn-start-unscheduled-timer': start_button,
+                "#timer-display": timer_display,
+                "#timer-description": timer_description,
+            }
+        )
+        timer_display.visible = False
+        original_click = start_button.click
+
+        def click_and_show_linked_timer():
+            original_click()
+            timer_display.visible = True
+            timer_description.value = "Linked task"
+
+        start_button.click = click_and_show_linked_timer
+
+        start_timer_from_unscheduled_task(page, task_id, "Linked task")
+
+        self.assertEqual(start_button.clicks, 1)
 
     def test_stop_activity_timer_clicks_stop_button_and_waits_for_form(self):
         timer_display = FakeLocator(visible=True)


### PR DESCRIPTION
## Summary
- Add shared category select rendering, validation, and color-dot syncing helpers.
- Add category editing and clearing to scheduled and unscheduled task edit flows.
- Reuse shared category helpers in activity edit rendering/validation and update Phase 4.7 planning docs.

## Test Plan
- npm run check
- npm test -- --runInBand
- pre-commit hook: npm run check + jest --coverage