### PR TITLE
Polish activity sync and taxonomy settings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,3 +53,4 @@ Historical and planned repo tasks for Fortudo.
   - convert all remaining incomplete scheduled tasks from prior days into unscheduled tasks, copying `duration` into `estDuration` and defaulting `priority` to `medium`
   - show a summary toast after rollover so the user can see what changed
 - [ ] (vNext) add checkbox to "make a habit" so we can have a second list that gets injected daily
+- [ ] (vNext) support pomodoro alarms on running timers (?)

--- a/__tests__/app-lifecycle.test.js
+++ b/__tests__/app-lifecycle.test.js
@@ -44,7 +44,7 @@ describe('app room/session lifecycle', () => {
         };
     }
 
-    test('dedupes overlapping storage refreshes and re-syncs restored timer state', async () => {
+    test('dedupes overlapping storage refreshes without restoring the activity form', async () => {
         let resolveLoadAppState;
         const pendingLoadAppState = new Promise((resolve) => {
             resolveLoadAppState = resolve;
@@ -63,9 +63,33 @@ describe('app room/session lifecycle', () => {
         await secondRefresh;
 
         expect(deps.refreshUI).toHaveBeenCalledTimes(1);
-        expect(deps.syncRestoredRunningTimer).toHaveBeenCalledWith(true);
+        expect(deps.syncRestoredRunningTimer).not.toHaveBeenCalled();
         expect(deps.refreshActiveTaskColor).toHaveBeenCalledWith([]);
         expect(deps.refreshCurrentGapHighlight).toHaveBeenCalledTimes(1);
+    });
+
+    test('restores running timer form state on the first synced event only', async () => {
+        let syncStatusCallback;
+        const { deps, lifecycle } = createLifecycle({
+            onSyncStatusChange: jest.fn((callback) => {
+                syncStatusCallback = callback;
+                return jest.fn();
+            })
+        });
+
+        const abortController = new AbortController();
+        lifecycle.start({ signal: abortController.signal });
+
+        syncStatusCallback('synced');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        syncStatusCallback('synced');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.syncRestoredRunningTimer).toHaveBeenCalledTimes(1);
+        expect(deps.syncRestoredRunningTimer).toHaveBeenCalledWith(true);
     });
 
     test('stops a stale restored timer at the midnight after it started', async () => {
@@ -159,7 +183,7 @@ describe('app room/session lifecycle', () => {
         expect(deps.stopTimerAt).toHaveBeenCalledWith(expectedBoundary.toISOString());
         expect(deps.loadAppState).toHaveBeenCalledTimes(1);
         expect(deps.refreshUI).toHaveBeenCalledTimes(1);
-        expect(deps.syncRestoredRunningTimer).toHaveBeenCalledWith(true);
+        expect(deps.syncRestoredRunningTimer).not.toHaveBeenCalled();
         expect(deps.syncTimerFormState).not.toHaveBeenCalled();
         expect(deps.refreshTaskDisplays).not.toHaveBeenCalled();
         expect(deps.refreshStartTimeField).toHaveBeenCalledTimes(1);

--- a/__tests__/category-colors.test.js
+++ b/__tests__/category-colors.test.js
@@ -11,11 +11,15 @@ import {
 } from '../public/js/category-colors.js';
 
 describe('category-colors', () => {
-    test('exposes gray as a supported family', () => {
+    test('exposes gray and violet as supported families', () => {
         expect(COLOR_FAMILIES.gray).toEqual(
             expect.arrayContaining([expect.stringMatching(/^#/), expect.stringMatching(/^#/)])
         );
+        expect(COLOR_FAMILIES.violet).toEqual(
+            expect.arrayContaining([expect.stringMatching(/^#/), expect.stringMatching(/^#/)])
+        );
         expect(normalizeFamilyName('gray')).toBe('gray');
+        expect(normalizeFamilyName('violet')).toBe('violet');
     });
 
     test('normalizeFamilyName accepts known families and falls back to blue', () => {
@@ -29,7 +33,7 @@ describe('category-colors', () => {
     });
 
     test('COLOR_FAMILIES family arrays are frozen', () => {
-        for (const familyName of ['blue', 'green', 'amber', 'rose', 'gray']) {
+        for (const familyName of ['blue', 'green', 'amber', 'rose', 'gray', 'violet']) {
             expect(Object.isFrozen(COLOR_FAMILIES[familyName])).toBe(true);
         }
     });

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -1387,6 +1387,51 @@ describe('DOM Handler Interaction Tests', () => {
             expect(() => refreshUI()).not.toThrow();
         });
 
+        test('renders only today scheduled tasks from state', () => {
+            const scheduledCallbacks = { onCompleteTask: jest.fn() };
+            const unscheduledCallbacks = { onScheduleUnscheduledTask: jest.fn() };
+            const today = extractDateFromDateTime(new Date());
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            const yesterdayDate = extractDateFromDateTime(yesterday);
+
+            renderTasks([], scheduledCallbacks);
+            renderUnscheduledTasks([], unscheduledCallbacks);
+
+            updateTaskState([
+                {
+                    id: 'stale-scheduled',
+                    type: 'scheduled',
+                    description: 'Stale scheduled',
+                    startDateTime: timeToDateTime('10:00', yesterdayDate),
+                    endDateTime: calculateEndDateTime(timeToDateTime('10:00', yesterdayDate), 30),
+                    duration: 30,
+                    status: 'completed',
+                    editing: false,
+                    confirmingDelete: false,
+                    locked: false
+                },
+                {
+                    id: 'today-scheduled',
+                    type: 'scheduled',
+                    description: 'Today scheduled',
+                    startDateTime: timeToDateTime('11:00', today),
+                    endDateTime: calculateEndDateTime(timeToDateTime('11:00', today), 30),
+                    duration: 30,
+                    status: 'incomplete',
+                    editing: false,
+                    confirmingDelete: false,
+                    locked: false
+                }
+            ]);
+
+            refreshUI();
+
+            const scheduledList = document.getElementById('scheduled-task-list');
+            expect(scheduledList.textContent).toContain('Today scheduled');
+            expect(scheduledList.textContent).not.toContain('Stale scheduled');
+        });
+
         test('uses the latest activity end time when refreshing in activity mode', () => {
             jest.useFakeTimers();
             jest.setSystemTime(new Date('2026-04-07T12:00:00.000Z'));

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -20,7 +20,7 @@ import { resetEventDelegation } from '../public/js/dom-renderer.js';
 import { refreshActiveTaskColor } from '../public/js/tasks/scheduled-renderer.js';
 import * as appCoordinator from '../public/js/app-coordinator.js';
 
-import { extractTimeFromDateTime } from '../public/js/utils.js';
+import { extractDateFromDateTime, extractTimeFromDateTime } from '../public/js/utils.js';
 import { COLOR_FAMILIES } from '../public/js/category-colors.js';
 
 // Mock storage.js to spy on saveTasks
@@ -962,7 +962,7 @@ describe('User Confirmation Flows', () => {
         };
 
         test('Active task color changes from green to yellow when it becomes late', async () => {
-            const date = '2023-01-01';
+            const date = extractDateFromDateTime(new Date());
             const activeTask = createTaskWithDateTime({
                 description: 'Active Task',
                 startTime: '13:30',
@@ -985,12 +985,9 @@ describe('User Confirmation Flows', () => {
 
             await setupInitialStateAndApp([completedTask, activeTask]);
 
-            // Get the active task element (should be the first incomplete task)
-            // The active task should be at index 1 (after the completed task)
-            // Use data-task-index attribute to find the task element since IDs are now generated UUIDs
-            const activeTaskElement = document.querySelector(
-                '#scheduled-task-list [data-task-index="1"]'
-            );
+            const activeTaskElement = Array.from(
+                document.querySelectorAll('#scheduled-task-list [data-task-id]')
+            ).find((element) => element.textContent.includes('Active Task'));
             expect(activeTaskElement).toBeTruthy();
             if (!activeTaskElement) return; // Type guard
 

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -258,6 +258,28 @@ describe('Scheduled Task Renderer Tests', () => {
             });
         });
 
+        test('current gap label counts down from now', () => {
+            const tasks = [createTask('1', '10:00', 60), createTask('2', '11:30', 60)];
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            refreshCurrentGapHighlight(new Date('2025-01-15T11:10:00.000'));
+
+            const gapEl = document.querySelector('.schedule-gap');
+            expect(gapEl.textContent).toContain('20m free');
+            expect(gapEl.getAttribute('title')).toContain('20m available until next task');
+        });
+
+        test('gap label returns to total duration when it is no longer current', () => {
+            const tasks = [createTask('1', '10:00', 60), createTask('2', '11:30', 60)];
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            refreshCurrentGapHighlight(new Date('2025-01-15T11:10:00.000'));
+            refreshCurrentGapHighlight(new Date('2025-01-15T12:00:00.000'));
+
+            const gapEl = document.querySelector('.schedule-gap');
+            expect(gapEl.textContent).toContain('30m free');
+        });
+
         test('gap NOT matching current time keeps default slate classes', () => {
             const tasks = [createTask('1', '10:00', 60), createTask('2', '11:30', 60)];
             renderTasks(tasks, mockCallbacks, mockInitListeners, null);
@@ -303,6 +325,8 @@ describe('Scheduled Task Renderer Tests', () => {
                 '.schedule-boundary[data-boundary="after"]'
             );
             expect(afterBoundary.classList.contains('hidden')).toBe(true);
+            expect(beforeBoundary.textContent).toContain('now');
+            expect(beforeBoundary.textContent).toContain('next in 2h');
         });
 
         test('"after" boundary shown when now >= last task end', () => {
@@ -317,6 +341,8 @@ describe('Scheduled Task Renderer Tests', () => {
                 '.schedule-boundary[data-boundary="after"]'
             );
             expect(afterBoundary.classList.contains('hidden')).toBe(false);
+            expect(afterBoundary.textContent).toContain('now');
+            expect(afterBoundary.textContent).toContain('all done');
 
             const beforeBoundary = document.querySelector(
                 '.schedule-boundary[data-boundary="before"]'

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -265,7 +265,7 @@ describe('Scheduled Task Renderer Tests', () => {
             refreshCurrentGapHighlight(new Date('2025-01-15T11:10:00.000'));
 
             const gapEl = document.querySelector('.schedule-gap');
-            expect(gapEl.textContent).toContain('20m free');
+            expect(gapEl.textContent).toContain('20m until next');
             expect(gapEl.getAttribute('title')).toContain('20m available until next task');
         });
 

--- a/__tests__/settings-renderer.test.js
+++ b/__tests__/settings-renderer.test.js
@@ -34,7 +34,8 @@ import {
     closeSettingsModal,
     renderSettingsContent,
     getSettingsModalElement,
-    initializeSettingsModalListeners
+    initializeSettingsModalListeners,
+    openSettingsAfterActivitiesReloadIfNeeded
 } from '../public/js/settings-renderer.js';
 import {
     renderTaxonomyManagementContent,
@@ -132,6 +133,7 @@ beforeEach(() => {
     setupSettingsDOM();
     resetTaxonomySettingsViewState();
     localStorage.clear();
+    sessionStorage.clear();
     jest.clearAllMocks();
 });
 
@@ -300,6 +302,62 @@ describe('settings-renderer', () => {
             expect(message.textContent).toContain('Activities disabled');
         });
 
+        test('reload after enabling Activities records a one-time return to settings', async () => {
+            const reloadWindow = jest.fn();
+            await renderDisabledSettings({ reloadWindow });
+
+            const toggle = document.getElementById('activities-toggle');
+            toggle.checked = true;
+            toggle.dispatchEvent(new Event('change'));
+            await waitForCondition(() => {
+                const reloadPrompt = document.getElementById('reload-prompt');
+                return reloadPrompt && !reloadPrompt.classList.contains('hidden');
+            });
+
+            document.getElementById('reload-apply-btn').click();
+
+            expect(sessionStorage.getItem('fortudo-open-settings-after-activities-reload')).toBe(
+                'true'
+            );
+            expect(reloadWindow).toHaveBeenCalledTimes(1);
+        });
+
+        test('does not record settings return when reloading after disabling Activities', async () => {
+            const reloadWindow = jest.fn();
+            await renderEnabledSettings({ reloadWindow });
+
+            const toggle = document.getElementById('activities-toggle');
+            toggle.checked = false;
+            toggle.dispatchEvent(new Event('change'));
+            await waitForCondition(() => {
+                const reloadPrompt = document.getElementById('reload-prompt');
+                return reloadPrompt && !reloadPrompt.classList.contains('hidden');
+            });
+
+            document.getElementById('reload-apply-btn').click();
+
+            expect(sessionStorage.getItem('fortudo-open-settings-after-activities-reload')).toBe(
+                null
+            );
+            expect(reloadWindow).toHaveBeenCalledTimes(1);
+        });
+
+        test('opens settings once after an Activities enable reload settles', async () => {
+            const waitForIdleSync = jest.fn(() => Promise.resolve());
+            const renderContent = jest.fn(() => renderSettingsContent());
+            sessionStorage.setItem('fortudo-open-settings-after-activities-reload', 'true');
+            await renderEnabledSettings();
+
+            await openSettingsAfterActivitiesReloadIfNeeded({ waitForIdleSync, renderContent });
+
+            expect(waitForIdleSync).toHaveBeenCalledTimes(1);
+            expect(renderContent).toHaveBeenCalledTimes(1);
+            expect(getSettingsModalElement().classList.contains('hidden')).toBe(false);
+            expect(sessionStorage.getItem('fortudo-open-settings-after-activities-reload')).toBe(
+                null
+            );
+        });
+
         test('toggle failure restores previous state and shows toast', async () => {
             await renderDisabledSettings();
 
@@ -380,6 +438,33 @@ describe('settings-renderer', () => {
 
             expect(getGroupByKey('work').colorFamily).toBe('amber');
             expect(getCategoryByKey('work/meetings').color).toBe(COLOR_FAMILIES.amber[1]);
+        });
+
+        test('group color family options use common color names', async () => {
+            await renderEnabledSettings();
+            await clickAndWait(document.getElementById('add-group-btn'));
+
+            const options = Array.from(document.querySelector('[name="group-family"]').options).map(
+                (option) => option.textContent
+            );
+
+            expect(options).toEqual(
+                expect.arrayContaining(['Blue', 'Green', 'Orange', 'Red', 'Gray', 'Purple'])
+            );
+            expect(options).not.toContain('Amber');
+            expect(options).not.toContain('Rose');
+            expect(options).not.toContain('Violet');
+        });
+
+        test('taxonomy group and category rows keep names left aligned', async () => {
+            await renderEnabledSettings();
+
+            expect(document.querySelector('[data-group-key="work"]').className).toContain(
+                'text-left'
+            );
+            expect(document.querySelector('[data-category-key="work/deep"]').className).toContain(
+                'text-left'
+            );
         });
 
         test('saving a group edit preserves an open category add draft', async () => {

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -16,6 +16,7 @@ import {
     editTask,
     cancelEdit,
     deleteAllTasks,
+    deleteAllScheduledTasks,
     performReschedule,
     confirmAddTaskAndReschedule,
     confirmScheduleUnscheduledTask,
@@ -26,6 +27,7 @@ import {
     getSuggestedStartTime,
     getTaskById,
     getTaskIndex,
+    getTodaysScheduledTasks,
     setTaskInlineEditing,
     resetAllInlineEditingFlags,
     consumeUnscheduledTask
@@ -1678,6 +1680,28 @@ describe('Task Management Functions (task-manager.js)', () => {
             expect(result).toBe('14:35'); // getCurrentTimeRounded() returns 14:35
         });
 
+        test('ignores scheduled tasks from prior days', () => {
+            const today = extractDateFromDateTime(new Date());
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            const staleTask = createTaskWithDateTime({
+                description: 'Yesterday task',
+                startTime: '16:00',
+                duration: 60,
+                date: extractDateFromDateTime(yesterday)
+            });
+            const todaysTask = createTaskWithDateTime({
+                description: 'Today task',
+                startTime: '15:00',
+                duration: 60,
+                date: today
+            });
+
+            updateTaskState([staleTask, todaysTask]);
+
+            expect(getSuggestedStartTime()).toBe('16:00');
+        });
+
         test('should return current time rounded up when no incomplete tasks exist (only completed)', () => {
             const completedTask = createTaskWithDateTime({
                 description: 'Completed Task',
@@ -1970,6 +1994,34 @@ describe('Task Management Functions (task-manager.js)', () => {
             updateTaskState([futureTask1, futureTask2]);
             const result = getSuggestedStartTime();
             expect(result).toBe('18:00'); // No tasks before current time (14:35), so continue planning from latest
+        });
+    });
+
+    describe('getTodaysScheduledTasks', () => {
+        test('returns only scheduled tasks that start on the current local day', () => {
+            const now = new Date('2026-06-22T13:00:00.000');
+            const staleTask = createTaskWithDateTime({
+                description: 'Yesterday scheduled',
+                startTime: '10:00',
+                duration: 30,
+                date: '2026-06-21'
+            });
+            const todayTask = createTaskWithDateTime({
+                description: 'Today scheduled',
+                startTime: '11:00',
+                duration: 30,
+                date: '2026-06-22'
+            });
+            const unscheduledTask = {
+                id: 'unscheduled-1',
+                type: 'unscheduled',
+                description: 'Backlog',
+                status: 'incomplete'
+            };
+
+            updateTaskState([staleTask, todayTask, unscheduledTask]);
+
+            expect(getTodaysScheduledTasks(now)).toEqual([todayTask]);
         });
     });
 
@@ -2295,10 +2347,7 @@ describe('Task Management Functions (task-manager.js)', () => {
     });
 
     describe('Delete Functions Edge Cases', () => {
-        const {
-            deleteAllScheduledTasks,
-            deleteCompletedTasks
-        } = require('../public/js/tasks/manager.js');
+        const { deleteCompletedTasks } = require('../public/js/tasks/manager.js');
 
         test('deleteAllScheduledTasks removes only scheduled tasks', () => {
             const scheduledTask = createTaskWithDateTime({
@@ -2326,6 +2375,30 @@ describe('Task Management Functions (task-manager.js)', () => {
             const tasks = getTaskState();
             expect(tasks).toHaveLength(1);
             expect(tasks[0].type).toBe('unscheduled');
+        });
+
+        test('deleteAllScheduledTasks removes only today scheduled tasks', () => {
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            const staleScheduledTask = createTaskWithDateTime({
+                description: 'Yesterday scheduled',
+                startTime: '09:00',
+                duration: 30,
+                date: extractDateFromDateTime(yesterday)
+            });
+            const todayScheduledTask = createTaskWithDateTime({
+                description: 'Today scheduled',
+                startTime: '10:00',
+                duration: 30
+            });
+
+            updateTaskState([staleScheduledTask, todayScheduledTask]);
+
+            const result = deleteAllScheduledTasks();
+
+            expect(result.success).toBe(true);
+            expect(result.tasksDeleted).toBe(1);
+            expect(getTaskState()).toEqual([staleScheduledTask]);
         });
 
         test('deleteCompletedTasks removes completed tasks from both types', () => {

--- a/public/js/app-lifecycle.js
+++ b/public/js/app-lifecycle.js
@@ -21,6 +21,7 @@ export function createRoomSessionLifecycle({
     let activeTaskColorInterval = null;
     let midnightTimerStopInFlight = false;
     let lastObservedDate = extractDateFromDateTime(new Date());
+    let shouldRestoreRunningTimerAfterInitialSync = true;
 
     function getNextLocalMidnight(dateTime) {
         const boundary = new Date(dateTime);
@@ -74,7 +75,7 @@ export function createRoomSessionLifecycle({
         }
     }
 
-    async function refreshFromStorage() {
+    async function refreshFromStorage({ restoreRunningTimer = false } = {}) {
         if (refreshFromStoragePromise) {
             return refreshFromStoragePromise;
         }
@@ -83,7 +84,9 @@ export function createRoomSessionLifecycle({
             await loadAppState();
             await stopStaleRunningTimerIfNeeded();
             refreshUI();
-            syncRestoredRunningTimer(getActivitiesEnabled());
+            if (restoreRunningTimer) {
+                syncRestoredRunningTimer(getActivitiesEnabled());
+            }
             refreshActiveTaskColor(getTaskState());
             refreshCurrentGapHighlight();
         })();
@@ -150,7 +153,9 @@ export function createRoomSessionLifecycle({
         unsubscribeSyncStatus = onSyncStatusChange((status) => {
             updateSyncStatusUI(status);
             if (status === 'synced') {
-                refreshFromStorage().catch((err) => {
+                const restoreRunningTimer = shouldRestoreRunningTimerAfterInitialSync;
+                shouldRestoreRunningTimerAfterInitialSync = false;
+                refreshFromStorage({ restoreRunningTimer }).catch((err) => {
                     logger.error('Failed to refresh tasks after sync:', err);
                 });
             }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,7 +3,8 @@ import {
     updateTaskState,
     getTaskState,
     resetAllConfirmingDeleteFlags,
-    getSortedUnscheduledTasks
+    getSortedUnscheduledTasks,
+    getTodaysScheduledTasks
 } from './tasks/manager.js';
 import { initializeModalEventListeners } from './modal-manager.js';
 import {
@@ -149,14 +150,11 @@ async function initAndBootApp(roomCode) {
     const scheduledTaskEventCallbacks = createScheduledTaskCallbacks();
     const unscheduledTaskEventCallbacks = createUnscheduledTaskCallbacks();
     refreshTaskDisplays = () => {
-        const allTasks = getTaskState();
-        renderTasks(
-            allTasks.filter((task) => task.type === 'scheduled'),
-            scheduledTaskEventCallbacks
-        );
+        const todaysScheduledTasks = getTodaysScheduledTasks();
+        renderTasks(todaysScheduledTasks, scheduledTaskEventCallbacks);
         renderUnscheduledTasks(getSortedUnscheduledTasks(), unscheduledTaskEventCallbacks);
         renderTodayActivities(isActivitiesEnabled());
-        refreshActiveTaskColor(allTasks);
+        refreshActiveTaskColor(todaysScheduledTasks);
         refreshCurrentGapHighlight();
         renderActiveInsightsView();
     };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -53,7 +53,11 @@ import { createRoomSessionLifecycle } from './app-lifecycle.js';
 import { prepareStorage, loadTasks } from './storage.js';
 import { loadTaxonomy } from './taxonomy/taxonomy-store.js';
 import { isActivitiesEnabled, loadSettings } from './settings-manager.js';
-import { initializeSettingsModalListeners, renderSettingsContent } from './settings-renderer.js';
+import {
+    initializeSettingsModalListeners,
+    openSettingsAfterActivitiesReloadIfNeeded,
+    renderSettingsContent
+} from './settings-renderer.js';
 import { refreshTaskCategoryDropdownUI } from './settings/taxonomy-settings.js';
 import { logger } from './utils.js';
 import { createScheduledTaskCallbacks } from './tasks/scheduled-handlers.js';
@@ -62,7 +66,7 @@ import { handleAddTaskProcess } from './tasks/add-handler.js';
 import { initializeClearTasksHandlers } from './tasks/clear-handler.js';
 import { showRoomEntryScreen, showMainApp, updateSyncStatusUI } from './room-renderer.js';
 import { getActiveRoom } from './room-manager.js';
-import { onSyncStatusChange, triggerSync } from './sync-manager.js';
+import { onSyncStatusChange, triggerSync, waitForIdleSync } from './sync-manager.js';
 import { COUCHDB_URL } from './config.js';
 
 /** @type {AbortController|null} */
@@ -302,6 +306,16 @@ async function initAndBootApp(roomCode) {
     updateStartTimeField(suggested, true);
 
     focusTaskDescriptionInput();
+
+    await openSettingsAfterActivitiesReloadIfNeeded({
+        waitForIdleSync,
+        renderContent: () =>
+            renderSettingsContent({
+                onTaxonomyChanged: () => {
+                    refreshTaxonomyUI();
+                }
+            })
+    });
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/public/js/category-colors.js
+++ b/public/js/category-colors.js
@@ -3,6 +3,7 @@ const COLOR_FAMILIES_RAW = {
     green: ['#15803d', '#16a34a', '#22c55e', '#4ade80'],
     amber: ['#b45309', '#d97706', '#f59e0b', '#fbbf24'],
     rose: ['#be123c', '#e11d48', '#f43f5e', '#fb7185'],
+    violet: ['#6d28d9', '#7c3aed', '#8b5cf6', '#a78bfa'],
     gray: ['#374151', '#4b5563', '#6b7280', '#9ca3af']
 };
 

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -1,6 +1,10 @@
 import { logger, getCurrentTimeRounded } from './utils.js';
-import { getTaskState, getSortedUnscheduledTasks, getSuggestedStartTime } from './tasks/manager.js';
-import { isScheduledTask } from './tasks/validators.js';
+import {
+    getTaskState,
+    getSortedUnscheduledTasks,
+    getSuggestedStartTime,
+    getTodaysScheduledTasks
+} from './tasks/manager.js';
 import { isActivitiesEnabled } from './settings-manager.js';
 import { renderTodayActivities } from './activities/ui-handlers.js';
 import { getSuggestedActivityStartTime } from './activities/manager.js';
@@ -15,7 +19,8 @@ import {
 // Import from new modules
 import {
     renderTasks as renderScheduledTasks,
-    getScheduledTaskListElement
+    getScheduledTaskListElement,
+    refreshActiveTaskColor
 } from './tasks/scheduled-renderer.js';
 
 import {
@@ -330,9 +335,14 @@ function handleScheduledTaskListClick(event) {
 
     if (target.closest('.checkbox')) {
         event.preventDefault();
-        // Get all tasks and find the first uncompleted one (active task)
-        const allTasks = getTaskState().filter((t) => t.type === 'scheduled');
-        const activeTask = allTasks.find((t) => t.status !== 'completed');
+        const visibleTaskIds = new Set(
+            Array.from(getScheduledTaskListElement()?.querySelectorAll('[data-task-id]') || []).map(
+                (element) => element.dataset.taskId
+            )
+        );
+        const activeTask = getTaskState().find(
+            (t) => t.type === 'scheduled' && visibleTaskIds.has(t.id) && t.status !== 'completed'
+        );
 
         // Only allow completion if this is the active task
         if (activeTask && activeTask.id === taskId && globalScheduledTaskCallbacks.onCompleteTask) {
@@ -437,7 +447,7 @@ function handleScheduledTaskListInput(event) {
     const saveBtn = editForm.querySelector('.btn-save-edit');
     if (warningEl && saveBtn) {
         const excludeTaskId = editForm.dataset.taskId;
-        const scheduledTasks = getTaskState().filter((t) => t.type === 'scheduled');
+        const scheduledTasks = getTodaysScheduledTasks();
         const overlapResult = computeOverlapPreview(
             startInput.value,
             hoursInput.value,
@@ -603,13 +613,14 @@ export function renderUnscheduledTasks(unscheduledTasks, eventCallbacks) {
  * Convenience function that replaces repeated 3-line render boilerplate.
  */
 export function refreshUI() {
-    const tasks = getTaskState();
-    renderTasks(tasks.filter(isScheduledTask));
+    const todaysScheduledTasks = getTodaysScheduledTasks();
+    renderTasks(todaysScheduledTasks);
     renderUnscheduledTasks(getSortedUnscheduledTasks());
     if (isActivitiesEnabled()) {
         renderTodayActivities(true);
         renderActiveInsightsView();
     }
+    refreshActiveTaskColor(todaysScheduledTasks);
     updateStartTimeField(getSuggestedFormStartTime(), true);
 }
 

--- a/public/js/settings-renderer.js
+++ b/public/js/settings-renderer.js
@@ -6,6 +6,8 @@ import {
 } from './settings/taxonomy-settings.js';
 import { showToast } from './toast-manager.js';
 
+const OPEN_SETTINGS_AFTER_ACTIVITIES_RELOAD_KEY = 'fortudo-open-settings-after-activities-reload';
+
 /**
  * Get the settings modal element.
  * @returns {HTMLElement|null}
@@ -77,7 +79,26 @@ export function renderSettingsContent(options = {}) {
     wireSettingsEvents(options);
 }
 
+export async function openSettingsAfterActivitiesReloadIfNeeded({
+    waitForIdleSync = async () => {},
+    renderContent = () => renderSettingsContent()
+} = {}) {
+    if (sessionStorage.getItem(OPEN_SETTINGS_AFTER_ACTIVITIES_RELOAD_KEY) !== 'true') {
+        return;
+    }
+
+    sessionStorage.removeItem(OPEN_SETTINGS_AFTER_ACTIVITIES_RELOAD_KEY);
+    if (!isActivitiesEnabled()) {
+        return;
+    }
+
+    await waitForIdleSync();
+    renderContent();
+    openSettingsModal();
+}
+
 function wireSettingsEvents(options) {
+    let pendingActivitiesEnabledValue = isActivitiesEnabled();
     const toggle = document.getElementById('activities-toggle');
     if (toggle) {
         toggle.onchange = async () => {
@@ -92,6 +113,7 @@ function wireSettingsEvents(options) {
                 return;
             }
 
+            pendingActivitiesEnabledValue = newValue;
             const reloadPrompt = document.getElementById('reload-prompt');
             const message = document.getElementById('reload-prompt-message');
             const taxonomySection = document.getElementById('taxonomy-management-section');
@@ -113,7 +135,12 @@ function wireSettingsEvents(options) {
     const reloadButton = document.getElementById('reload-apply-btn');
     if (reloadButton) {
         reloadButton.onclick = () => {
-            window.location.reload();
+            if (pendingActivitiesEnabledValue) {
+                sessionStorage.setItem(OPEN_SETTINGS_AFTER_ACTIVITIES_RELOAD_KEY, 'true');
+            } else {
+                sessionStorage.removeItem(OPEN_SETTINGS_AFTER_ACTIVITIES_RELOAD_KEY);
+            }
+            (options.reloadWindow || (() => window.location.reload()))();
         };
     }
 

--- a/public/js/settings/taxonomy-settings.js
+++ b/public/js/settings/taxonomy-settings.js
@@ -109,7 +109,7 @@ function renderGroupsList() {
             }
 
             return `
-                <div data-group-key="${escapeHtml(group.key)}" class="flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-slate-700 bg-slate-800/40">
+                <div data-group-key="${escapeHtml(group.key)}" class="flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-slate-700 bg-slate-800/40 text-left">
                     <div class="flex items-center gap-3 min-w-0">
                         <span class="w-3 h-3 rounded-full shrink-0" style="background-color: ${group.color}"></span>
                         <div class="min-w-0">
@@ -232,7 +232,7 @@ function renderCategoryRow(category, group) {
         : 'text-amber-300 border-amber-500/30 bg-amber-500/10';
 
     return `
-        <div data-category-key="${escapeHtml(category.key)}" class="flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-slate-700 bg-slate-800/40">
+        <div data-category-key="${escapeHtml(category.key)}" class="flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-slate-700 bg-slate-800/40 text-left">
             <div class="flex items-center gap-3 min-w-0">
                 <span class="category-dot w-3 h-3 rounded-full shrink-0" style="background-color: ${category.color}"></span>
                 <div class="min-w-0">
@@ -328,9 +328,18 @@ function renderColorFamilyOptions(selectedFamily) {
     return Object.keys(COLOR_FAMILIES)
         .map((familyName) => {
             const selected = familyName === selectedFamily ? 'selected' : '';
-            return `<option value="${familyName}" ${selected}>${titleCase(familyName)}</option>`;
+            return `<option value="${familyName}" ${selected}>${getColorFamilyLabel(familyName)}</option>`;
         })
         .join('');
+}
+
+function getColorFamilyLabel(familyName) {
+    const labels = {
+        amber: 'Orange',
+        rose: 'Red',
+        violet: 'Purple'
+    };
+    return labels[familyName] || titleCase(familyName);
 }
 
 function bindGroupEvents(options) {

--- a/public/js/tasks/clear-handler.js
+++ b/public/js/tasks/clear-handler.js
@@ -1,5 +1,6 @@
 import {
     getTaskState,
+    getTodaysScheduledTasks,
     deleteAllTasks,
     deleteAllScheduledTasks,
     deleteCompletedTasks
@@ -30,7 +31,7 @@ export function initializeClearTasksHandlers() {
     if (clearScheduleButton) {
         clearScheduleButton.addEventListener('click', async (event) => {
             event.stopPropagation();
-            const scheduledTasksExist = getTaskState().some((task) => task.type === 'scheduled');
+            const scheduledTasksExist = getTodaysScheduledTasks().length > 0;
             if (!scheduledTasksExist) {
                 showToast('There are no scheduled tasks to clear.', { theme: 'teal' });
                 return;

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -213,6 +213,19 @@ const getSortedScheduledTasks = () => {
     return sortedScheduledTasksCache;
 };
 
+function isTaskScheduledForLocalDate(task, dateString) {
+    if (task.type !== 'scheduled' || !task.startDateTime) {
+        return false;
+    }
+
+    return extractDateFromDateTime(new Date(task.startDateTime)) === dateString;
+}
+
+export function getTodaysScheduledTasks(now = new Date()) {
+    const today = extractDateFromDateTime(now instanceof Date ? now : new Date(now));
+    return getSortedScheduledTasks().filter((task) => isTaskScheduledForLocalDate(task, today));
+}
+
 const createTaskObject = (taskData) => {
     logger.debug('createTaskObject called with taskData:', taskData);
     const id = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`; // Generic ID prefix initially
@@ -362,8 +375,8 @@ export function getSuggestedStartTime() {
     let hasTasksBeforeCurrentTime = false;
     let incompleteTaskCount = 0;
 
-    // Consider only scheduled tasks
-    const scheduledTasks = tasks.filter((task) => task.type === 'scheduled');
+    // Consider only today's scheduled tasks for the main schedule form.
+    const scheduledTasks = getTodaysScheduledTasks();
 
     for (const task of scheduledTasks) {
         // Ensure task has startDateTime and endDateTime, skip if not (should not happen for scheduled tasks)
@@ -1210,15 +1223,16 @@ export function deleteAllTasks() {
 
 export function deleteAllScheduledTasks() {
     const currentTasks = getTaskState();
-    const unscheduledTasks = currentTasks.filter((task) => task.type === 'unscheduled');
-    const scheduledTasksCount = currentTasks.length - unscheduledTasks.length;
+    const today = extractDateFromDateTime(new Date());
+    const remainingTasks = currentTasks.filter((task) => !isTaskScheduledForLocalDate(task, today));
+    const scheduledTasksCount = currentTasks.length - remainingTasks.length;
 
     if (scheduledTasksCount === 0) {
         logger.info('deleteAllScheduledTasks: No scheduled tasks to delete.');
         return { success: true, message: 'No scheduled tasks to delete.', tasksDeleted: 0 };
     }
 
-    updateTaskState(unscheduledTasks);
+    updateTaskState(remainingTasks);
     logger.info(
         `deleteAllScheduledTasks: All ${scheduledTasksCount} scheduled tasks have been deleted.`
     );

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -218,7 +218,7 @@ function updateGapLabel(el, now, isCurrent) {
 
     const end = new Date(el.dataset.gapEnd);
     const remainingText = formatRemainingMinutes(now, end);
-    label.innerHTML = `<span class="gap-plus-icon">+ </span>${remainingText} free`;
+    label.innerHTML = `<span class="gap-plus-icon">+ </span>${remainingText} until next`;
     el.title = `${remainingText} available until next task`;
 }
 

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -178,7 +178,7 @@ export function renderGapHTML(gap) {
     const durationText = calculateHoursAndMinutes(gap.durationMinutes);
     return `<div class="schedule-gap flex items-center justify-center py-1 text-xs text-slate-500 cursor-pointer hover:text-teal-300 transition-colors group" role="button" tabindex="0" data-gap-start="${gap.startISO}" data-gap-end="${gap.endISO}" data-gap-duration="${gap.durationMinutes}" title="Click to schedule a task in this gap">
         <span class="border-t border-dashed border-slate-600 flex-1"></span>
-        <span class="px-2 whitespace-nowrap"><span class="gap-plus-icon">+ </span>${durationText} free</span>
+        <span class="schedule-gap-label px-2 whitespace-nowrap"><span class="gap-plus-icon">+ </span>${durationText} free</span>
         <span class="border-t border-dashed border-slate-600 flex-1"></span>
     </div>`;
 }
@@ -193,9 +193,46 @@ export function renderBoundaryMarkerHTML(boundaryTime, position) {
     return `<div class="schedule-boundary hidden flex items-center justify-center py-1 text-xs text-teal-400"
         aria-hidden="true" data-boundary="${position}" data-boundary-time="${boundaryTime}">
         <span class="border-t border-solid border-teal-400 flex-1"></span>
-        <span class="px-2 whitespace-nowrap">now</span>
+        <span class="schedule-boundary-label px-2 whitespace-nowrap">now</span>
         <span class="border-t border-solid border-teal-400 flex-1"></span>
     </div>`;
+}
+
+function formatRemainingMinutes(from, to) {
+    const minutes = Math.max(0, Math.ceil((to.getTime() - from.getTime()) / 60000));
+    return calculateHoursAndMinutes(minutes);
+}
+
+function updateGapLabel(el, now, isCurrent) {
+    const label = el.querySelector('.schedule-gap-label');
+    if (!label) {
+        return;
+    }
+
+    const totalText = calculateHoursAndMinutes(Number(el.dataset.gapDuration || 0));
+    if (!isCurrent) {
+        label.innerHTML = `<span class="gap-plus-icon">+ </span>${totalText} free`;
+        el.title = 'Click to schedule a task in this gap';
+        return;
+    }
+
+    const end = new Date(el.dataset.gapEnd);
+    const remainingText = formatRemainingMinutes(now, end);
+    label.innerHTML = `<span class="gap-plus-icon">+ </span>${remainingText} free`;
+    el.title = `${remainingText} available until next task`;
+}
+
+function updateBoundaryLabel(el, now, isCurrent) {
+    const label = el.querySelector('.schedule-boundary-label');
+    if (!label || !isCurrent) {
+        return;
+    }
+
+    const boundaryTime = new Date(el.dataset.boundaryTime);
+    label.textContent =
+        el.dataset.boundary === 'before'
+            ? `now - next in ${formatRemainingMinutes(now, boundaryTime)}`
+            : 'now - all done';
 }
 
 function ensureScheduleBoundaryElement(taskListElement, position) {
@@ -461,6 +498,7 @@ export function refreshCurrentGapHighlight(now = new Date()) {
         const isCurrent = now >= start && now < end;
 
         const borderSpans = el.querySelectorAll('.border-t');
+        updateGapLabel(el, now, isCurrent);
         if (isCurrent) {
             el.classList.replace('text-slate-500', 'text-teal-400');
             borderSpans.forEach((s) => {
@@ -483,6 +521,7 @@ export function refreshCurrentGapHighlight(now = new Date()) {
         const isCurrent =
             (position === 'before' && now < boundaryTime) ||
             (position === 'after' && now >= boundaryTime);
+        updateBoundaryLabel(el, now, isCurrent);
         if (isCurrent) {
             el.classList.remove('hidden');
         } else {

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -681,6 +681,54 @@ def build_relative_day_activity_doc(
     return doc
 
 
+def build_relative_day_scheduled_task_doc(
+    page: Any,
+    *,
+    doc_id: str,
+    description: str,
+    day_offset: int,
+    start_hour: int,
+    start_minute: int,
+    duration_minutes: int,
+) -> dict[str, Any]:
+    doc = page.evaluate(
+        """
+        ({ id, description, dayOffset, startHour, startMinute, durationMinutes }) => {
+            const start = new Date();
+            start.setDate(start.getDate() + Number(dayOffset || 0));
+            start.setHours(Number(startHour || 0), Number(startMinute || 0), 0, 0);
+            const end = new Date(start.getTime() + Number(durationMinutes || 0) * 60000);
+
+            return {
+                _id: id,
+                id,
+                docType: 'task',
+                type: 'scheduled',
+                description,
+                startDateTime: start.toISOString(),
+                endDateTime: end.toISOString(),
+                duration: Number(durationMinutes || 0),
+                status: 'incomplete',
+                editing: false,
+                confirmingDelete: false,
+                locked: false,
+            };
+        }
+        """,
+        {
+            "id": doc_id,
+            "description": description,
+            "dayOffset": day_offset,
+            "startHour": start_hour,
+            "startMinute": start_minute,
+            "durationMinutes": duration_minutes,
+        },
+    )
+    if not doc:
+        raise ValueError(f"Could not build relative scheduled task doc for {description!r}.")
+    return doc
+
+
 def stop_activity_timer(
     page: Any, *, timeout_s: float = 10.0, interval_s: float = 0.2
 ) -> None:
@@ -2541,8 +2589,36 @@ def run_smoke(
                 demo_step(page, "opening alpha room", step_pause_ms)
                 enter_room(page, rooms["alpha"])
                 clear_room_storage(page, rooms["alpha"])
+                stale_schedule_description = "Playwright stale scheduled task"
+                seed_docs(
+                    page,
+                    rooms["alpha"],
+                    [
+                        build_relative_day_scheduled_task_doc(
+                            page,
+                            doc_id="task-playwright-stale-scheduled",
+                            description=stale_schedule_description,
+                            day_offset=-1,
+                            start_hour=10,
+                            start_minute=0,
+                            duration_minutes=30,
+                        )
+                    ],
+                )
                 page.reload(wait_until="load")
                 wait_for_main_app(page)
+                wait_until(
+                    lambda: any(
+                        doc.get("description") == stale_schedule_description
+                        for doc in list(map(normalize_doc, read_docs(page, rooms["alpha"])))
+                    ),
+                    "prior-day scheduled task remains in storage",
+                )
+                wait_until(
+                    lambda: stale_schedule_description
+                    not in (page.locator("#scheduled-task-list").text_content() or ""),
+                    "prior-day scheduled task hidden from today's schedule",
+                )
 
                 demo_step(page, "adding fresh-room tasks", step_pause_ms)
                 add_scheduled_task(page, "Playwright scheduled task", "09:00", 30)
@@ -2555,6 +2631,7 @@ def run_smoke(
                 scheduled_doc = ensure_task_doc_present(
                     rooms["alpha"], "Playwright scheduled task", alpha_docs
                 )
+                ensure_task_doc_present(rooms["alpha"], stale_schedule_description, alpha_docs)
                 unscheduled_doc = ensure_task_doc_present(
                     rooms["alpha"], "Playwright unscheduled task", alpha_docs
                 )


### PR DESCRIPTION
## Summary

- Limit restored running timer focus to initial app load / first sync so later sync refreshes preserve the user's current task/activity selection.
- Add live countdown labels for the current free gap and richer now boundary labels in the schedule.
- Add a new violet taxonomy color family while showing common color names in settings (Orange, Red, Purple).
- Left-align taxonomy group/category rows and reopen Settings after reloading from Activities enablement so taxonomy controls are immediately available after sync settles.
- Scope the main Tasks schedule to the current local day so stale scheduled tasks from prior days stay out of Today's Schedule, active-task selection, start-time suggestions, and Clear Schedule behavior.
- Include the roadmap note for possible pomodoro alarms on running timers.

## Validation

- npm test
- npm run check
- npm test -- --coverage
- python -m py_compile scripts/playwright_preview_smoke.py

The pre-commit hook also reran lint/format and coverage successfully.