### PR TITLE
Add do-now scheduled task action

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,4 +53,5 @@ Historical and planned repo tasks for Fortudo.
   - convert all remaining incomplete scheduled tasks from prior days into unscheduled tasks, copying `duration` into `estDuration` and defaulting `priority` to `medium`
   - show a summary toast after rollover so the user can see what changed
 - [ ] (vNext) add checkbox to "make a habit" so we can have a second list that gets injected daily
+- [ ] (vNext) support configurable task quick actions so frequently used menu actions can be promoted back onto the task card
 - [ ] (vNext) support pomodoro alarms on running timers (?)

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -116,6 +116,7 @@ describe('DOM Handler Interaction Tests', () => {
             onCompleteTask: jest.fn(),
             onEditTask: jest.fn(),
             onDeleteTask: jest.fn(),
+            onMakeNextTask: jest.fn(),
             onSaveTaskEdit: jest.fn(),
             onCancelEdit: jest.fn()
         };
@@ -141,6 +142,7 @@ describe('DOM Handler Interaction Tests', () => {
     });
 
     afterEach(() => {
+        jest.useRealTimers();
         jest.clearAllMocks();
         resetEventDelegation();
         resetActivityState();
@@ -174,6 +176,31 @@ describe('DOM Handler Interaction Tests', () => {
             );
 
             jest.useRealTimers();
+        });
+    });
+
+    describe('scheduled task action delegation', () => {
+        test('clicking make-next invokes the scheduled make-next callback', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2026-06-22T09:00:00.000'));
+            const futureTask = {
+                id: 'future-task',
+                type: 'scheduled',
+                description: 'Future Task',
+                startDateTime: timeToDateTime('11:00', '2026-06-22'),
+                endDateTime: calculateEndDateTime(timeToDateTime('11:00', '2026-06-22'), 30),
+                duration: 30,
+                status: 'incomplete',
+                editing: false,
+                confirmingDelete: false,
+                locked: false
+            };
+
+            renderTasks([futureTask], mockTaskEventCallbacks);
+
+            document.querySelector('.btn-make-next').click();
+
+            expect(mockTaskEventCallbacks.onMakeNextTask).toHaveBeenCalledWith('future-task', 0);
         });
     });
 

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -146,6 +146,7 @@ describe('DOM Handler Interaction Tests', () => {
         jest.clearAllMocks();
         resetEventDelegation();
         resetActivityState();
+        disableStartTimeAutoUpdate();
         document.body.innerHTML = '';
     });
 

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -1011,10 +1011,15 @@ describe('DOM Handler Interaction Tests', () => {
                             <i class="fa-regular ${isCompleted ? 'fa-check-square' : 'fa-square'}"></i>
                         </label>
                         <span>Test Task</span>
-                        <button class="btn-start-unscheduled-timer" data-task-id="${taskId}" ${isCompleted ? 'disabled' : ''}>Start Timer</button>
-                        <button class="btn-schedule-task" data-task-id="${taskId}" ${isCompleted ? 'disabled' : ''}>Schedule</button>
-                        <button class="btn-edit-unscheduled" data-task-id="${taskId}">Edit</button>
-                        <button class="btn-delete-unscheduled" data-task-id="${taskId}">Delete</button>
+                        <div class="unscheduled-task-actions">
+                            <button class="btn-unscheduled-task-actions-menu" aria-expanded="false">Actions</button>
+                            <div class="unscheduled-task-actions-menu" hidden>
+                                <button class="btn-start-unscheduled-timer" data-task-id="${taskId}" ${isCompleted ? 'disabled' : ''}>Start Timer</button>
+                                <button class="btn-schedule-task" data-task-id="${taskId}" ${isCompleted ? 'disabled' : ''}>Schedule</button>
+                                <button class="btn-edit-unscheduled" data-task-id="${taskId}">Edit</button>
+                                <button class="btn-delete-unscheduled" data-task-id="${taskId}">Delete</button>
+                            </div>
+                        </div>
                     </div>
                     <div class="inline-edit-unscheduled-form hidden">
                         <form>
@@ -1045,9 +1050,52 @@ describe('DOM Handler Interaction Tests', () => {
             initializeUnscheduledTaskListEventListeners(mockUnscheduledTaskCallbacks);
         }
 
+        test('actions trigger opens and closes the unscheduled task actions menu', () => {
+            setupUnscheduledTask('unsched-1');
+
+            const trigger = document.querySelector('.btn-unscheduled-task-actions-menu');
+            const menu = document.querySelector('.unscheduled-task-actions-menu');
+
+            expect(menu.hidden).toBe(true);
+
+            trigger.click();
+
+            expect(trigger.getAttribute('aria-expanded')).toBe('true');
+            expect(menu.hidden).toBe(false);
+
+            trigger.click();
+
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(menu.hidden).toBe(true);
+        });
+
+        test('outside click and Escape close an open unscheduled task actions menu', () => {
+            setupUnscheduledTask('unsched-1');
+
+            const trigger = document.querySelector('.btn-unscheduled-task-actions-menu');
+            const menu = document.querySelector('.unscheduled-task-actions-menu');
+
+            trigger.click();
+            expect(menu.hidden).toBe(false);
+
+            document.body.click();
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(menu.hidden).toBe(true);
+
+            trigger.click();
+            expect(menu.hidden).toBe(false);
+
+            document
+                .getElementById('unscheduled-task-list')
+                .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(menu.hidden).toBe(true);
+        });
+
         test('schedule button calls onScheduleUnscheduledTask', () => {
             setupUnscheduledTask('unsched-1');
 
+            document.querySelector('.btn-unscheduled-task-actions-menu').click();
             const scheduleBtn = document.querySelector('.btn-schedule-task');
             scheduleBtn.dispatchEvent(new Event('click', { bubbles: true }));
 
@@ -1061,17 +1109,20 @@ describe('DOM Handler Interaction Tests', () => {
         test('start timer button calls onStartTimerFromUnscheduledTask', () => {
             setupUnscheduledTask('unsched-1');
 
+            document.querySelector('.btn-unscheduled-task-actions-menu').click();
             const startTimerBtn = document.querySelector('.btn-start-unscheduled-timer');
             startTimerBtn.dispatchEvent(new Event('click', { bubbles: true }));
 
             expect(
                 mockUnscheduledTaskCallbacks.onStartTimerFromUnscheduledTask
             ).toHaveBeenCalledWith('unsched-1');
+            expect(document.querySelector('.unscheduled-task-actions-menu').hidden).toBe(true);
         });
 
         test('schedule button does not call callback for completed task', () => {
             setupUnscheduledTask('unsched-1', true);
 
+            document.querySelector('.btn-unscheduled-task-actions-menu').click();
             const scheduleBtn = document.querySelector('.btn-schedule-task');
             scheduleBtn.dispatchEvent(new Event('click', { bubbles: true }));
 
@@ -1081,23 +1132,27 @@ describe('DOM Handler Interaction Tests', () => {
         test('edit button calls onEditUnscheduledTask', () => {
             setupUnscheduledTask('unsched-1');
 
+            document.querySelector('.btn-unscheduled-task-actions-menu').click();
             const editBtn = document.querySelector('.btn-edit-unscheduled');
             editBtn.dispatchEvent(new Event('click', { bubbles: true }));
 
             expect(mockUnscheduledTaskCallbacks.onEditUnscheduledTask).toHaveBeenCalledWith(
                 'unsched-1'
             );
+            expect(document.querySelector('.unscheduled-task-actions-menu').hidden).toBe(true);
         });
 
         test('delete button calls onDeleteUnscheduledTask', () => {
             setupUnscheduledTask('unsched-1');
 
+            document.querySelector('.btn-unscheduled-task-actions-menu').click();
             const deleteBtn = document.querySelector('.btn-delete-unscheduled');
             deleteBtn.dispatchEvent(new Event('click', { bubbles: true }));
 
             expect(mockUnscheduledTaskCallbacks.onDeleteUnscheduledTask).toHaveBeenCalledWith(
                 'unsched-1'
             );
+            expect(document.querySelector('.unscheduled-task-actions-menu').hidden).toBe(true);
         });
 
         test('checkbox calls onToggleCompleteUnscheduledTask', () => {

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -180,7 +180,7 @@ describe('DOM Handler Interaction Tests', () => {
     });
 
     describe('scheduled task action delegation', () => {
-        test('clicking make-next invokes the scheduled make-next callback', () => {
+        function renderFutureScheduledTask() {
             jest.useFakeTimers();
             jest.setSystemTime(new Date('2026-06-22T09:00:00.000'));
             const futureTask = {
@@ -197,10 +197,58 @@ describe('DOM Handler Interaction Tests', () => {
             };
 
             renderTasks([futureTask], mockTaskEventCallbacks);
+            return futureTask;
+        }
+
+        test('clicking the actions trigger opens and closes the task actions menu', () => {
+            renderFutureScheduledTask();
+
+            const trigger = document.querySelector('.btn-task-actions-menu');
+            const menu = document.querySelector('.task-actions-menu');
+
+            expect(menu.hidden).toBe(true);
+
+            trigger.click();
+
+            expect(trigger.getAttribute('aria-expanded')).toBe('true');
+            expect(menu.hidden).toBe(false);
+
+            trigger.click();
+
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(menu.hidden).toBe(true);
+        });
+
+        test('clicking make-next menu item invokes the scheduled make-next callback', () => {
+            renderFutureScheduledTask();
+            document.querySelector('.btn-task-actions-menu').click();
 
             document.querySelector('.btn-make-next').click();
 
             expect(mockTaskEventCallbacks.onMakeNextTask).toHaveBeenCalledWith('future-task', 0);
+            expect(document.querySelector('.task-actions-menu').hidden).toBe(true);
+        });
+
+        test('outside click and Escape close an open task actions menu', () => {
+            renderFutureScheduledTask();
+            const trigger = document.querySelector('.btn-task-actions-menu');
+            const menu = document.querySelector('.task-actions-menu');
+
+            trigger.click();
+            expect(menu.hidden).toBe(false);
+
+            document.body.click();
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(menu.hidden).toBe(true);
+
+            trigger.click();
+            expect(menu.hidden).toBe(false);
+
+            document
+                .getElementById('scheduled-task-list')
+                .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(menu.hidden).toBe(true);
         });
     });
 

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -212,11 +212,15 @@ describe('DOM Handler Interaction Tests', () => {
 
             expect(trigger.getAttribute('aria-expanded')).toBe('true');
             expect(menu.hidden).toBe(false);
+            expect(trigger.closest('[data-task-id]').className).toContain('z-40');
+            expect(trigger.closest('.task-actions').className).toContain('z-50');
 
             trigger.click();
 
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(trigger.closest('[data-task-id]').className).not.toContain('z-40');
+            expect(trigger.closest('.task-actions').className).not.toContain('z-50');
         });
 
         test('clicking make-next menu item invokes the scheduled make-next callback', () => {
@@ -1062,11 +1066,15 @@ describe('DOM Handler Interaction Tests', () => {
 
             expect(trigger.getAttribute('aria-expanded')).toBe('true');
             expect(menu.hidden).toBe(false);
+            expect(trigger.closest('[data-task-id]').className).toContain('z-40');
+            expect(trigger.closest('.unscheduled-task-actions').className).toContain('z-50');
 
             trigger.click();
 
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(trigger.closest('[data-task-id]').className).not.toContain('z-40');
+            expect(trigger.closest('.unscheduled-task-actions').className).not.toContain('z-50');
         });
 
         test('outside click and Escape close an open unscheduled task actions menu', () => {

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -116,7 +116,7 @@ describe('DOM Handler Interaction Tests', () => {
             onCompleteTask: jest.fn(),
             onEditTask: jest.fn(),
             onDeleteTask: jest.fn(),
-            onMakeNextTask: jest.fn(),
+            onDoNowTask: jest.fn(),
             onSaveTaskEdit: jest.fn(),
             onCancelEdit: jest.fn()
         };
@@ -223,13 +223,13 @@ describe('DOM Handler Interaction Tests', () => {
             expect(trigger.closest('.task-actions').className).not.toContain('z-50');
         });
 
-        test('clicking make-next menu item invokes the scheduled make-next callback', () => {
+        test('clicking do-now menu item invokes the scheduled do-now callback', () => {
             renderFutureScheduledTask();
             document.querySelector('.btn-task-actions-menu').click();
 
-            document.querySelector('.btn-make-next').click();
+            document.querySelector('.btn-do-now').click();
 
-            expect(mockTaskEventCallbacks.onMakeNextTask).toHaveBeenCalledWith('future-task', 0);
+            expect(mockTaskEventCallbacks.onDoNowTask).toHaveBeenCalledWith('future-task', 0);
             expect(document.querySelector('.task-actions-menu').hidden).toBe(true);
         });
 

--- a/__tests__/scheduled-task-handlers.test.js
+++ b/__tests__/scheduled-task-handlers.test.js
@@ -8,6 +8,7 @@ import {
     handleEditTask,
     handleDeleteTask,
     handleUnscheduleTask,
+    handleMakeNextTask,
     handleSaveTaskEdit,
     handleCancelEdit,
     handleGapClick,
@@ -15,6 +16,7 @@ import {
 } from '../public/js/tasks/scheduled-handlers.js';
 import { updateTaskState, getTaskState, getTaskById } from '../public/js/tasks/manager.js';
 import * as taskManager from '../public/js/tasks/manager.js';
+import { extractTimeFromDateTime } from '../public/js/utils.js';
 import { createTaskWithDateTime } from './test-utils.js';
 
 // Mock storage
@@ -80,8 +82,13 @@ jest.mock('../public/js/tasks/form-utils.js', () => ({
     getUnscheduledTaskInlineFormData: jest.fn()
 }));
 
-import { refreshUI } from '../public/js/dom-renderer.js';
-import { showAlert, showGapTaskPicker, showScheduleModal } from '../public/js/modal-manager.js';
+import { refreshUI, getCurrentTimeElement } from '../public/js/dom-renderer.js';
+import {
+    showAlert,
+    askConfirmation,
+    showGapTaskPicker,
+    showScheduleModal
+} from '../public/js/modal-manager.js';
 import { showToast } from '../public/js/toast-manager.js';
 import { extractTaskFormData } from '../public/js/tasks/form-utils.js';
 import {
@@ -114,6 +121,7 @@ describe('Scheduled Task Handlers', () => {
             expect(callbacks).toHaveProperty('onEditTask');
             expect(callbacks).toHaveProperty('onDeleteTask');
             expect(callbacks).toHaveProperty('onUnscheduleTask');
+            expect(callbacks).toHaveProperty('onMakeNextTask');
             expect(callbacks).toHaveProperty('onSaveTaskEdit');
             expect(callbacks).toHaveProperty('onCancelEdit');
         });
@@ -127,6 +135,61 @@ describe('Scheduled Task Handlers', () => {
             expect(callbacks.onUnscheduleTask).toBe(handleUnscheduleTask);
             expect(callbacks.onSaveTaskEdit).toBe(handleSaveTaskEdit);
             expect(callbacks.onCancelEdit).toBe(handleCancelEdit);
+        });
+    });
+
+    describe('handleMakeNextTask', () => {
+        test('moves a task immediately when the current slot is free', async () => {
+            getCurrentTimeElement.mockReturnValue({ textContent: '10:00 AM' });
+            const currentTask = createTaskWithDateTime({
+                description: 'Current Task',
+                startTime: '09:00',
+                duration: 60,
+                status: 'completed'
+            });
+            const futureTask = createTaskWithDateTime({
+                description: 'Future Task',
+                startTime: '11:00',
+                duration: 30
+            });
+            updateTaskState([currentTask, futureTask]);
+
+            await handleMakeNextTask(futureTask.id);
+
+            expect(askConfirmation).not.toHaveBeenCalled();
+            expect(
+                extractTimeFromDateTime(
+                    new Date(taskManager.getTaskById(futureTask.id).startDateTime)
+                )
+            ).toBe('10:00');
+            expect(onTaskEdited).toHaveBeenCalledWith({
+                task: expect.objectContaining({ id: futureTask.id })
+            });
+        });
+
+        test('leaves schedule unchanged when user declines reschedule confirmation', async () => {
+            getCurrentTimeElement.mockReturnValue({ textContent: '9:30 AM' });
+            const currentTask = createTaskWithDateTime({
+                description: 'Current Task',
+                startTime: '09:00',
+                duration: 60
+            });
+            const futureTask = createTaskWithDateTime({
+                description: 'Future Task',
+                startTime: '11:00',
+                duration: 30
+            });
+            updateTaskState([currentTask, futureTask]);
+            askConfirmation.mockResolvedValueOnce(false);
+
+            await handleMakeNextTask(futureTask.id);
+
+            expect(askConfirmation).toHaveBeenCalled();
+            expect(showToast).toHaveBeenCalledWith('Schedule unchanged.', { theme: 'teal' });
+            expect(taskManager.getTaskById(futureTask.id).startDateTime).toBe(
+                futureTask.startDateTime
+            );
+            expect(onTaskEdited).not.toHaveBeenCalled();
         });
     });
 

--- a/__tests__/scheduled-task-handlers.test.js
+++ b/__tests__/scheduled-task-handlers.test.js
@@ -8,7 +8,7 @@ import {
     handleEditTask,
     handleDeleteTask,
     handleUnscheduleTask,
-    handleMakeNextTask,
+    handleDoNowTask,
     handleSaveTaskEdit,
     handleCancelEdit,
     handleGapClick,
@@ -121,7 +121,7 @@ describe('Scheduled Task Handlers', () => {
             expect(callbacks).toHaveProperty('onEditTask');
             expect(callbacks).toHaveProperty('onDeleteTask');
             expect(callbacks).toHaveProperty('onUnscheduleTask');
-            expect(callbacks).toHaveProperty('onMakeNextTask');
+            expect(callbacks).toHaveProperty('onDoNowTask');
             expect(callbacks).toHaveProperty('onSaveTaskEdit');
             expect(callbacks).toHaveProperty('onCancelEdit');
         });
@@ -138,7 +138,7 @@ describe('Scheduled Task Handlers', () => {
         });
     });
 
-    describe('handleMakeNextTask', () => {
+    describe('handleDoNowTask', () => {
         test('moves a task immediately when the current slot is free', async () => {
             getCurrentTimeElement.mockReturnValue({ textContent: '10:00 AM' });
             const currentTask = createTaskWithDateTime({
@@ -154,7 +154,7 @@ describe('Scheduled Task Handlers', () => {
             });
             updateTaskState([currentTask, futureTask]);
 
-            await handleMakeNextTask(futureTask.id);
+            await handleDoNowTask(futureTask.id);
 
             expect(askConfirmation).not.toHaveBeenCalled();
             expect(
@@ -182,7 +182,7 @@ describe('Scheduled Task Handlers', () => {
             updateTaskState([currentTask, futureTask]);
             askConfirmation.mockResolvedValueOnce(false);
 
-            await handleMakeNextTask(futureTask.id);
+            await handleDoNowTask(futureTask.id);
 
             expect(askConfirmation).toHaveBeenCalled();
             expect(showToast).toHaveBeenCalledWith('Schedule unchanged.', { theme: 'teal' });

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -250,6 +250,31 @@ describe('Scheduled Task Renderer Tests', () => {
             jest.useRealTimers();
         });
 
+        test('renders lock action copy based on lock state', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));
+            const unlockedTask = createTask('unlocked', '11:30', 30, {
+                description: 'Unlocked Task'
+            });
+            const lockedTask = createTask('locked', '12:30', 30, {
+                description: 'Locked Task',
+                locked: true
+            });
+
+            renderTasks([unlockedTask, lockedTask], mockCallbacks, mockInitListeners, null);
+
+            const unlockedTaskElement = document.querySelector('[data-task-id="unlocked"]');
+            const lockedTaskElement = document.querySelector('[data-task-id="locked"]');
+
+            expect(unlockedTaskElement.querySelector('.btn-lock').textContent).toContain(
+                'Lock time'
+            );
+            expect(lockedTaskElement.querySelector('.btn-lock').textContent).toContain(
+                'Allow reschedule'
+            );
+            jest.useRealTimers();
+        });
+
         test('keeps the actions menu open when delete is waiting for confirmation', () => {
             jest.useFakeTimers();
             jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -293,7 +293,12 @@ describe('Scheduled Task Renderer Tests', () => {
             expect(unlockedTaskElement.querySelector('.scheduled-lock-badge')).toBeNull();
             expect(badge).not.toBeNull();
             expect(badge.textContent.trim()).toBe('');
-            expect(badge.getAttribute('aria-label')).toBe('Fixed time');
+            expect(badge.getAttribute('aria-label')).toBe(
+                'Time is locked to prevent auto-rescheduling.'
+            );
+            expect(badge.getAttribute('title')).toBe(
+                'Time is locked to prevent auto-rescheduling.'
+            );
             expect(badge.querySelector('.fa-lock')).not.toBeNull();
         });
 

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -251,6 +251,27 @@ describe('Scheduled Task Renderer Tests', () => {
             jest.useRealTimers();
         });
 
+        test('keeps the actions menu open when delete is waiting for confirmation', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));
+            const tasks = [
+                {
+                    ...createTask('confirm-delete', '10:30', 30),
+                    confirmingDelete: true
+                }
+            ];
+
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            const task = document.querySelector('[data-task-id="confirm-delete"]');
+            expect(task.querySelector('.btn-task-actions-menu').getAttribute('aria-expanded')).toBe(
+                'true'
+            );
+            expect(task.querySelector('.task-actions-menu').hasAttribute('hidden')).toBe(false);
+            expect(task.querySelector('.btn-delete').textContent).toContain('Confirm delete');
+            jest.useRealTimers();
+        });
+
         test('gap elements do not have data-task-id attribute', () => {
             const tasks = [createTask('1', '10:00', 60), createTask('2', '11:30', 60)];
 

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -275,7 +275,7 @@ describe('Scheduled Task Renderer Tests', () => {
             jest.useRealTimers();
         });
 
-        test('shows a passive fixed-time badge on locked scheduled tasks', () => {
+        test('shows a passive icon-only fixed-time indicator on locked scheduled tasks', () => {
             const unlockedTask = createTask('unlocked', '11:30', 30, {
                 description: 'Unlocked Task'
             });
@@ -292,7 +292,8 @@ describe('Scheduled Task Renderer Tests', () => {
 
             expect(unlockedTaskElement.querySelector('.scheduled-lock-badge')).toBeNull();
             expect(badge).not.toBeNull();
-            expect(badge.textContent).toContain('Fixed time');
+            expect(badge.textContent.trim()).toBe('');
+            expect(badge.getAttribute('aria-label')).toBe('Fixed time');
             expect(badge.querySelector('.fa-lock')).not.toBeNull();
         });
 

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -219,7 +219,7 @@ describe('Scheduled Task Renderer Tests', () => {
             expect(badge.textContent).toBe('work/deep');
         });
 
-        test('renders make-next button only for incomplete non-active scheduled tasks', () => {
+        test('renders actions menu with make-next only for incomplete non-active scheduled tasks', () => {
             jest.useFakeTimers();
             jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));
             const tasks = [
@@ -233,9 +233,21 @@ describe('Scheduled Task Renderer Tests', () => {
 
             renderTasks(tasks, mockCallbacks, mockInitListeners, null);
 
-            expect(document.querySelector('[data-task-id="active"] .btn-make-next')).toBeNull();
-            expect(document.querySelector('[data-task-id="future"] .btn-make-next')).not.toBeNull();
-            expect(document.querySelector('[data-task-id="completed"] .btn-make-next')).toBeNull();
+            const activeTask = document.querySelector('[data-task-id="active"]');
+            const futureTask = document.querySelector('[data-task-id="future"]');
+            const completedTask = document.querySelector('[data-task-id="completed"]');
+
+            expect(activeTask.querySelector('.btn-task-actions-menu')).not.toBeNull();
+            expect(activeTask.querySelector('.btn-make-next')).toBeNull();
+            expect(futureTask.querySelector('.task-actions-menu')).not.toBeNull();
+            expect(futureTask.querySelector('.task-actions-menu').hasAttribute('hidden')).toBe(
+                true
+            );
+            expect(futureTask.querySelector('.btn-make-next')).not.toBeNull();
+            expect(futureTask.querySelector('.btn-make-next').textContent).toContain(
+                'Make this next'
+            );
+            expect(completedTask.querySelector('.btn-make-next')).toBeNull();
             jest.useRealTimers();
         });
 

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -264,9 +264,11 @@ describe('Scheduled Task Renderer Tests', () => {
             renderTasks(tasks, mockCallbacks, mockInitListeners, null);
 
             const task = document.querySelector('[data-task-id="confirm-delete"]');
+            expect(task.className).toContain('z-40');
             expect(task.querySelector('.btn-task-actions-menu').getAttribute('aria-expanded')).toBe(
                 'true'
             );
+            expect(task.querySelector('.task-actions').className).toContain('z-50');
             expect(task.querySelector('.task-actions-menu').hasAttribute('hidden')).toBe(false);
             expect(task.querySelector('.btn-delete').textContent).toContain('Confirm delete');
             jest.useRealTimers();

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -275,6 +275,27 @@ describe('Scheduled Task Renderer Tests', () => {
             jest.useRealTimers();
         });
 
+        test('shows a passive fixed-time badge on locked scheduled tasks', () => {
+            const unlockedTask = createTask('unlocked', '11:30', 30, {
+                description: 'Unlocked Task'
+            });
+            const lockedTask = createTask('locked', '12:30', 30, {
+                description: 'Locked Task',
+                locked: true
+            });
+
+            renderTasks([unlockedTask, lockedTask], mockCallbacks, mockInitListeners, null);
+
+            const unlockedTaskElement = document.querySelector('[data-task-id="unlocked"]');
+            const lockedTaskElement = document.querySelector('[data-task-id="locked"]');
+            const badge = lockedTaskElement.querySelector('.scheduled-lock-badge');
+
+            expect(unlockedTaskElement.querySelector('.scheduled-lock-badge')).toBeNull();
+            expect(badge).not.toBeNull();
+            expect(badge.textContent).toContain('Fixed time');
+            expect(badge.querySelector('.fa-lock')).not.toBeNull();
+        });
+
         test('keeps the actions menu open when delete is waiting for confirmation', () => {
             jest.useFakeTimers();
             jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -56,6 +56,7 @@ describe('Scheduled Task Renderer Tests', () => {
     });
 
     afterEach(() => {
+        jest.useRealTimers();
         document.body.innerHTML = '';
     });
 
@@ -216,6 +217,26 @@ describe('Scheduled Task Renderer Tests', () => {
             const badge = document.querySelector('.category-badge');
             expect(badge).not.toBeNull();
             expect(badge.textContent).toBe('work/deep');
+        });
+
+        test('renders make-next button only for incomplete non-active scheduled tasks', () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));
+            const tasks = [
+                createTask('active', '10:00', 60, { description: 'Active Task' }),
+                createTask('future', '11:30', 30, { description: 'Future Task' }),
+                createTask('completed', '12:30', 30, {
+                    description: 'Completed Task',
+                    status: 'completed'
+                })
+            ];
+
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            expect(document.querySelector('[data-task-id="active"] .btn-make-next')).toBeNull();
+            expect(document.querySelector('[data-task-id="future"] .btn-make-next')).not.toBeNull();
+            expect(document.querySelector('[data-task-id="completed"] .btn-make-next')).toBeNull();
+            jest.useRealTimers();
         });
 
         test('gap elements do not have data-task-id attribute', () => {

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -219,7 +219,7 @@ describe('Scheduled Task Renderer Tests', () => {
             expect(badge.textContent).toBe('work/deep');
         });
 
-        test('renders actions menu with make-next only for incomplete non-active scheduled tasks', () => {
+        test('renders actions menu with do-now only for incomplete non-active scheduled tasks', () => {
             jest.useFakeTimers();
             jest.setSystemTime(new Date('2025-01-15T10:15:00.000'));
             const tasks = [
@@ -238,16 +238,15 @@ describe('Scheduled Task Renderer Tests', () => {
             const completedTask = document.querySelector('[data-task-id="completed"]');
 
             expect(activeTask.querySelector('.btn-task-actions-menu')).not.toBeNull();
-            expect(activeTask.querySelector('.btn-make-next')).toBeNull();
+            expect(activeTask.querySelector('.btn-do-now')).toBeNull();
             expect(futureTask.querySelector('.task-actions-menu')).not.toBeNull();
             expect(futureTask.querySelector('.task-actions-menu').hasAttribute('hidden')).toBe(
                 true
             );
-            expect(futureTask.querySelector('.btn-make-next')).not.toBeNull();
-            expect(futureTask.querySelector('.btn-make-next').textContent).toContain(
-                'Make this next'
-            );
-            expect(completedTask.querySelector('.btn-make-next')).toBeNull();
+            expect(futureTask.querySelector('.btn-do-now')).not.toBeNull();
+            expect(futureTask.querySelector('.btn-do-now').textContent).toContain('Do now');
+            expect(futureTask.querySelector('.btn-do-now .fa-bolt')).not.toBeNull();
+            expect(completedTask.querySelector('.btn-do-now')).toBeNull();
             jest.useRealTimers();
         });
 

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -11,7 +11,7 @@ import {
     addTask,
     scheduleUnscheduledTask,
     updateTask,
-    makeScheduledTaskNext,
+    doScheduledTaskNow,
     completeTask,
     deleteTask,
     editTask,
@@ -997,7 +997,7 @@ describe('Task Management Functions (task-manager.js)', () => {
         });
     });
 
-    describe('makeScheduledTaskNext', () => {
+    describe('doScheduledTaskNow', () => {
         beforeEach(() => {
             const currentTask = createTaskWithDateTime({
                 description: 'Current Task',
@@ -1026,7 +1026,7 @@ describe('Task Management Functions (task-manager.js)', () => {
         test('moves a selected scheduled task to the requested start time', () => {
             const futureTask = getTaskState().find((task) => task.description === 'Future Task');
 
-            const result = makeScheduledTaskNext(futureTask.id, '10:00');
+            const result = doScheduledTaskNow(futureTask.id, '10:00');
 
             expect(result.success).toBe(true);
             const movedTask = getTaskById(futureTask.id);
@@ -1041,7 +1041,7 @@ describe('Task Management Functions (task-manager.js)', () => {
         test('requires confirmation and leaves state unchanged when moving into an occupied slot', () => {
             const futureTask = getTaskState().find((task) => task.description === 'Future Task');
 
-            const result = makeScheduledTaskNext(futureTask.id, '09:30');
+            const result = doScheduledTaskNow(futureTask.id, '09:30');
 
             expect(result.success).toBe(false);
             expect(result.requiresConfirmation).toBe(true);
@@ -1063,11 +1063,11 @@ describe('Task Management Functions (task-manager.js)', () => {
             const [currentTask, futureTask] = getTaskState();
             updateTaskState([{ ...currentTask }, { ...futureTask, status: 'completed' }]);
 
-            expect(makeScheduledTaskNext(futureTask.id, '09:30')).toEqual({
+            expect(doScheduledTaskNow(futureTask.id, '09:30')).toEqual({
                 success: false,
-                reason: 'Completed tasks cannot be made next.'
+                reason: 'Completed tasks cannot be done now.'
             });
-            expect(makeScheduledTaskNext('missing-task', '09:30')).toEqual({
+            expect(doScheduledTaskNow('missing-task', '09:30')).toEqual({
                 success: false,
                 reason: 'Scheduled task not found.'
             });

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -11,6 +11,7 @@ import {
     addTask,
     scheduleUnscheduledTask,
     updateTask,
+    makeScheduledTaskNext,
     completeTask,
     deleteTask,
     editTask,
@@ -991,6 +992,83 @@ describe('Task Management Functions (task-manager.js)', () => {
             const result = updateTask(5, { description: 'Valid Desc', duration: 30 });
             expect(result.success).toBe(false);
             expect(result.reason).toBe('Invalid task index.');
+        });
+    });
+
+    describe('makeScheduledTaskNext', () => {
+        beforeEach(() => {
+            const currentTask = createTaskWithDateTime({
+                description: 'Current Task',
+                startTime: '09:00',
+                duration: 60,
+                status: 'incomplete',
+                editing: false,
+                confirmingDelete: false
+            });
+            const futureTask = {
+                ...createTaskWithDateTime({
+                    description: 'Future Task',
+                    startTime: '10:30',
+                    duration: 30,
+                    status: 'incomplete',
+                    editing: false,
+                    confirmingDelete: false
+                }),
+                category: 'work/deep'
+            };
+            updateTaskState([currentTask, futureTask]);
+            mockSaveTasks.mockClear();
+            mockPutTask.mockClear();
+        });
+
+        test('moves a selected scheduled task to the requested start time', () => {
+            const futureTask = getTaskState().find((task) => task.description === 'Future Task');
+
+            const result = makeScheduledTaskNext(futureTask.id, '10:00');
+
+            expect(result.success).toBe(true);
+            const movedTask = getTaskById(futureTask.id);
+            expect(extractTimeFromDateTime(new Date(movedTask.startDateTime))).toBe('10:00');
+            expect(extractTimeFromDateTime(new Date(movedTask.endDateTime))).toBe('10:30');
+            expect(movedTask.category).toBe('work/deep');
+            expect(mockPutTask).toHaveBeenCalledWith(
+                expect.objectContaining({ id: futureTask.id })
+            );
+        });
+
+        test('requires confirmation and leaves state unchanged when moving into an occupied slot', () => {
+            const futureTask = getTaskState().find((task) => task.description === 'Future Task');
+
+            const result = makeScheduledTaskNext(futureTask.id, '09:30');
+
+            expect(result.success).toBe(false);
+            expect(result.requiresConfirmation).toBe(true);
+            expect(result.confirmationType).toBe('RESCHEDULE_UPDATE');
+            expect(result.updatedTaskObject).toEqual(
+                expect.objectContaining({
+                    id: futureTask.id,
+                    description: 'Future Task',
+                    duration: 30,
+                    category: 'work/deep'
+                })
+            );
+            const unchangedTask = getTaskById(futureTask.id);
+            expect(extractTimeFromDateTime(new Date(unchangedTask.startDateTime))).toBe('10:30');
+            expect(mockPutTask).not.toHaveBeenCalled();
+        });
+
+        test('rejects completed and missing scheduled tasks', () => {
+            const [currentTask, futureTask] = getTaskState();
+            updateTaskState([{ ...currentTask }, { ...futureTask, status: 'completed' }]);
+
+            expect(makeScheduledTaskNext(futureTask.id, '09:30')).toEqual({
+                success: false,
+                reason: 'Completed tasks cannot be made next.'
+            });
+            expect(makeScheduledTaskNext('missing-task', '09:30')).toEqual({
+                success: false,
+                reason: 'Scheduled task not found.'
+            });
         });
     });
 

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -298,6 +298,7 @@ function getRenderedTasksDOM() {
 
         if (descriptionElement) {
             description = descriptionElement.textContent?.trim() || '';
+            description = description.replace(/\s*Fixed time\s*/g, '').trim();
 
             // Remove "locked" badge text if present
             description = description.replace(/\s*🔒\s*Locked\s*/g, '').trim();

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -298,8 +298,6 @@ function getRenderedTasksDOM() {
 
         if (descriptionElement) {
             description = descriptionElement.textContent?.trim() || '';
-            description = description.replace(/\s*Fixed time\s*/g, '').trim();
-
             // Remove "locked" badge text if present
             description = description.replace(/\s*🔒\s*Locked\s*/g, '').trim();
         }

--- a/__tests__/unscheduled-task-renderer.test.js
+++ b/__tests__/unscheduled-task-renderer.test.js
@@ -30,7 +30,7 @@ describe('unscheduled task renderer', () => {
         document.body.innerHTML = '<div id="unscheduled-task-list"></div>';
     });
 
-    test('renders a start timer action for incomplete unscheduled tasks', () => {
+    test('renders an actions menu with start timer for incomplete unscheduled tasks', () => {
         renderUnscheduledTasks(
             [
                 {
@@ -46,11 +46,23 @@ describe('unscheduled task renderer', () => {
             jest.fn()
         );
 
+        const actionsTrigger = document.querySelector('.btn-unscheduled-task-actions-menu');
+        const actionsMenu = document.querySelector('.unscheduled-task-actions-menu');
         const startTimerButton = document.querySelector('.btn-start-unscheduled-timer');
+        expect(actionsTrigger).not.toBeNull();
+        expect(actionsTrigger.getAttribute('aria-haspopup')).toBe('menu');
+        expect(actionsTrigger.getAttribute('aria-expanded')).toBe('false');
+        expect(actionsMenu).not.toBeNull();
+        expect(actionsMenu.hasAttribute('hidden')).toBe(true);
         expect(startTimerButton).not.toBeNull();
-        expect(startTimerButton.getAttribute('title')).toBe('Start timer from task');
+        expect(startTimerButton.textContent).toContain('Start timer');
         expect(startTimerButton.querySelector('.fa-stopwatch')).not.toBeNull();
         expect(startTimerButton.hasAttribute('disabled')).toBe(false);
+        expect(document.querySelector('.btn-schedule-task').textContent).toContain('Schedule');
+        expect(document.querySelector('.btn-edit-unscheduled').textContent).toContain('Edit task');
+        expect(document.querySelector('.btn-delete-unscheduled').textContent).toContain(
+            'Delete task'
+        );
     });
 
     test('renders the linked source task with a subdued in-progress badge and fully disabled while its timer runs', () => {

--- a/__tests__/unscheduled-task-renderer.test.js
+++ b/__tests__/unscheduled-task-renderer.test.js
@@ -107,6 +107,37 @@ describe('unscheduled task renderer', () => {
         );
     });
 
+    test('keeps the actions menu open when delete is waiting for confirmation', () => {
+        renderUnscheduledTasks(
+            [
+                {
+                    id: 'unsched-confirm-delete',
+                    type: 'unscheduled',
+                    description: 'Inbox zero',
+                    priority: 'medium',
+                    estDuration: 30,
+                    status: 'incomplete',
+                    confirmingDelete: true
+                }
+            ],
+            {},
+            jest.fn()
+        );
+
+        const taskCard = document.querySelector('[data-task-id="unsched-confirm-delete"]');
+        expect(
+            taskCard
+                .querySelector('.btn-unscheduled-task-actions-menu')
+                .getAttribute('aria-expanded')
+        ).toBe('true');
+        expect(
+            taskCard.querySelector('.unscheduled-task-actions-menu').hasAttribute('hidden')
+        ).toBe(false);
+        expect(taskCard.querySelector('.btn-delete-unscheduled').textContent).toContain(
+            'Confirm delete'
+        );
+    });
+
     test('renders category select and color dot for inline editing task', () => {
         renderUnscheduledTasks(
             [

--- a/__tests__/unscheduled-task-renderer.test.js
+++ b/__tests__/unscheduled-task-renderer.test.js
@@ -125,11 +125,13 @@ describe('unscheduled task renderer', () => {
         );
 
         const taskCard = document.querySelector('[data-task-id="unsched-confirm-delete"]');
+        expect(taskCard.className).toContain('z-40');
         expect(
             taskCard
                 .querySelector('.btn-unscheduled-task-actions-menu')
                 .getAttribute('aria-expanded')
         ).toBe('true');
+        expect(taskCard.querySelector('.unscheduled-task-actions').className).toContain('z-50');
         expect(
             taskCard.querySelector('.unscheduled-task-actions-menu').hasAttribute('hidden')
         ).toBe(false);

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -368,6 +368,14 @@ function handleScheduledTaskListClick(event) {
         return;
     }
 
+    if (target.closest('.btn-make-next')) {
+        event.preventDefault();
+        if (globalScheduledTaskCallbacks.onMakeNextTask) {
+            globalScheduledTaskCallbacks.onMakeNextTask(taskId, taskIndex);
+        }
+        return;
+    }
+
     if (target.closest('.btn-delete')) {
         event.preventDefault();
         event.stopPropagation();

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -285,6 +285,33 @@ function toggleScheduledTaskActionMenu(trigger) {
     }
 }
 
+function closeUnscheduledTaskActionMenus(exceptMenu = null) {
+    const taskListElement = getUnscheduledTaskListElement();
+    if (!taskListElement) return;
+
+    taskListElement.querySelectorAll('.unscheduled-task-actions-menu').forEach((menu) => {
+        if (menu === exceptMenu) return;
+        menu.hidden = true;
+        const trigger = menu.parentElement?.querySelector('.btn-unscheduled-task-actions-menu');
+        if (trigger instanceof HTMLElement) {
+            trigger.setAttribute('aria-expanded', 'false');
+        }
+    });
+}
+
+function toggleUnscheduledTaskActionMenu(trigger) {
+    const menu = trigger.parentElement?.querySelector('.unscheduled-task-actions-menu');
+    if (!(menu instanceof HTMLElement)) return;
+
+    const shouldOpen = menu.hidden;
+    closeUnscheduledTaskActionMenus(shouldOpen ? menu : null);
+    menu.hidden = !shouldOpen;
+    trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+    if (shouldOpen) {
+        menu.querySelector('[role="menuitem"]')?.focus();
+    }
+}
+
 function handleScheduledTaskListKeydown(event) {
     if (event.key === 'Escape') {
         closeScheduledTaskActionMenus();
@@ -531,11 +558,21 @@ function handleUnscheduledTaskListClick(event) {
 
     const taskId = taskCard.dataset.taskId;
 
+    const actionsTrigger = target.closest('.btn-unscheduled-task-actions-menu');
+    if (actionsTrigger instanceof HTMLElement) {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleUnscheduledTaskActionMenu(actionsTrigger);
+        return;
+    }
+
     if (target.closest('.btn-start-unscheduled-timer')) {
+        closeUnscheduledTaskActionMenus();
         if (globalUnscheduledTaskCallbacks.onStartTimerFromUnscheduledTask && taskId) {
             globalUnscheduledTaskCallbacks.onStartTimerFromUnscheduledTask(taskId);
         }
     } else if (target.closest('.btn-schedule-task')) {
+        closeUnscheduledTaskActionMenus();
         if (globalUnscheduledTaskCallbacks.onScheduleUnscheduledTask && taskId) {
             const taskName = taskCard.dataset.taskName || 'Task';
             const estDurationText = taskCard.dataset.taskEstDuration || 'N/A';
@@ -550,11 +587,13 @@ function handleUnscheduledTaskListClick(event) {
             }
         }
     } else if (target.closest('.btn-edit-unscheduled')) {
+        closeUnscheduledTaskActionMenus();
         if (globalUnscheduledTaskCallbacks.onEditUnscheduledTask && taskId) {
             logger.debug(`Edit button clicked for unscheduled task: ${taskId}`);
             globalUnscheduledTaskCallbacks.onEditUnscheduledTask(taskId);
         }
     } else if (target.closest('.btn-delete-unscheduled')) {
+        closeUnscheduledTaskActionMenus();
         if (globalUnscheduledTaskCallbacks.onDeleteUnscheduledTask && taskId) {
             globalUnscheduledTaskCallbacks.onDeleteUnscheduledTask(taskId);
         }
@@ -582,6 +621,11 @@ function handleUnscheduledTaskListClick(event) {
 }
 
 function handleUnscheduledTaskListKeydown(event) {
+    if (event.key === 'Escape') {
+        closeUnscheduledTaskActionMenus();
+        return;
+    }
+
     if (event.key !== 'Enter') return;
     if (!(event.target instanceof HTMLInputElement)) return;
     const form = event.target.closest('form');
@@ -821,6 +865,9 @@ export function initializePageEventListeners(appCallbacks, taskFormElement) {
             const target = /** @type {HTMLElement|null} */ (event.target);
             if (!target?.closest?.('.task-actions')) {
                 closeScheduledTaskActionMenus();
+            }
+            if (!target?.closest?.('.unscheduled-task-actions')) {
+                closeUnscheduledTaskActionMenus();
             }
             if (appCallbacks && appCallbacks.onGlobalClick) {
                 appCallbacks.onGlobalClick(event);

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -459,11 +459,11 @@ function handleScheduledTaskListClick(event) {
         return;
     }
 
-    if (target.closest('.btn-make-next')) {
+    if (target.closest('.btn-do-now')) {
         event.preventDefault();
         closeScheduledTaskActionMenus();
-        if (globalScheduledTaskCallbacks.onMakeNextTask) {
-            globalScheduledTaskCallbacks.onMakeNextTask(taskId, taskIndex);
+        if (globalScheduledTaskCallbacks.onDoNowTask) {
+            globalScheduledTaskCallbacks.onDoNowTask(taskId, taskIndex);
         }
         return;
     }

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -258,6 +258,39 @@ export function initializeTaskTypeToggle() {
 
 // --- Event Handlers ---
 
+function closeScheduledTaskActionMenus(exceptMenu = null) {
+    const taskListElement = getScheduledTaskListElement();
+    if (!taskListElement) return;
+
+    taskListElement.querySelectorAll('.task-actions-menu').forEach((menu) => {
+        if (menu === exceptMenu) return;
+        menu.hidden = true;
+        const trigger = menu.parentElement?.querySelector('.btn-task-actions-menu');
+        if (trigger instanceof HTMLElement) {
+            trigger.setAttribute('aria-expanded', 'false');
+        }
+    });
+}
+
+function toggleScheduledTaskActionMenu(trigger) {
+    const menu = trigger.parentElement?.querySelector('.task-actions-menu');
+    if (!(menu instanceof HTMLElement)) return;
+
+    const shouldOpen = menu.hidden;
+    closeScheduledTaskActionMenus(shouldOpen ? menu : null);
+    menu.hidden = !shouldOpen;
+    trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+    if (shouldOpen) {
+        menu.querySelector('[role="menuitem"]')?.focus();
+    }
+}
+
+function handleScheduledTaskListKeydown(event) {
+    if (event.key === 'Escape') {
+        closeScheduledTaskActionMenus();
+    }
+}
+
 function handleScheduledTaskListClick(event) {
     if (!globalScheduledTaskCallbacks) {
         logger.warn('handleScheduledTaskListClick: globalScheduledTaskCallbacks not initialized');
@@ -333,6 +366,14 @@ function handleScheduledTaskListClick(event) {
 
     const taskIndex = parseInt(taskIndexStr, 10);
 
+    const actionsTrigger = target.closest('.btn-task-actions-menu');
+    if (actionsTrigger instanceof HTMLElement) {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleScheduledTaskActionMenu(actionsTrigger);
+        return;
+    }
+
     if (target.closest('.checkbox')) {
         event.preventDefault();
         const visibleTaskIds = new Set(
@@ -356,6 +397,7 @@ function handleScheduledTaskListClick(event) {
     if (target.closest('.btn-edit')) {
         // "pencil" icon on view task
         event.preventDefault();
+        closeScheduledTaskActionMenus();
         if (globalScheduledTaskCallbacks.onEditTask) {
             globalScheduledTaskCallbacks.onEditTask(taskId, taskIndex);
         }
@@ -364,6 +406,7 @@ function handleScheduledTaskListClick(event) {
 
     if (target.closest('.btn-lock')) {
         event.preventDefault();
+        closeScheduledTaskActionMenus();
         if (globalScheduledTaskCallbacks.onLockTask) {
             globalScheduledTaskCallbacks.onLockTask(taskId, taskIndex);
         }
@@ -372,6 +415,7 @@ function handleScheduledTaskListClick(event) {
 
     if (target.closest('.btn-unschedule')) {
         event.preventDefault();
+        closeScheduledTaskActionMenus();
         if (globalScheduledTaskCallbacks.onUnscheduleTask) {
             globalScheduledTaskCallbacks.onUnscheduleTask(taskId, taskIndex);
         }
@@ -380,6 +424,7 @@ function handleScheduledTaskListClick(event) {
 
     if (target.closest('.btn-make-next')) {
         event.preventDefault();
+        closeScheduledTaskActionMenus();
         if (globalScheduledTaskCallbacks.onMakeNextTask) {
             globalScheduledTaskCallbacks.onMakeNextTask(taskId, taskIndex);
         }
@@ -389,6 +434,7 @@ function handleScheduledTaskListClick(event) {
     if (target.closest('.btn-delete')) {
         event.preventDefault();
         event.stopPropagation();
+        closeScheduledTaskActionMenus();
         if (globalScheduledTaskCallbacks.onDeleteTask) {
             globalScheduledTaskCallbacks.onDeleteTask(taskId, taskIndex);
         }
@@ -575,10 +621,12 @@ export function initializeScheduledTaskListEventListeners(eventCallbacks) {
     taskListElement.removeEventListener('click', handleScheduledTaskListClick);
     taskListElement.removeEventListener('submit', handleScheduledTaskListSubmit);
     taskListElement.removeEventListener('input', handleScheduledTaskListInput);
+    taskListElement.removeEventListener('keydown', handleScheduledTaskListKeydown);
     globalScheduledTaskCallbacks = eventCallbacks;
     taskListElement.addEventListener('click', handleScheduledTaskListClick);
     taskListElement.addEventListener('submit', handleScheduledTaskListSubmit);
     taskListElement.addEventListener('input', handleScheduledTaskListInput);
+    taskListElement.addEventListener('keydown', handleScheduledTaskListKeydown);
 }
 
 export function initializeUnscheduledTaskListEventListeners(callbacks) {
@@ -770,6 +818,10 @@ export function initializePageEventListeners(appCallbacks, taskFormElement) {
     document.addEventListener(
         'click',
         (event) => {
+            const target = /** @type {HTMLElement|null} */ (event.target);
+            if (!target?.closest?.('.task-actions')) {
+                closeScheduledTaskActionMenus();
+            }
             if (appCallbacks && appCallbacks.onGlobalClick) {
                 appCallbacks.onGlobalClick(event);
             }

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -258,6 +258,12 @@ export function initializeTaskTypeToggle() {
 
 // --- Event Handlers ---
 
+function setTaskActionMenuElevation(menu, isElevated) {
+    const actions = menu.parentElement;
+    actions?.classList.toggle('z-50', isElevated);
+    actions?.closest('[data-task-id]')?.classList.toggle('z-40', isElevated);
+}
+
 function closeScheduledTaskActionMenus(exceptMenu = null) {
     const taskListElement = getScheduledTaskListElement();
     if (!taskListElement) return;
@@ -265,6 +271,7 @@ function closeScheduledTaskActionMenus(exceptMenu = null) {
     taskListElement.querySelectorAll('.task-actions-menu').forEach((menu) => {
         if (menu === exceptMenu) return;
         menu.hidden = true;
+        setTaskActionMenuElevation(menu, false);
         const trigger = menu.parentElement?.querySelector('.btn-task-actions-menu');
         if (trigger instanceof HTMLElement) {
             trigger.setAttribute('aria-expanded', 'false');
@@ -279,6 +286,7 @@ function toggleScheduledTaskActionMenu(trigger) {
     const shouldOpen = menu.hidden;
     closeScheduledTaskActionMenus(shouldOpen ? menu : null);
     menu.hidden = !shouldOpen;
+    setTaskActionMenuElevation(menu, shouldOpen);
     trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
     if (shouldOpen) {
         menu.querySelector('[role="menuitem"]')?.focus();
@@ -292,6 +300,7 @@ function closeUnscheduledTaskActionMenus(exceptMenu = null) {
     taskListElement.querySelectorAll('.unscheduled-task-actions-menu').forEach((menu) => {
         if (menu === exceptMenu) return;
         menu.hidden = true;
+        setTaskActionMenuElevation(menu, false);
         const trigger = menu.parentElement?.querySelector('.btn-unscheduled-task-actions-menu');
         if (trigger instanceof HTMLElement) {
             trigger.setAttribute('aria-expanded', 'false');
@@ -306,6 +315,7 @@ function toggleUnscheduledTaskActionMenu(trigger) {
     const shouldOpen = menu.hidden;
     closeUnscheduledTaskActionMenus(shouldOpen ? menu : null);
     menu.hidden = !shouldOpen;
+    setTaskActionMenuElevation(menu, shouldOpen);
     trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
     if (shouldOpen) {
         menu.querySelector('[role="menuitem"]')?.focus();

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -867,7 +867,7 @@ export function updateTask(index, taskData) {
     return { success: true, task: tasks[index], autoRescheduledMessage: autoMessage };
 }
 
-export function makeScheduledTaskNext(taskId, startTime) {
+export function doScheduledTaskNow(taskId, startTime) {
     const taskIndex = tasks.findIndex((task) => task.id === taskId && task.type === 'scheduled');
     if (taskIndex === -1) {
         return { success: false, reason: 'Scheduled task not found.' };
@@ -875,7 +875,7 @@ export function makeScheduledTaskNext(taskId, startTime) {
 
     const task = tasks[taskIndex];
     if (task.status === 'completed') {
-        return { success: false, reason: 'Completed tasks cannot be made next.' };
+        return { success: false, reason: 'Completed tasks cannot be done now.' };
     }
 
     return updateTask(taskIndex, {

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -854,6 +854,27 @@ export function updateTask(index, taskData) {
     return { success: true, task: tasks[index], autoRescheduledMessage: autoMessage };
 }
 
+export function makeScheduledTaskNext(taskId, startTime) {
+    const taskIndex = tasks.findIndex((task) => task.id === taskId && task.type === 'scheduled');
+    if (taskIndex === -1) {
+        return { success: false, reason: 'Scheduled task not found.' };
+    }
+
+    const task = tasks[taskIndex];
+    if (task.status === 'completed') {
+        return { success: false, reason: 'Completed tasks cannot be made next.' };
+    }
+
+    return updateTask(taskIndex, {
+        description: task.description,
+        taskType: 'scheduled',
+        startTime,
+        duration: task.duration,
+        locked: task.locked,
+        category: task.category || null
+    });
+}
+
 export function updateUnscheduledTask(taskId, newData) {
     const taskIndex = tasks.findIndex((t) => t.id === taskId && t.type === 'unscheduled');
     if (taskIndex === -1) {

--- a/public/js/tasks/scheduled-handlers.js
+++ b/public/js/tasks/scheduled-handlers.js
@@ -7,6 +7,7 @@ import {
     editTask,
     deleteTask,
     unscheduleTask,
+    makeScheduledTaskNext,
     updateTask,
     confirmUpdateTaskAndReschedule,
     cancelEdit,
@@ -25,6 +26,7 @@ import {
     convertTo24HourTime,
     convertTo12HourTime,
     calculateHoursAndMinutes,
+    getCurrentTimeRounded,
     logger,
     getThemeForTask
 } from '../utils.js';
@@ -147,6 +149,58 @@ export function handleUnscheduleTask(taskId, _taskIndex) {
     }
 }
 
+export async function handleMakeNextTask(taskId, _taskIndex) {
+    const taskToMove = getTaskById(taskId);
+    if (!taskToMove || taskToMove.type !== 'scheduled') {
+        logger.warn('handleMakeNextTask for non-scheduled', taskId);
+        return;
+    }
+
+    const currentTimeDisplayElement = getCurrentTimeElement();
+    const startTime =
+        currentTimeDisplayElement && currentTimeDisplayElement.textContent
+            ? convertTo24HourTime(currentTimeDisplayElement.textContent)
+            : getCurrentTimeRounded();
+    const result = makeScheduledTaskNext(taskId, startTime);
+
+    if (
+        result.requiresConfirmation &&
+        result.confirmationType === 'RESCHEDULE_UPDATE' &&
+        result.taskIndex !== undefined &&
+        result.updatedTaskObject
+    ) {
+        const userConfirmed = await askConfirmation(
+            result.reason,
+            { ok: 'Yes, reschedule', cancel: 'No, cancel' },
+            getThemeForTask(taskToMove)
+        );
+        if (!userConfirmed) {
+            showToast('Schedule unchanged.', { theme: 'teal' });
+            refreshUI();
+            return;
+        }
+
+        const confirmedResult = confirmUpdateTaskAndReschedule({
+            taskIndex: result.taskIndex,
+            updatedTaskObject: result.updatedTaskObject
+        });
+        if (confirmedResult.success) {
+            onTaskEdited({ task: confirmedResult.task });
+        } else if (confirmedResult.reason) {
+            showAlert(confirmedResult.reason, getThemeForTask(taskToMove));
+            refreshUI();
+        }
+        return;
+    }
+
+    if (result.success) {
+        onTaskEdited({ task: result.task });
+    } else if (result.reason) {
+        showAlert(result.reason, getThemeForTask(taskToMove));
+        refreshUI();
+    }
+}
+
 export async function handleSaveTaskEdit(taskId, formElement, _taskIndex) {
     const taskData = extractTaskFormData(formElement);
     if (!taskData) {
@@ -242,6 +296,7 @@ export function createScheduledTaskCallbacks() {
         onEditTask: handleEditTask,
         onDeleteTask: handleDeleteTask,
         onUnscheduleTask: handleUnscheduleTask,
+        onMakeNextTask: handleMakeNextTask,
         onSaveTaskEdit: handleSaveTaskEdit,
         onCancelEdit: handleCancelEdit,
         onGapClick: handleGapClick

--- a/public/js/tasks/scheduled-handlers.js
+++ b/public/js/tasks/scheduled-handlers.js
@@ -7,7 +7,7 @@ import {
     editTask,
     deleteTask,
     unscheduleTask,
-    makeScheduledTaskNext,
+    doScheduledTaskNow,
     updateTask,
     confirmUpdateTaskAndReschedule,
     cancelEdit,
@@ -149,10 +149,10 @@ export function handleUnscheduleTask(taskId, _taskIndex) {
     }
 }
 
-export async function handleMakeNextTask(taskId, _taskIndex) {
+export async function handleDoNowTask(taskId, _taskIndex) {
     const taskToMove = getTaskById(taskId);
     if (!taskToMove || taskToMove.type !== 'scheduled') {
-        logger.warn('handleMakeNextTask for non-scheduled', taskId);
+        logger.warn('handleDoNowTask for non-scheduled', taskId);
         return;
     }
 
@@ -161,7 +161,7 @@ export async function handleMakeNextTask(taskId, _taskIndex) {
         currentTimeDisplayElement && currentTimeDisplayElement.textContent
             ? convertTo24HourTime(currentTimeDisplayElement.textContent)
             : getCurrentTimeRounded();
-    const result = makeScheduledTaskNext(taskId, startTime);
+    const result = doScheduledTaskNow(taskId, startTime);
 
     if (
         result.requiresConfirmation &&
@@ -296,7 +296,7 @@ export function createScheduledTaskCallbacks() {
         onEditTask: handleEditTask,
         onDeleteTask: handleDeleteTask,
         onUnscheduleTask: handleUnscheduleTask,
-        onMakeNextTask: handleMakeNextTask,
+        onDoNowTask: handleDoNowTask,
         onSaveTaskEdit: handleSaveTaskEdit,
         onCancelEdit: handleCancelEdit,
         onGapClick: handleGapClick

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -175,7 +175,7 @@ export function renderViewTaskHTML(task, index, isActiveTask, canDoNow = false) 
                 <div class="task-actions-menu-group ${canDoNow ? 'mt-1.5 pt-1.5 border-t border-slate-700' : ''}">
                     <button class="task-actions-menu-item btn-lock grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
                         <i class="fa-solid ${task.locked ? 'fa-lock text-rose-400' : 'fa-lock-open text-slate-400'} text-center" aria-hidden="true"></i>
-                        <span>${task.locked ? 'Unlock task' : 'Lock task'}</span>
+                        <span>${task.locked ? 'Allow reschedule' : 'Lock time'}</span>
                     </button>
                     <button class="task-actions-menu-item btn-unschedule grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
                         <i class="fa-regular fa-calendar-xmark text-slate-400 text-center" aria-hidden="true"></i>

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -134,6 +134,8 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
     const durationText = calculateHoursAndMinutes(task.duration);
     const actionMenuExpanded = task.confirmingDelete ? 'true' : 'false';
     const actionMenuHidden = task.confirmingDelete ? '' : ' hidden';
+    const openMenuTaskClass = task.confirmingDelete ? ' z-40' : '';
+    const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
 
     const makeNextMenuItem = canMakeNext
         ? `<div class="task-actions-menu-group">
@@ -144,7 +146,7 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
             </div>`
         : '';
 
-    return `<div id="view-task-${task.id}" class="flex flex-col sm:flex-row sm:items-center justify-between p-2 sm:p-3 rounded-lg border border-slate-700 bg-slate-800 bg-opacity-60 hover:bg-opacity-80 transition-all shadow-md relative gap-2 sm:gap-0" data-task-index="${index}" data-task-id="${task.id}">
+    return `<div id="view-task-${task.id}" class="flex flex-col sm:flex-row sm:items-center justify-between p-2 sm:p-3 rounded-lg border border-slate-700 bg-slate-800 bg-opacity-60 hover:bg-opacity-80 transition-all shadow-md relative gap-2 sm:gap-0${openMenuTaskClass}" data-task-index="${index}" data-task-id="${task.id}">
         <div class="celebration-container hidden">
             <span class="celebration-emoji">🎉</span>
             <span class="celebration-emoji">🌟</span>
@@ -164,7 +166,7 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
                 <div class="${isCompleted ? 'text-white' : activeTaskColorClass} text-xs sm:text-sm mt-0.5">${convertTo12HourTime(displayStartTime)} &ndash; ${convertTo12HourTime(displayEndTime)} (${durationText})</div>
             </div>
         </div>
-        <div class="task-actions relative ml-auto -mt-1 -mr-1">
+        <div class="task-actions relative ml-auto -mt-1 -mr-1${openMenuActionsClass}">
             <button class="btn-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-teal-400 transition-colors" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="${actionMenuExpanded}">
                 <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -114,10 +114,10 @@ export function renderEditTaskHTML(task, index) {
  * @param {Object} task - The task object
  * @param {number} index - The task index
  * @param {boolean} isActiveTask - Whether this is the active task
- * @param {boolean} canMakeNext - Whether to show the make-next action
+ * @param {boolean} canDoNow - Whether to show the do-now action
  * @returns {string} HTML string for the task view
  */
-export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = false) {
+export function renderViewTaskHTML(task, index, isActiveTask, canDoNow = false) {
     const isCompleted = task.status === 'completed';
     const checkboxDisabled = isCompleted || !isActiveTask;
     let activeTaskColorClass = 'text-slate-200';
@@ -137,11 +137,11 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
     const openMenuTaskClass = task.confirmingDelete ? ' z-40' : '';
     const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
 
-    const makeNextMenuItem = canMakeNext
+    const doNowMenuItem = canDoNow
         ? `<div class="task-actions-menu-group">
-                <button class="task-actions-menu-item task-actions-menu-item-primary btn-make-next grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-teal-400/10 hover:bg-teal-400/20 text-teal-300 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
-                    <i class="fa-solid fa-forward-step text-teal-400 text-center" aria-hidden="true"></i>
-                    <span>Make this next</span>
+                <button class="task-actions-menu-item task-actions-menu-item-primary btn-do-now grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-teal-400/10 hover:bg-teal-400/20 text-teal-300 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
+                    <i class="fa-solid fa-bolt text-teal-400 text-center" aria-hidden="true"></i>
+                    <span>Do now</span>
                 </button>
             </div>`
         : '';
@@ -171,8 +171,8 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
                 <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>
             <div class="task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions"${actionMenuHidden}>
-                ${makeNextMenuItem}
-                <div class="task-actions-menu-group ${canMakeNext ? 'mt-1.5 pt-1.5 border-t border-slate-700' : ''}">
+                ${doNowMenuItem}
+                <div class="task-actions-menu-group ${canDoNow ? 'mt-1.5 pt-1.5 border-t border-slate-700' : ''}">
                     <button class="task-actions-menu-item btn-lock grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
                         <i class="fa-solid ${task.locked ? 'fa-lock text-rose-400' : 'fa-lock-open text-slate-400'} text-center" aria-hidden="true"></i>
                         <span>${task.locked ? 'Unlock task' : 'Lock task'}</span>

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -136,6 +136,12 @@ export function renderViewTaskHTML(task, index, isActiveTask, canDoNow = false) 
     const actionMenuHidden = task.confirmingDelete ? '' : ' hidden';
     const openMenuTaskClass = task.confirmingDelete ? ' z-40' : '';
     const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
+    const lockedBadge = task.locked
+        ? `<span class="scheduled-lock-badge inline-flex items-center gap-1 rounded-full border border-rose-400/40 bg-rose-400/10 px-2 py-0.5 text-[11px] font-medium tracking-normal text-rose-200" title="Time locked">
+                <i class="fa-solid fa-lock text-[10px] text-rose-300" aria-hidden="true"></i>
+                <span>Fixed time</span>
+            </span>`
+        : '';
 
     const doNowMenuItem = canDoNow
         ? `<div class="task-actions-menu-group">
@@ -162,7 +168,7 @@ export function renderViewTaskHTML(task, index, isActiveTask, canDoNow = false) 
             </label>
             <input type="checkbox" id="task-checkbox-${task.id}" class="hidden">
             <div class="${isCompleted ? 'line-through opacity-70' : ''} ${isActiveTask && !isCompleted && task.type === 'scheduled' ? '' : isCompleted ? '' : 'opacity-60'} min-w-0 flex-1">
-                <div class="${isCompleted ? 'text-white font-medium' : `${activeTaskColorClass} font-medium`} text-sm sm:text-base break-words flex items-center gap-2 flex-wrap">${task.description} ${renderCategoryBadge(task.category)}</div>
+                <div class="${isCompleted ? 'text-white font-medium' : `${activeTaskColorClass} font-medium`} text-sm sm:text-base break-words flex items-center gap-2 flex-wrap">${task.description} ${renderCategoryBadge(task.category)} ${lockedBadge}</div>
                 <div class="${isCompleted ? 'text-white' : activeTaskColorClass} text-xs sm:text-sm mt-0.5">${convertTo12HourTime(displayStartTime)} &ndash; ${convertTo12HourTime(displayEndTime)} (${durationText})</div>
             </div>
         </div>

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -137,9 +137,8 @@ export function renderViewTaskHTML(task, index, isActiveTask, canDoNow = false) 
     const openMenuTaskClass = task.confirmingDelete ? ' z-40' : '';
     const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
     const lockedBadge = task.locked
-        ? `<span class="scheduled-lock-badge inline-flex items-center gap-1 rounded-full border border-rose-400/40 bg-rose-400/10 px-2 py-0.5 text-[11px] font-medium tracking-normal text-rose-200" title="Time locked">
-                <i class="fa-solid fa-lock text-[10px] text-rose-300" aria-hidden="true"></i>
-                <span>Fixed time</span>
+        ? `<span class="scheduled-lock-badge inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-rose-300/90 align-middle" title="Fixed time" aria-label="Fixed time">
+                <i class="fa-solid fa-lock text-[11px]" aria-hidden="true"></i>
             </span>`
         : '';
 

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -132,6 +132,8 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
         ? extractTimeFromDateTime(new Date(task.endDateTime))
         : '';
     const durationText = calculateHoursAndMinutes(task.duration);
+    const actionMenuExpanded = task.confirmingDelete ? 'true' : 'false';
+    const actionMenuHidden = task.confirmingDelete ? '' : ' hidden';
 
     const makeNextMenuItem = canMakeNext
         ? `<div class="task-actions-menu-group">
@@ -163,10 +165,10 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
             </div>
         </div>
         <div class="task-actions relative ml-auto -mt-1 -mr-1">
-            <button class="btn-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-teal-400 transition-colors" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="false">
+            <button class="btn-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-teal-400 transition-colors" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="${actionMenuExpanded}">
                 <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>
-            <div class="task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions" hidden>
+            <div class="task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions"${actionMenuHidden}>
                 ${makeNextMenuItem}
                 <div class="task-actions-menu-group ${canMakeNext ? 'mt-1.5 pt-1.5 border-t border-slate-700' : ''}">
                     <button class="task-actions-menu-item btn-lock grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -114,9 +114,10 @@ export function renderEditTaskHTML(task, index) {
  * @param {Object} task - The task object
  * @param {number} index - The task index
  * @param {boolean} isActiveTask - Whether this is the active task
+ * @param {boolean} canMakeNext - Whether to show the make-next action
  * @returns {string} HTML string for the task view
  */
-export function renderViewTaskHTML(task, index, isActiveTask) {
+export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = false) {
     const isCompleted = task.status === 'completed';
     const checkboxDisabled = isCompleted || !isActiveTask;
     let activeTaskColorClass = 'text-slate-200';
@@ -153,6 +154,13 @@ export function renderViewTaskHTML(task, index, isActiveTask) {
             </div>
         </div>
         <div class="flex space-x-1 ml-auto">
+            ${
+                canMakeNext
+                    ? `<button class="text-slate-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-slate-700 rounded-lg transition-colors btn-make-next" title="Make next" data-task-id="${task.id}" data-task-index="${index}">
+                <i class="fa-solid fa-forward-step text-sm sm:text-base"></i>
+            </button>`
+                    : ''
+            }
             <button class="text-slate-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-slate-700 rounded-lg transition-colors btn-lock" title="${task.locked ? 'Unlock task' : 'Lock task'}" data-task-id="${task.id}" data-task-index="${index}">
                 <i class="fa-solid ${task.locked ? 'fa-lock text-rose-400' : 'fa-lock-open'} text-sm sm:text-base"></i>
             </button>
@@ -290,7 +298,12 @@ export function renderTasks(
         }
         html += task.editing
             ? renderEditTaskHTML(task, originalIndex)
-            : renderViewTaskHTML(task, originalIndex, isActiveTask);
+            : renderViewTaskHTML(
+                  task,
+                  originalIndex,
+                  isActiveTask,
+                  task.status !== 'completed' && !isActiveTask
+              );
 
         const gap = gapAfterTask.get(task.id);
         if (gap) {

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -133,6 +133,15 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
         : '';
     const durationText = calculateHoursAndMinutes(task.duration);
 
+    const makeNextMenuItem = canMakeNext
+        ? `<div class="task-actions-menu-group">
+                <button class="task-actions-menu-item task-actions-menu-item-primary btn-make-next grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-teal-400/10 hover:bg-teal-400/20 text-teal-300 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
+                    <i class="fa-solid fa-forward-step text-teal-400 text-center" aria-hidden="true"></i>
+                    <span>Make this next</span>
+                </button>
+            </div>`
+        : '';
+
     return `<div id="view-task-${task.id}" class="flex flex-col sm:flex-row sm:items-center justify-between p-2 sm:p-3 rounded-lg border border-slate-700 bg-slate-800 bg-opacity-60 hover:bg-opacity-80 transition-all shadow-md relative gap-2 sm:gap-0" data-task-index="${index}" data-task-id="${task.id}">
         <div class="celebration-container hidden">
             <span class="celebration-emoji">🎉</span>
@@ -153,26 +162,33 @@ export function renderViewTaskHTML(task, index, isActiveTask, canMakeNext = fals
                 <div class="${isCompleted ? 'text-white' : activeTaskColorClass} text-xs sm:text-sm mt-0.5">${convertTo12HourTime(displayStartTime)} &ndash; ${convertTo12HourTime(displayEndTime)} (${durationText})</div>
             </div>
         </div>
-        <div class="flex space-x-1 ml-auto">
-            ${
-                canMakeNext
-                    ? `<button class="text-slate-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-slate-700 rounded-lg transition-colors btn-make-next" title="Make next" data-task-id="${task.id}" data-task-index="${index}">
-                <i class="fa-solid fa-forward-step text-sm sm:text-base"></i>
-            </button>`
-                    : ''
-            }
-            <button class="text-slate-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-slate-700 rounded-lg transition-colors btn-lock" title="${task.locked ? 'Unlock task' : 'Lock task'}" data-task-id="${task.id}" data-task-index="${index}">
-                <i class="fa-solid ${task.locked ? 'fa-lock text-rose-400' : 'fa-lock-open'} text-sm sm:text-base"></i>
+        <div class="task-actions relative ml-auto -mt-1 -mr-1">
+            <button class="btn-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-teal-400 transition-colors" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="false">
+                <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>
-            <button class="text-slate-400 hover:text-indigo-400 p-1.5 sm:p-2 hover:bg-slate-700 rounded-lg transition-colors btn-unschedule" title="Unschedule task" data-task-id="${task.id}" data-task-index="${index}">
-                <i class="fa-regular fa-calendar-xmark text-sm sm:text-base"></i>
-            </button>
-            <button class="text-slate-400 hover:text-amber-300 p-1.5 sm:p-2 hover:bg-slate-700 rounded-lg transition-colors btn-edit" title="Edit task">
-                <i class="fa-solid fa-pen text-sm sm:text-base"></i>
-            </button>
-            <button class="${task.confirmingDelete ? 'text-rose-400' : 'text-slate-400 hover:text-rose-400 hover:bg-slate-700 rounded-lg transition-colors'} btn-delete p-1.5 sm:p-2" title="Delete task">
-                <i class="fa-regular ${task.confirmingDelete ? 'fa-check-circle' : 'fa-trash-can'} text-sm sm:text-base"></i>
-            </button>
+            <div class="task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions" hidden>
+                ${makeNextMenuItem}
+                <div class="task-actions-menu-group ${canMakeNext ? 'mt-1.5 pt-1.5 border-t border-slate-700' : ''}">
+                    <button class="task-actions-menu-item btn-lock grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
+                        <i class="fa-solid ${task.locked ? 'fa-lock text-rose-400' : 'fa-lock-open text-slate-400'} text-center" aria-hidden="true"></i>
+                        <span>${task.locked ? 'Unlock task' : 'Lock task'}</span>
+                    </button>
+                    <button class="task-actions-menu-item btn-unschedule grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
+                        <i class="fa-regular fa-calendar-xmark text-slate-400 text-center" aria-hidden="true"></i>
+                        <span>Unschedule</span>
+                    </button>
+                    <button class="task-actions-menu-item btn-edit grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-teal-400" type="button" role="menuitem">
+                        <i class="fa-solid fa-pen text-slate-400 text-center" aria-hidden="true"></i>
+                        <span>Edit task</span>
+                    </button>
+                </div>
+                <div class="task-actions-menu-group mt-1.5 pt-1.5 border-t border-slate-700">
+                    <button class="task-actions-menu-item task-actions-menu-item-danger btn-delete grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-rose-300 hover:bg-rose-400/10 text-sm text-left focus:outline-none focus:ring-2 focus:ring-rose-400" type="button" role="menuitem">
+                        <i class="fa-regular ${task.confirmingDelete ? 'fa-check-circle' : 'fa-trash-can'} text-rose-400 text-center" aria-hidden="true"></i>
+                        <span>${task.confirmingDelete ? 'Confirm delete' : 'Delete task'}</span>
+                    </button>
+                </div>
+            </div>
         </div>
     </div>`;
 }

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -137,7 +137,7 @@ export function renderViewTaskHTML(task, index, isActiveTask, canDoNow = false) 
     const openMenuTaskClass = task.confirmingDelete ? ' z-40' : '';
     const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
     const lockedBadge = task.locked
-        ? `<span class="scheduled-lock-badge inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-rose-300/90 align-middle" title="Fixed time" aria-label="Fixed time">
+        ? `<span class="scheduled-lock-badge inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-rose-300/90 align-middle" title="Time is locked to prevent auto-rescheduling." aria-label="Time is locked to prevent auto-rescheduling.">
                 <i class="fa-solid fa-lock text-[11px]" aria-hidden="true"></i>
             </span>`
         : '';

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -65,9 +65,10 @@ function getDurationText(estDuration) {
 function renderUnscheduledTaskActionsMenu(task, disabledAttr, disabledButtonClasses) {
     const actionMenuExpanded = task.confirmingDelete ? 'true' : 'false';
     const actionMenuHidden = task.confirmingDelete ? '' : ' hidden';
+    const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
 
     return `
-        <div class="unscheduled-task-actions relative ml-auto -mt-1 -mr-1">
+        <div class="unscheduled-task-actions relative ml-auto -mt-1 -mr-1${openMenuActionsClass}">
             <button class="btn-unscheduled-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition-colors${disabledButtonClasses}" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="${actionMenuExpanded}" ${disabledAttr}>
                 <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>
@@ -247,7 +248,7 @@ function createUnscheduledTaskCard(task) {
     const durationText = getDurationText(task.estDuration);
 
     const taskCard = document.createElement('div');
-    taskCard.className = `task-card bg-gray-800 bg-opacity-60 ${priorityClasses.border} p-2 sm:p-4 rounded-lg shadow-lg flex flex-col gap-2 ${isLinkedToRunningTimer ? 'opacity-70 pointer-events-none' : ''}`;
+    taskCard.className = `task-card relative bg-gray-800 bg-opacity-60 ${priorityClasses.border} p-2 sm:p-4 rounded-lg shadow-lg flex flex-col gap-2 ${task.confirmingDelete ? 'z-40 ' : ''}${isLinkedToRunningTimer ? 'opacity-70 pointer-events-none' : ''}`;
     taskCard.dataset.taskId = task.id;
     taskCard.dataset.taskName = task.description;
     taskCard.dataset.taskEstDuration = durationText;

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -63,12 +63,15 @@ function getDurationText(estDuration) {
 }
 
 function renderUnscheduledTaskActionsMenu(task, disabledAttr, disabledButtonClasses) {
+    const actionMenuExpanded = task.confirmingDelete ? 'true' : 'false';
+    const actionMenuHidden = task.confirmingDelete ? '' : ' hidden';
+
     return `
         <div class="unscheduled-task-actions relative ml-auto -mt-1 -mr-1">
-            <button class="btn-unscheduled-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition-colors${disabledButtonClasses}" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="false" ${disabledAttr}>
+            <button class="btn-unscheduled-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition-colors${disabledButtonClasses}" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="${actionMenuExpanded}" ${disabledAttr}>
                 <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>
-            <div class="unscheduled-task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions" hidden>
+            <div class="unscheduled-task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions"${actionMenuHidden}>
                 <div class="unscheduled-task-actions-menu-group">
                     <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-primary btn-start-unscheduled-timer grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-indigo-400/10 hover:bg-indigo-400/20 text-indigo-200 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
                         <i class="fa-solid fa-stopwatch text-indigo-300 text-center" aria-hidden="true"></i>

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -62,6 +62,40 @@ function getDurationText(estDuration) {
     return calculateHoursAndMinutes(estDuration, true).text;
 }
 
+function renderUnscheduledTaskActionsMenu(task, disabledAttr, disabledButtonClasses) {
+    return `
+        <div class="unscheduled-task-actions relative ml-auto -mt-1 -mr-1">
+            <button class="btn-unscheduled-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition-colors${disabledButtonClasses}" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="false" ${disabledAttr}>
+                <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
+            </button>
+            <div class="unscheduled-task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions" hidden>
+                <div class="unscheduled-task-actions-menu-group">
+                    <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-primary btn-start-unscheduled-timer grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-indigo-400/10 hover:bg-indigo-400/20 text-indigo-200 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                        <i class="fa-solid fa-stopwatch text-indigo-300 text-center" aria-hidden="true"></i>
+                        <span>Start timer</span>
+                    </button>
+                </div>
+                <div class="unscheduled-task-actions-menu-group mt-1.5 pt-1.5 border-t border-slate-700">
+                    <button class="unscheduled-task-actions-menu-item btn-schedule-task grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                        <i class="fa-regular fa-calendar-plus text-slate-400 text-center" aria-hidden="true"></i>
+                        <span>Schedule</span>
+                    </button>
+                    <button class="unscheduled-task-actions-menu-item btn-edit-unscheduled grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                        <i class="fa-solid fa-pen text-slate-400 text-center" aria-hidden="true"></i>
+                        <span>Edit task</span>
+                    </button>
+                </div>
+                <div class="unscheduled-task-actions-menu-group mt-1.5 pt-1.5 border-t border-slate-700">
+                    <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-danger btn-delete-unscheduled grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-rose-300 hover:bg-rose-400/10 text-sm text-left focus:outline-none focus:ring-2 focus:ring-rose-400${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                        <i class="fa-regular ${task.confirmingDelete ? 'fa-check-circle' : 'fa-trash-can'} text-rose-400 text-center" aria-hidden="true"></i>
+                        <span>${task.confirmingDelete ? 'Confirm delete' : 'Delete task'}</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
 /**
  * Creates the display view HTML for a task card
  * @param {Object} task - The task object
@@ -102,20 +136,7 @@ function createTaskDisplayHTML(task, priorityClasses, durationText, isCompleted)
                 </div>
             </div>
         </div>
-        <div class="flex space-x-1 ml-auto">
-            <button class="text-gray-400 hover:text-sky-300 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-start-unscheduled-timer${disabledButtonClasses}" title="Start timer from task" data-task-id="${task.id}" ${disabledAttr}>
-                <i class="fa-solid fa-stopwatch text-sm sm:text-base"></i>
-            </button>
-            <button class="text-gray-400 hover:text-teal-400 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-schedule-task${disabledButtonClasses}" title="Schedule task" data-task-id="${task.id}" ${disabledAttr}>
-                <i class="fa-regular fa-calendar-plus text-sm sm:text-base"></i>
-            </button>
-            <button class="text-gray-400 hover:text-amber-300 p-1.5 sm:p-2 hover:bg-gray-700 rounded-lg transition-colors btn-edit-unscheduled${disabledButtonClasses}" title="Edit task" data-task-id="${task.id}" ${disabledAttr}>
-                <i class="fa-solid fa-pen text-sm sm:text-base"></i>
-            </button>
-            <button class="${task.confirmingDelete ? 'text-rose-400' : 'text-gray-400 hover:text-rose-500 hover:bg-gray-700 rounded-lg transition-colors'} btn-delete-unscheduled p-1.5 sm:p-2${disabledButtonClasses}" title="Delete task" data-task-id="${task.id}" ${disabledAttr}>
-                <i class="fa-regular ${task.confirmingDelete ? 'fa-check-circle' : 'fa-trash-can'} text-sm sm:text-base"></i>
-            </button>
-        </div>
+        ${renderUnscheduledTaskActionsMenu(task, disabledAttr, disabledButtonClasses)}
     `;
 }
 

--- a/scripts/playwright_preview_smoke.py
+++ b/scripts/playwright_preview_smoke.py
@@ -742,6 +742,7 @@ def stop_activity_timer(
 
 
 def start_timer_from_unscheduled_task(page: Any, task_id: str, expected_description: str) -> None:
+    open_unscheduled_task_actions_menu(page, task_id)
     page.locator(f'.task-card[data-task-id="{task_id}"] .btn-start-unscheduled-timer').click()
     wait_for_running_timer_ui(page, expected_description)
 
@@ -967,6 +968,19 @@ def dismiss_open_modals(page: Any) -> None:
         if locator.count() and locator.first.is_visible():
             locator.first.click(force=True)
             page.wait_for_timeout(100)
+
+
+def cancel_open_confirm_modal(page: Any, *, timeout_ms: int = 1500) -> None:
+    confirm_modal = page.locator("#custom-confirm-modal")
+    cancel_button = page.locator("#cancel-custom-confirm-modal")
+    if confirm_modal.count():
+        try:
+            confirm_modal.first.wait_for(state="visible", timeout=timeout_ms)
+        except Exception:
+            return
+    if confirm_modal.count() and confirm_modal.first.is_visible() and cancel_button.count():
+        cancel_button.first.click(force=True)
+        page.wait_for_timeout(100)
 
 
 def request_manual_sync(page: Any) -> None:
@@ -1453,6 +1467,7 @@ def add_unscheduled_task(
     priority: str = "medium",
     category: str | None = None,
 ) -> None:
+    cancel_open_confirm_modal(page)
     page.locator("#unscheduled").check()
     fill_locator_value(
         page,
@@ -1527,6 +1542,7 @@ def open_scheduled_edit_form(
 
         button_locator = page.locator(button_selector)
         try:
+            open_scheduled_task_actions_menu(page, task_id)
             button_locator.scroll_into_view_if_needed()
             button_locator.click()
             form_locator.wait_for(state="visible", timeout=form_timeout_ms)
@@ -1537,6 +1553,28 @@ def open_scheduled_edit_form(
                 page.wait_for_timeout(retry_delay_ms)
 
     raise TimeoutError(f"Timed out opening scheduled edit form for {task_id}: {last_error}")
+
+
+def open_scheduled_task_actions_menu(page: Any, task_id: str) -> None:
+    task_selector = f'[data-task-id="{task_id}"]'
+    menu = page.locator(f"{task_selector} .task-actions-menu").first
+    if menu.is_visible():
+        return
+    trigger = page.locator(f"{task_selector} .btn-task-actions-menu").first
+    trigger.scroll_into_view_if_needed()
+    trigger.click()
+    menu.wait_for(state="visible", timeout=5000)
+
+
+def open_unscheduled_task_actions_menu(page: Any, task_id: str) -> None:
+    task_selector = f'.task-card[data-task-id="{task_id}"]'
+    menu = page.locator(f"{task_selector} .unscheduled-task-actions-menu").first
+    if menu.is_visible():
+        return
+    trigger = page.locator(f"{task_selector} .btn-unscheduled-task-actions-menu").first
+    trigger.scroll_into_view_if_needed()
+    trigger.click()
+    menu.wait_for(state="visible", timeout=5000)
 
 
 def get_unscheduled_delete_state(page: Any, task_id: str) -> str:
@@ -1561,6 +1599,7 @@ def delete_unscheduled_task_via_ui(
 ) -> None:
     button_selector = f'.task-card[data-task-id="{task_id}"] .btn-delete-unscheduled'
     deadline = time.time() + timeout_s
+    open_unscheduled_task_actions_menu(page, task_id)
     page.locator(button_selector).click()
 
     state_after_first_click = wait_until(
@@ -1575,8 +1614,12 @@ def delete_unscheduled_task_via_ui(
     )
     if state_after_first_click == "deleted":
         return
+    page.locator(
+        f'.task-card[data-task-id="{task_id}"] .unscheduled-task-actions-menu'
+    ).wait_for(state="visible", timeout=5000)
 
     while time.time() < deadline:
+        open_unscheduled_task_actions_menu(page, task_id)
         page.locator(button_selector).click()
         state = wait_until(
             lambda: (
@@ -1600,6 +1643,7 @@ def arm_unscheduled_delete_confirm(
     page: Any, task_id: str, *, timeout_s: float = 10.0, interval_s: float = 0.2
 ) -> None:
     button_selector = f'.task-card[data-task-id="{task_id}"] .btn-delete-unscheduled'
+    open_unscheduled_task_actions_menu(page, task_id)
     page.locator(button_selector).click()
     state = wait_until(
         lambda: (
@@ -1613,6 +1657,9 @@ def arm_unscheduled_delete_confirm(
     )
     if state != "confirming":
         raise TimeoutError(f"Timed out arming unscheduled delete confirmation for {task_id}")
+    page.locator(
+        f'.task-card[data-task-id="{task_id}"] .unscheduled-task-actions-menu'
+    ).wait_for(state="visible", timeout=5000)
 
 
 def complete_scheduled_task_via_ui(page: Any, task_id: str) -> None:
@@ -2641,6 +2688,7 @@ def run_smoke(
                     "Playwright scheduled task edited"
                 )
                 page.locator(edit_form_selector).evaluate("(form) => form.requestSubmit()")
+                cancel_open_confirm_modal(page)
                 wait_until(
                     lambda: any(
                         doc.get("id") == scheduled_doc["id"]
@@ -2993,6 +3041,7 @@ def run_smoke(
                 page.locator(scheduled_edit_form_selector).evaluate(
                     "(form) => form.requestSubmit()"
                 )
+                cancel_open_confirm_modal(page)
                 page.locator(scheduled_edit_form_selector).wait_for(
                     state="hidden", timeout=10000
                 )
@@ -3005,6 +3054,7 @@ def run_smoke(
                 unscheduled_card_selector = (
                     f'.task-card[data-task-id="{unscheduled_taxonomy_doc["id"]}"]'
                 )
+                open_unscheduled_task_actions_menu(page, unscheduled_taxonomy_doc["id"])
                 page.locator(f"{unscheduled_card_selector} .btn-edit-unscheduled").click()
                 page.locator(
                     f'{unscheduled_card_selector} select[name="inline-edit-category"]'

--- a/test_functional.py
+++ b/test_functional.py
@@ -57,6 +57,44 @@ def dismiss_modals(page):
             page.locator("#ok-custom-alert-modal").click()
             page.wait_for_timeout(300)
 
+def open_scheduled_action_menu(page, index=0):
+    """Open the action menu for a scheduled task by visual order."""
+    task = page.locator("#scheduled-task-list > [data-task-id]").nth(index)
+    menu = task.locator(".task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
+def click_scheduled_action(page, index, selector):
+    task = open_scheduled_action_menu(page, index)
+    task.locator(selector).evaluate("el => el.click()")
+
+def open_unscheduled_action_menu(page, index=0):
+    """Open the action menu for an unscheduled task by visual order."""
+    task = page.locator("#unscheduled-task-list .task-card").nth(index)
+    menu = task.locator(".unscheduled-task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-unscheduled-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
+def click_unscheduled_action(page, index, selector):
+    task = open_unscheduled_action_menu(page, index)
+    task.locator(selector).evaluate("el => el.click()")
+
+def open_unscheduled_action_menu_for_text(page, text):
+    """Open the action menu for the unscheduled task matching visible text."""
+    task = page.locator("#unscheduled-task-list .task-card").filter(has_text=text).first
+    menu = task.locator(".unscheduled-task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-unscheduled-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)
     page = browser.new_page(viewport={"width": 1280, "height": 900})
@@ -182,13 +220,13 @@ with sync_playwright() as p:
     delete_buttons = page.locator("#scheduled-task-list .btn-delete")
     del_count = delete_buttons.count()
     if del_count >= 2:
-        delete_buttons.nth(1).click()
+        click_scheduled_action(page, 1, ".btn-delete")
         page.wait_for_timeout(300)
         screenshot(page, "05a_delete_confirm_state")
 
         delete_buttons_after = page.locator("#scheduled-task-list .btn-delete")
         if delete_buttons_after.count() >= 2:
-            delete_buttons_after.nth(1).click()
+            click_scheduled_action(page, 1, ".btn-delete")
             page.wait_for_timeout(500)
 
         scheduled_tasks_after = page.locator("#scheduled-task-list > [data-task-id]")
@@ -206,12 +244,21 @@ with sync_playwright() as p:
     initial_unsched_count = page.locator("#unscheduled-task-list .task-card").count()
 
     if unsched_delete_buttons.count() >= 1:
-        unsched_delete_buttons.nth(0).click()
-        page.wait_for_timeout(300)
-        unsched_delete_buttons_after = page.locator("#unscheduled-task-list .btn-delete-unscheduled")
-        if unsched_delete_buttons_after.count() >= 1:
-            unsched_delete_buttons_after.nth(0).click()
-            page.wait_for_timeout(500)
+        open_unscheduled_action_menu_for_text(page, "Fix login bug").locator(
+            ".btn-delete-unscheduled"
+        ).evaluate("el => el.click()")
+        confirm_delete = page.get_by_text("Confirm delete").first
+        try:
+            confirm_delete.wait_for(state="visible", timeout=5000)
+        except Exception:
+            page.wait_for_timeout(300)
+        confirming_task = open_unscheduled_action_menu_for_text(page, "Fix login bug")
+        if "Confirm delete" in (confirming_task.text_content() or ""):
+            confirming_task.locator(".btn-delete-unscheduled").evaluate("el => el.click()")
+            page.wait_for_function(
+                f"document.querySelectorAll('#unscheduled-task-list .task-card').length < {initial_unsched_count}",
+                timeout=5000,
+            )
             dismiss_modals(page)
 
         final_unsched_count = page.locator("#unscheduled-task-list .task-card").count()

--- a/test_overlap_warnings.py
+++ b/test_overlap_warnings.py
@@ -143,6 +143,44 @@ def add_unscheduled_task(page, description, hours, minutes, priority="medium"):
     page.wait_for_timeout(500)
     dismiss_modals(page)
 
+def open_scheduled_action_menu(page, index=0):
+    """Open the action menu for a scheduled task by visual order."""
+    task = page.locator("#scheduled-task-list > [data-task-id]").nth(index)
+    menu = task.locator(".task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
+def click_scheduled_action(page, index, selector):
+    task = open_scheduled_action_menu(page, index)
+    task.locator(selector).evaluate("el => el.click()")
+
+def open_unscheduled_action_menu(page, index=0):
+    """Open the action menu for an unscheduled task by visual order."""
+    task = page.locator("#unscheduled-task-list .task-card").nth(index)
+    menu = task.locator(".unscheduled-task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-unscheduled-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
+def click_unscheduled_action(page, index, selector):
+    task = open_unscheduled_action_menu(page, index)
+    task.locator(selector).evaluate("el => el.click()")
+
+def open_unscheduled_action_menu_for_text(page, text):
+    """Open the action menu for the unscheduled task matching visible text."""
+    task = page.locator("#unscheduled-task-list .task-card").filter(has_text=text).first
+    menu = task.locator(".unscheduled-task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-unscheduled-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
 
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)
@@ -449,7 +487,7 @@ with sync_playwright() as p:
     print("\nTEST 11: Edit form shows end-time hint", flush=True)
     edit_buttons = page.locator("#scheduled-task-list .btn-edit")
     if edit_buttons.count() >= 1:
-        edit_buttons.nth(0).click()
+        click_scheduled_action(page, 0, ".btn-edit")
         page.wait_for_timeout(500)
 
         edit_hint = page.locator("#scheduled-task-list .edit-end-time-hint")
@@ -477,7 +515,7 @@ with sync_playwright() as p:
     edit_buttons = page.locator("#scheduled-task-list .btn-edit")
     if edit_buttons.count() >= 2:
         # Edit the second task and change its time to overlap the first
-        edit_buttons.nth(1).click()
+        click_scheduled_action(page, 1, ".btn-edit")
         page.wait_for_timeout(500)
 
         edit_form = page.locator("#scheduled-task-list form[id^='edit-task-']")
@@ -542,10 +580,15 @@ with sync_playwright() as p:
 
     schedule_btns = page.locator("#unscheduled-task-list .btn-schedule-task")
     if schedule_btns.count() >= 1:
-        schedule_btns.nth(0).click()
-        page.wait_for_timeout(500)
+        open_unscheduled_action_menu_for_text(page, "Modal overlap test").locator(
+            ".btn-schedule-task"
+        ).evaluate("el => el.click()")
 
         schedule_modal = page.locator("#schedule-modal")
+        try:
+            schedule_modal.wait_for(state="visible", timeout=5000)
+        except Exception:
+            pass
         if schedule_modal.is_visible():
             # Fill in overlapping time
             page.fill('input[name="modal-start-time"]', OVERLAP_TIME)
@@ -600,10 +643,15 @@ with sync_playwright() as p:
     print("\nTEST 14: Schedule modal warning clears for non-conflicting time", flush=True)
     schedule_btns = page.locator("#unscheduled-task-list .btn-schedule-task")
     if schedule_btns.count() >= 1:
-        schedule_btns.nth(0).click()
-        page.wait_for_timeout(500)
+        open_unscheduled_action_menu_for_text(page, "Modal overlap test").locator(
+            ".btn-schedule-task"
+        ).evaluate("el => el.click()")
 
         schedule_modal = page.locator("#schedule-modal")
+        try:
+            schedule_modal.wait_for(state="visible", timeout=5000)
+        except Exception:
+            pass
         if schedule_modal.is_visible():
             # Use a time far in the future with no overlap
             no_conflict_time = fmt_time(T3_OFF + D3 + 30)

--- a/test_ui_interaction.py
+++ b/test_ui_interaction.py
@@ -107,6 +107,44 @@ def dismiss_modals(page):
             page.locator("#ok-custom-alert-modal").click()
             page.wait_for_timeout(300)
 
+def open_scheduled_action_menu(page, index=0):
+    """Open the action menu for a scheduled task by visual order."""
+    task = page.locator("#scheduled-task-list > [data-task-id]").nth(index)
+    menu = task.locator(".task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
+def click_scheduled_action(page, index, selector):
+    task = open_scheduled_action_menu(page, index)
+    task.locator(selector).evaluate("el => el.click()")
+
+def open_unscheduled_action_menu(page, index=0):
+    """Open the action menu for an unscheduled task by visual order."""
+    task = page.locator("#unscheduled-task-list .task-card").nth(index)
+    menu = task.locator(".unscheduled-task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-unscheduled-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
+def click_unscheduled_action(page, index, selector):
+    task = open_unscheduled_action_menu(page, index)
+    task.locator(selector).evaluate("el => el.click()")
+
+def open_unscheduled_action_menu_for_text(page, text):
+    """Open the action menu for the unscheduled task matching visible text."""
+    task = page.locator("#unscheduled-task-list .task-card").filter(has_text=text).first
+    menu = task.locator(".unscheduled-task-actions-menu")
+    if menu.is_visible():
+        return task
+    task.locator(".btn-unscheduled-task-actions-menu").click()
+    menu.wait_for(state="visible", timeout=5000)
+    return task
+
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)
     page = browser.new_page(viewport={"width": 1280, "height": 900})
@@ -222,7 +260,7 @@ with sync_playwright() as p:
 
     edit_buttons = page.locator("#scheduled-task-list .btn-edit")
     if edit_buttons.count() >= 1:
-        edit_buttons.nth(0).click()
+        click_scheduled_action(page, 0, ".btn-edit")
         page.wait_for_timeout(500)
 
         edit_form = page.locator("#scheduled-task-list form[id^='edit-task-']")
@@ -255,7 +293,7 @@ with sync_playwright() as p:
     print("\nTEST 5: Cancel edit", flush=True)
     edit_buttons = page.locator("#scheduled-task-list .btn-edit")
     if edit_buttons.count() >= 1:
-        edit_buttons.nth(0).click()
+        click_scheduled_action(page, 0, ".btn-edit")
         page.wait_for_timeout(500)
 
         cancel_btn = page.locator("#scheduled-task-list .btn-edit-cancel")
@@ -279,7 +317,7 @@ with sync_playwright() as p:
     print("\nTEST 6: Lock/unlock task", flush=True)
     lock_buttons = page.locator("#scheduled-task-list .btn-lock")
     if lock_buttons.count() >= 1:
-        lock_buttons.nth(0).click()
+        click_scheduled_action(page, 0, ".btn-lock")
         page.wait_for_timeout(500)
 
         task_html = page.locator("#scheduled-task-list > [data-task-id]").nth(0).inner_html()
@@ -290,7 +328,7 @@ with sync_playwright() as p:
 
         lock_buttons_after = page.locator("#scheduled-task-list .btn-lock")
         if lock_buttons_after.count() >= 1:
-            lock_buttons_after.nth(0).click()
+            click_scheduled_action(page, 0, ".btn-lock")
             page.wait_for_timeout(500)
         screenshot(page, "06b_task_unlocked")
     else:
@@ -305,7 +343,7 @@ with sync_playwright() as p:
     unsched_before = page.locator("#unscheduled-task-list .task-card").count()
 
     if unsched_btns.count() >= 1:
-        unsched_btns.nth(0).click()
+        click_scheduled_action(page, 0, ".btn-unschedule")
         page.wait_for_timeout(500)
 
         sched_after = page.locator("#scheduled-task-list > [data-task-id]").count()
@@ -326,10 +364,13 @@ with sync_playwright() as p:
     print("\nTEST 8: Schedule an unscheduled task via modal", flush=True)
     schedule_btns = page.locator("#unscheduled-task-list .btn-schedule-task")
     if schedule_btns.count() >= 1:
-        schedule_btns.nth(0).click()
-        page.wait_for_timeout(500)
+        click_unscheduled_action(page, 0, ".btn-schedule-task")
 
         schedule_modal = page.locator("#schedule-modal")
+        try:
+            schedule_modal.wait_for(state="visible", timeout=5000)
+        except Exception:
+            pass
         test("Schedule modal appears", schedule_modal.is_visible(),
              "Modal did not appear")
 
@@ -367,10 +408,15 @@ with sync_playwright() as p:
 
     schedule_btns = page.locator("#unscheduled-task-list .btn-schedule-task")
     if schedule_btns.count() >= 1:
-        schedule_btns.last.click()
-        page.wait_for_timeout(500)
+        open_unscheduled_action_menu_for_text(page, "Modal test task").locator(
+            ".btn-schedule-task"
+        ).evaluate("el => el.click()")
 
         schedule_modal = page.locator("#schedule-modal")
+        try:
+            schedule_modal.wait_for(state="visible", timeout=5000)
+        except Exception:
+            pass
         if schedule_modal.is_visible():
             page.locator("#close-schedule-modal").click()
             page.wait_for_timeout(300)
@@ -416,7 +462,7 @@ with sync_playwright() as p:
     print("\nTEST 11: Edit unscheduled task inline", flush=True)
     unsched_edit_btns = page.locator("#unscheduled-task-list .btn-edit-unscheduled")
     if unsched_edit_btns.count() >= 1:
-        unsched_edit_btns.nth(0).click()
+        click_unscheduled_action(page, 0, ".btn-edit-unscheduled")
         page.wait_for_timeout(500)
 
         inline_form = page.locator("#unscheduled-task-list .inline-edit-form, #unscheduled-task-list form")
@@ -433,7 +479,7 @@ with sync_playwright() as p:
         else:
             unsched_edit_btns_after = page.locator("#unscheduled-task-list .btn-edit-unscheduled")
             if unsched_edit_btns_after.count() >= 1:
-                unsched_edit_btns_after.nth(0).click()
+                click_unscheduled_action(page, 0, ".btn-edit-unscheduled")
                 page.wait_for_timeout(300)
                 test("Inline edit toggled off", True)
     else:


### PR DESCRIPTION
## Summary

- Add a Do now action for incomplete scheduled tasks that are not currently active.
- Move the selected scheduled task to the current displayed time through the existing task update/reschedule flow.
- Reuse the existing reschedule confirmation shape when the move overlaps other tasks; declining leaves the schedule unchanged and shows a quiet toast.
- Replace the scheduled task icon cluster with a mockup-aligned actions menu: ellipsis trigger, labeled menu items, primary Do now treatment with a bolt icon, clearer Lock time / Allow reschedule labels, destructive Delete grouping, outside-click and Escape dismissal, and mobile bottom-sheet positioning.
- Show locked scheduled tasks with a passive icon-only fixed-time indicator so lock state remains visible when the action menu is closed.
- Apply the same actions-menu treatment to unscheduled tasks with Start timer, Schedule, Edit task, and Delete task actions.
- Keep action menus open when a task is waiting for delete confirmation so the second delete tap remains available.
- Add a roadmap note for configurable task quick actions so frequent menu actions can later be promoted back onto task cards.
- Wire the action menus through scheduled and unscheduled task rendering, DOM delegation, task handlers, preview smoke coverage, and legacy E2E coverage.

## Validation

- npm test
- npm run check
- npm test -- --coverage
- uv run --with playwright python -B scripts/playwright_preview_smoke.py http://127.0.0.1:5000 --headless --channel chrome
- uv run --with playwright python test_run_all.py

The pre-commit hook also reran lint/format and coverage successfully where relevant.