### PR TITLE
Fix running timer display after sync

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,6 +166,7 @@ jobs:
                   firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FORTUDO }}
                   projectId: fortudo
                   expires: 30d
+                  firebaseToolsVersion: 15.22.1
               env:
                   FIREBASE_CLI_EXPERIMENTS: webframeworks
 
@@ -192,5 +193,6 @@ jobs:
                   firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FORTUDO }}
                   channelId: live
                   projectId: fortudo
+                  firebaseToolsVersion: 15.22.1
               env:
                   FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -159,14 +159,45 @@ jobs:
                   name: build-files
                   path: public/
 
+            - name: Configure Firebase service account
+              shell: bash
+              env:
+                  FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FORTUDO }}
+              run: |
+                  printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
+                  echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
+
             - name: Deploy to Firebase Hosting (Preview)
-              uses: FirebaseExtended/action-hosting-deploy@v0
-              with:
-                  repoToken: ${{ secrets.GITHUB_TOKEN }}
-                  firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FORTUDO }}
-                  projectId: fortudo
-                  expires: 30d
-                  firebaseToolsVersion: 15.22.1
+              shell: bash
+              run: |
+                  set +e
+
+                  branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+                  slug="$(
+                    printf '%s' "$branch" |
+                    tr '[:upper:]' '[:lower:]' |
+                    sed -E 's/[^a-z0-9-]+/-/g; s/^-+|-+$//g' |
+                    cut -c1-20
+                  )"
+                  channel="pr${{ github.event.pull_request.number }}-${slug}"
+                  log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
+
+                  npx firebase-tools@latest hosting:channel:deploy "$channel" \
+                    --expires 30d \
+                    --project fortudo \
+                    --json 2>&1 | tee "$log_file"
+                  deploy_status=${PIPESTATUS[0]}
+
+                  if [ "$deploy_status" -eq 0 ]; then
+                    exit 0
+                  fi
+
+                  if grep -q 'is the current active version' "$log_file"; then
+                    echo "Firebase Hosting preview version is already active; treating retry as successful."
+                    exit 0
+                  fi
+
+                  exit "$deploy_status"
               env:
                   FIREBASE_CLI_EXPERIMENTS: webframeworks
 
@@ -193,6 +224,5 @@ jobs:
                   firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FORTUDO }}
                   channelId: live
                   projectId: fortudo
-                  firebaseToolsVersion: 15.22.1
               env:
                   FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/__tests__/activity-app-wiring.test.js
+++ b/__tests__/activity-app-wiring.test.js
@@ -30,7 +30,8 @@ jest.mock('../public/js/activities/insights-renderer.js', () => ({
 import {
     createActivityAppCallbacks,
     initializeActivityUi,
-    syncRestoredRunningTimer
+    syncRestoredRunningTimer,
+    syncRunningTimerDisplay
 } from '../public/js/activities/app-wiring.js';
 import {
     handleActivityAwareFormSubmit,
@@ -312,10 +313,27 @@ describe('activity app wiring', () => {
         expect(syncTimerFormState).toHaveBeenCalled();
     });
 
+    test('syncs running timer display without changing task type selection', () => {
+        const activityRadio = document.getElementById('activity');
+        const dispatchSpy = jest.spyOn(activityRadio, 'dispatchEvent');
+
+        syncRunningTimerDisplay(true);
+
+        expect(activityRadio.checked).toBe(false);
+        expect(dispatchSpy).not.toHaveBeenCalled();
+        expect(syncTimerFormState).toHaveBeenCalled();
+    });
+
     test('does nothing when activities are disabled', () => {
         syncRestoredRunningTimer(false);
 
         expect(syncTimerFormState).not.toHaveBeenCalled();
         expect(getRunningActivity).not.toHaveBeenCalled();
+    });
+
+    test('does not sync running timer display when activities are disabled', () => {
+        syncRunningTimerDisplay(false);
+
+        expect(syncTimerFormState).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/activity-handlers.test.js
+++ b/__tests__/activity-handlers.test.js
@@ -52,10 +52,16 @@ import {
 import { showAlert } from '../public/js/modal-manager.js';
 import { showToast } from '../public/js/toast-manager.js';
 import { consumeUnscheduledTask } from '../public/js/tasks/manager.js';
+import { logger } from '../public/js/utils.js';
 
 describe('activity handlers', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.spyOn(logger, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     test('handleAddActivity routes success through coordinator and toast', async () => {
@@ -348,6 +354,20 @@ describe('activity handlers', () => {
         });
         expect(consumeUnscheduledTask).toHaveBeenCalledWith('unsched-9');
         expect(showAlert).toHaveBeenCalledWith('Description is required to start a timer.', 'sky');
+    });
+
+    test('handleStartTimer logs caught errors before showing the generic alert', async () => {
+        const error = new Error('storage write failed');
+        startTimerReplacingCurrent.mockRejectedValueOnce(error);
+
+        const result = await handleStartTimer({ description: 'Next timer' });
+
+        expect(result).toEqual({
+            success: false,
+            reason: 'Could not start timer.'
+        });
+        expect(logger.error).toHaveBeenCalledWith('Failed to start timer:', error);
+        expect(showAlert).toHaveBeenCalledWith('Could not start timer.', 'sky');
     });
 
     test('handleStopTimer emits coordinator + toast on success', async () => {

--- a/__tests__/app-lifecycle.test.js
+++ b/__tests__/app-lifecycle.test.js
@@ -21,6 +21,7 @@ describe('app room/session lifecycle', () => {
             refreshUI: jest.fn(),
             getActivitiesEnabled: jest.fn(() => true),
             syncRestoredRunningTimer: jest.fn(),
+            syncRunningTimerDisplay: jest.fn(),
             getTaskState: jest.fn(() => []),
             refreshActiveTaskColor: jest.fn(),
             refreshCurrentGapHighlight: jest.fn(),
@@ -90,6 +91,38 @@ describe('app room/session lifecycle', () => {
 
         expect(deps.syncRestoredRunningTimer).toHaveBeenCalledTimes(1);
         expect(deps.syncRestoredRunningTimer).toHaveBeenCalledWith(true);
+    });
+
+    test('refreshes running timer display after every synced storage refresh', async () => {
+        let syncStatusCallback;
+        const { deps, lifecycle } = createLifecycle({
+            onSyncStatusChange: jest.fn((callback) => {
+                syncStatusCallback = callback;
+                return jest.fn();
+            })
+        });
+
+        const abortController = new AbortController();
+        lifecycle.start({ signal: abortController.signal });
+
+        syncStatusCallback('synced');
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        deps.syncRestoredRunningTimer.mockClear();
+        deps.syncRunningTimerDisplay.mockClear();
+
+        syncStatusCallback('synced');
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.loadAppState).toHaveBeenCalledTimes(2);
+        expect(deps.syncRestoredRunningTimer).not.toHaveBeenCalled();
+        expect(deps.syncRunningTimerDisplay).toHaveBeenCalledTimes(1);
+        expect(deps.syncRunningTimerDisplay).toHaveBeenCalledWith(true);
     });
 
     test('stops a stale restored timer at the midnight after it started', async () => {

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -224,6 +224,19 @@ describe('DOM Handler Interaction Tests', () => {
             expect(trigger.closest('.task-actions').className).not.toContain('z-50');
         });
 
+        test('opening the scheduled actions menu does not auto-focus the first action', () => {
+            renderFutureScheduledTask();
+
+            const trigger = document.querySelector('.btn-task-actions-menu');
+            const firstMenuItem = document.querySelector('.task-actions-menu [role="menuitem"]');
+            trigger.focus();
+
+            trigger.click();
+
+            expect(document.activeElement).toBe(trigger);
+            expect(document.activeElement).not.toBe(firstMenuItem);
+        });
+
         test('clicking do-now menu item invokes the scheduled do-now callback', () => {
             renderFutureScheduledTask();
             document.querySelector('.btn-task-actions-menu').click();
@@ -1076,6 +1089,21 @@ describe('DOM Handler Interaction Tests', () => {
             expect(menu.hidden).toBe(true);
             expect(trigger.closest('[data-task-id]').className).not.toContain('z-40');
             expect(trigger.closest('.unscheduled-task-actions').className).not.toContain('z-50');
+        });
+
+        test('opening the unscheduled actions menu does not auto-focus the first action', () => {
+            setupUnscheduledTask('unsched-1');
+
+            const trigger = document.querySelector('.btn-unscheduled-task-actions-menu');
+            const firstMenuItem = document.querySelector(
+                '.unscheduled-task-actions-menu [role="menuitem"]'
+            );
+            trigger.focus();
+
+            trigger.click();
+
+            expect(document.activeElement).toBe(trigger);
+            expect(document.activeElement).not.toBe(firstMenuItem);
         });
 
         test('outside click and Escape close an open unscheduled task actions menu', () => {

--- a/public/js/activities/app-wiring.js
+++ b/public/js/activities/app-wiring.js
@@ -216,3 +216,11 @@ export function syncRestoredRunningTimer(activitiesEnabled) {
 
     syncTimerFormState();
 }
+
+export function syncRunningTimerDisplay(activitiesEnabled) {
+    if (!activitiesEnabled) {
+        return;
+    }
+
+    syncTimerFormState();
+}

--- a/public/js/activities/handlers.js
+++ b/public/js/activities/handlers.js
@@ -11,6 +11,7 @@ import {
 import { consumeUnscheduledTask } from '../tasks/manager.js';
 import { consumeActivitySmokeFailure } from './smoke-hooks.js';
 import { onActivityCreated, onActivityEdited, onActivityDeleted } from '../app-coordinator.js';
+import { logger } from '../utils.js';
 
 function consumeSourceTaskIfPresent(activity) {
     if (activity?.sourceTaskId) {
@@ -129,7 +130,8 @@ export async function handleStartTimer(timerData) {
 
         showToast('Timer started.', { theme: 'sky' });
         return result;
-    } catch {
+    } catch (error) {
+        logger.error('Failed to start timer:', error);
         showAlert('Could not start timer.', 'sky');
         return { success: false, reason: 'Could not start timer.' };
     }

--- a/public/js/app-lifecycle.js
+++ b/public/js/app-lifecycle.js
@@ -5,6 +5,7 @@ export function createRoomSessionLifecycle({
     refreshUI,
     getActivitiesEnabled,
     syncRestoredRunningTimer,
+    syncRunningTimerDisplay,
     getTaskState,
     refreshActiveTaskColor,
     refreshCurrentGapHighlight,
@@ -86,6 +87,8 @@ export function createRoomSessionLifecycle({
             refreshUI();
             if (restoreRunningTimer) {
                 syncRestoredRunningTimer(getActivitiesEnabled());
+            } else if (typeof syncRunningTimerDisplay === 'function') {
+                syncRunningTimerDisplay(getActivitiesEnabled());
             }
             refreshActiveTaskColor(getTaskState());
             refreshCurrentGapHighlight();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -43,7 +43,8 @@ import {
 import {
     createActivityAppCallbacks,
     initializeActivityUi,
-    syncRestoredRunningTimer
+    syncRestoredRunningTimer,
+    syncRunningTimerDisplay
 } from './activities/app-wiring.js';
 import {
     initializeActivitiesViewToggle,
@@ -194,6 +195,7 @@ async function initAndBootApp(roomCode) {
         refreshUI: refreshAppUI,
         getActivitiesEnabled: () => isActivitiesEnabled(),
         syncRestoredRunningTimer,
+        syncRunningTimerDisplay,
         getTaskState,
         refreshActiveTaskColor,
         refreshCurrentGapHighlight,

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -288,9 +288,6 @@ function toggleScheduledTaskActionMenu(trigger) {
     menu.hidden = !shouldOpen;
     setTaskActionMenuElevation(menu, shouldOpen);
     trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
-    if (shouldOpen) {
-        menu.querySelector('[role="menuitem"]')?.focus();
-    }
 }
 
 function closeUnscheduledTaskActionMenus(exceptMenu = null) {
@@ -317,9 +314,6 @@ function toggleUnscheduledTaskActionMenu(trigger) {
     menu.hidden = !shouldOpen;
     setTaskActionMenuElevation(menu, shouldOpen);
     trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
-    if (shouldOpen) {
-        menu.querySelector('[role="menuitem"]')?.focus();
-    }
 }
 
 function handleScheduledTaskListKeydown(event) {


### PR DESCRIPTION
## Summary

- Refresh the running timer display after every storage refresh without forcing the Activity task type.
- Keep the existing initial-sync behavior that restores Activity mode when a running timer is first loaded.
- Stop task action menus from auto-focusing the first action when opened, avoiding the persistent focus-ring highlight.
- Log caught start-timer exceptions before showing the generic failure alert, so unexpected failures are diagnosable from the console.
- Make preview deploy CI tolerate Firebase's already-active retry response while still failing real deploy errors.
- Cover the stale-page sync path, non-restoring timer display helper, task menu focus behavior, and caught start-timer exception logging with unit tests.

## Validation

- npm.cmd test -- __tests__/app-lifecycle.test.js
- npm.cmd test -- __tests__/activity-app-wiring.test.js
- npm.cmd test -- __tests__/dom-interaction.test.js
- npm.cmd test -- __tests__/activity-handlers.test.js
- npm.cmd test
- npm.cmd run check
- pre-commit hook: npm test -- --coverage
- GitHub PR checks: passing, including Deploy Preview and E2E