### PR TITLE
Phase 6A/B: polish transitions and mobile timeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -182,6 +182,24 @@ jobs:
                   channel="pr${{ github.event.pull_request.number }}-${slug}"
                   log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
 
+                  print_preview_urls() {
+                    local source_file="$1"
+                    local urls
+                    urls="$(
+                      grep -Eo 'https://[^"[:space:]]+' "$source_file" |
+                      grep -E 'web\.app|firebaseapp\.com' |
+                      sort -u
+                      true
+                    )"
+
+                    if [ -n "$urls" ]; then
+                      echo "Firebase Hosting preview URL(s):"
+                      printf '%s\n' "$urls"
+                    else
+                      echo "Firebase Hosting preview URL was not present in $source_file."
+                    fi
+                  }
+
                   npx firebase-tools@latest hosting:channel:deploy "$channel" \
                     --expires 30d \
                     --project fortudo \
@@ -189,11 +207,17 @@ jobs:
                   deploy_status=${PIPESTATUS[0]}
 
                   if [ "$deploy_status" -eq 0 ]; then
+                    print_preview_urls "$log_file"
                     exit 0
                   fi
 
                   if grep -q 'is the current active version' "$log_file"; then
                     echo "Firebase Hosting preview version is already active; treating retry as successful."
+                    channel_list_file="$RUNNER_TEMP/firebase-preview-channels.log"
+                    npx firebase-tools@latest hosting:channel:list \
+                      --project fortudo \
+                      --json 2>&1 | tee "$channel_list_file"
+                    print_preview_urls "$channel_list_file"
                     exit 0
                   fi
 

--- a/__tests__/activity-insights-renderer.test.js
+++ b/__tests__/activity-insights-renderer.test.js
@@ -324,9 +324,12 @@ describe('activity insights renderer', () => {
         });
 
         const detail = document.querySelector('[data-selected-timeline-block]');
+        const selectedBlock = document.querySelector('[data-timeline-block-id="actual-2"]');
         expect(detail.textContent).toContain('tiny review');
         expect(detail.textContent).toContain('10:39 AM - 10:48 AM');
         expect(detail.textContent).toContain('9m');
+        expect(selectedBlock.dataset.selected).toBe('true');
+        expect(selectedBlock.className).toContain('shadow-cyan');
     });
 
     test('renderInsightsView renders visible Activity Log activities with summary metadata', () => {

--- a/__tests__/activity-insights-renderer.test.js
+++ b/__tests__/activity-insights-renderer.test.js
@@ -299,6 +299,41 @@ describe('activity insights renderer', () => {
         expect(narrow.querySelector('.sr-only').textContent).toContain('tiny review');
     });
 
+    test('timeline blocks meet minimum mobile touch target height', () => {
+        renderWith({ tasks: [scheduledTask()] });
+
+        const block = document.querySelector('[data-timeline-block-id="task-1"]');
+
+        expect(block).not.toBeNull();
+        expect(block.className).toContain('min-h-[44px]');
+        expect(block.className).toContain('leading-[44px]');
+    });
+
+    test('timeline row containers allow taller mobile touch targets', () => {
+        renderWith({ tasks: [scheduledTask()] });
+
+        const rowContainer = document
+            .querySelector('[data-timeline-block="planned"]')
+            ?.closest('.relative');
+
+        expect(rowContainer).not.toBeNull();
+        expect(rowContainer.className).toContain('min-h-[3.5rem]');
+    });
+
+    test('timeline midpoint tick is hidden on narrow screens', () => {
+        renderWith({ tasks: [scheduledTask()] });
+
+        const ticks = document
+            .getElementById('insights-timeline')
+            .querySelector('.grid.grid-cols-3');
+        const midpointTick = ticks.querySelectorAll('span')[1];
+        const endTick = ticks.querySelectorAll('span')[2];
+
+        expect(midpointTick.className).toContain('hidden');
+        expect(midpointTick.className).toContain('sm:block');
+        expect(endTick.className).toContain('col-start-3');
+    });
+
     test('timeline selected block detail follows selected timeline block state', () => {
         setSelectedTimelineBlock('actual-2');
 

--- a/__tests__/activity-render-options.test.js
+++ b/__tests__/activity-render-options.test.js
@@ -68,4 +68,27 @@ describe('activity render options', () => {
             activityIssuesById: new Map([['activity-1', [{ severity: 'warning' }]]])
         });
     });
+
+    test('does not refresh and overwrite drafts while clicking inside a scheduled task edit form', () => {
+        document.body.innerHTML = `
+            <form id="edit-task-task-1" data-task-id="task-1">
+                <input name="duration-minutes" value="45">
+            </form>
+        `;
+        const durationInput = document.querySelector('input[name="duration-minutes"]');
+        const refreshUI = jest.fn(() => {
+            durationInput.value = '30';
+        });
+        const resetAllConfirmingDeleteFlags = jest.fn(() => true);
+
+        const handled = handleActivityListClick(durationInput, {
+            refreshUI,
+            resetAllConfirmingDeleteFlags
+        });
+
+        expect(handled).toBe(false);
+        expect(resetAllConfirmingDeleteFlags).not.toHaveBeenCalled();
+        expect(refreshUI).not.toHaveBeenCalled();
+        expect(durationInput.value).toBe('45');
+    });
 });

--- a/__tests__/activity-renderer.test.js
+++ b/__tests__/activity-renderer.test.js
@@ -736,7 +736,7 @@ describe('activity renderer', () => {
         expect(expandedRail.textContent).toContain('Work');
         expect(expandedRail.textContent).toContain('Deep Work 45m');
         expect(expandedRail.textContent).toContain('Admin 20m');
-        expect(expandedRail.textContent).toContain('Unspecified 15m');
+        expect(expandedRail.textContent).toContain('Work 15m');
         expect(expandedRail.textContent).not.toContain('Zero Child');
         expect(container.querySelectorAll('[data-summary-child-segment]')).toHaveLength(3);
     });

--- a/__tests__/activity-summary.test.js
+++ b/__tests__/activity-summary.test.js
@@ -191,7 +191,7 @@ describe('activity summary selectors', () => {
         ]);
     });
 
-    test('builds expanded child detail for the selected group with unspecified fallback', () => {
+    test('builds expanded child detail for the selected group with parent label fallback', () => {
         const model = buildActivitySummaryModel(
             [
                 {
@@ -230,7 +230,7 @@ describe('activity summary selectors', () => {
             expect.objectContaining({ key: 'work/admin', label: 'Admin', duration: 20 }),
             expect.objectContaining({
                 key: 'work::__unspecified',
-                label: 'Unspecified',
+                label: 'Work',
                 duration: 15
             })
         ]);

--- a/__tests__/activity-view-toggle.test.js
+++ b/__tests__/activity-view-toggle.test.js
@@ -63,9 +63,16 @@ describe('activity view shell', () => {
 
         syncActivitiesViewToggle(false);
 
+        const tasksView = document.getElementById('tasks-view');
+        const insightsView = document.getElementById('insights-view');
+
         expect(document.getElementById('view-toggle').classList.contains('hidden')).toBe(true);
-        expect(document.getElementById('tasks-view').classList.contains('hidden')).toBe(false);
-        expect(document.getElementById('insights-view').classList.contains('hidden')).toBe(true);
+        expect(tasksView.classList.contains('hidden')).toBe(false);
+        expect(tasksView.classList.contains('view-panel--visible')).toBe(true);
+        expect(tasksView.classList.contains('view-panel--hidden')).toBe(false);
+        expect(insightsView.classList.contains('hidden')).toBe(false);
+        expect(insightsView.classList.contains('view-panel--hidden')).toBe(true);
+        expect(insightsView.classList.contains('view-panel--visible')).toBe(false);
         expect(getActiveActivitiesView()).toBe('tasks');
     });
 
@@ -80,9 +87,16 @@ describe('activity view shell', () => {
         syncActivitiesViewToggle(true);
         document.getElementById('view-toggle-insights').click();
 
+        const tasksView = document.getElementById('tasks-view');
+        const insightsView = document.getElementById('insights-view');
+
         expect(renderInsights).toHaveBeenCalledTimes(1);
-        expect(document.getElementById('tasks-view').classList.contains('hidden')).toBe(true);
-        expect(document.getElementById('insights-view').classList.contains('hidden')).toBe(false);
+        expect(tasksView.classList.contains('hidden')).toBe(false);
+        expect(tasksView.classList.contains('view-panel--hidden')).toBe(true);
+        expect(tasksView.classList.contains('view-panel--visible')).toBe(false);
+        expect(insightsView.classList.contains('hidden')).toBe(false);
+        expect(insightsView.classList.contains('view-panel--visible')).toBe(true);
+        expect(insightsView.classList.contains('view-panel--hidden')).toBe(false);
         expect(getActiveActivitiesView()).toBe('insights');
     });
 

--- a/__tests__/custom-css.test.js
+++ b/__tests__/custom-css.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment node
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+describe('custom CSS polish hooks', () => {
+    test('defines reduced motion and transition utility hooks', () => {
+        const css = fs.readFileSync(
+            path.join(__dirname, '..', 'public', 'css', 'custom.css'),
+            'utf8'
+        );
+
+        expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+        expect(css).toContain('.view-panel');
+        expect(css).toContain('.action-menu-content');
+        expect(css).toContain('[data-timeline-block-id]');
+        expect(css).toContain('.settings-reload-prompt');
+    });
+});

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -213,6 +213,9 @@ describe('DOM Handler Interaction Tests', () => {
 
             expect(trigger.getAttribute('aria-expanded')).toBe('true');
             expect(menu.hidden).toBe(false);
+            expect(menu.classList.contains('action-menu-content')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--open')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(false);
             expect(trigger.closest('[data-task-id]').className).toContain('z-40');
             expect(trigger.closest('.task-actions').className).toContain('z-50');
 
@@ -220,6 +223,9 @@ describe('DOM Handler Interaction Tests', () => {
 
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(menu.classList.contains('action-menu-content')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--open')).toBe(false);
             expect(trigger.closest('[data-task-id]').className).not.toContain('z-40');
             expect(trigger.closest('.task-actions').className).not.toContain('z-50');
         });
@@ -258,6 +264,7 @@ describe('DOM Handler Interaction Tests', () => {
             document.body.click();
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(true);
 
             trigger.click();
             expect(menu.hidden).toBe(false);
@@ -267,6 +274,7 @@ describe('DOM Handler Interaction Tests', () => {
                 .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(true);
         });
     });
 
@@ -1080,6 +1088,9 @@ describe('DOM Handler Interaction Tests', () => {
 
             expect(trigger.getAttribute('aria-expanded')).toBe('true');
             expect(menu.hidden).toBe(false);
+            expect(menu.classList.contains('action-menu-content')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--open')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(false);
             expect(trigger.closest('[data-task-id]').className).toContain('z-40');
             expect(trigger.closest('.unscheduled-task-actions').className).toContain('z-50');
 
@@ -1087,6 +1098,9 @@ describe('DOM Handler Interaction Tests', () => {
 
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(menu.classList.contains('action-menu-content')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(true);
+            expect(menu.classList.contains('action-menu-content--open')).toBe(false);
             expect(trigger.closest('[data-task-id]').className).not.toContain('z-40');
             expect(trigger.closest('.unscheduled-task-actions').className).not.toContain('z-50');
         });
@@ -1118,6 +1132,7 @@ describe('DOM Handler Interaction Tests', () => {
             document.body.click();
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(true);
 
             trigger.click();
             expect(menu.hidden).toBe(false);
@@ -1127,6 +1142,7 @@ describe('DOM Handler Interaction Tests', () => {
                 .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(menu.hidden).toBe(true);
+            expect(menu.classList.contains('action-menu-content--closed')).toBe(true);
         });
 
         test('schedule button calls onScheduleUnscheduledTask', () => {

--- a/__tests__/scheduled-task-renderer.test.js
+++ b/__tests__/scheduled-task-renderer.test.js
@@ -638,5 +638,29 @@ describe('Scheduled Task Renderer Tests', () => {
 
             expect(dot.style.backgroundColor).toBe('rgb(14, 165, 233)');
         });
+
+        test('preserves scheduled edit form drafts across incidental re-renders', () => {
+            const tasks = [createTask('1', '10:00', 30, { editing: true, date: today })];
+
+            renderTasks(tasks, mockCallbacks, mockInitListeners, null);
+
+            const form = document.querySelector('form[id^="edit-task-"]');
+            form.querySelector('input[name="description"]').value = 'Edited draft';
+            form.querySelector('input[name="start-time"]').value = '11:15';
+            form.querySelector('input[name="duration-hours"]').value = '1';
+            form.querySelector('input[name="duration-minutes"]').value = '45';
+            form.querySelector('select[name="category"]').value = 'work/deep';
+
+            renderTasks(tasks, mockCallbacks, mockInitListeners, mockCallbacks);
+
+            const rerenderedForm = document.querySelector('form[id^="edit-task-"]');
+            expect(rerenderedForm.querySelector('input[name="description"]').value).toBe(
+                'Edited draft'
+            );
+            expect(rerenderedForm.querySelector('input[name="start-time"]').value).toBe('11:15');
+            expect(rerenderedForm.querySelector('input[name="duration-hours"]').value).toBe('1');
+            expect(rerenderedForm.querySelector('input[name="duration-minutes"]').value).toBe('45');
+            expect(rerenderedForm.querySelector('select[name="category"]').value).toBe('work/deep');
+        });
     });
 });

--- a/__tests__/settings-renderer.test.js
+++ b/__tests__/settings-renderer.test.js
@@ -278,6 +278,8 @@ describe('settings-renderer', () => {
             const reloadPrompt = document.getElementById('reload-prompt');
             expect(reloadPrompt).not.toBeNull();
             expect(reloadPrompt.classList.contains('hidden')).toBe(false);
+            expect(reloadPrompt.classList.contains('settings-reload-prompt')).toBe(true);
+            expect(reloadPrompt.classList.contains('settings-reload-prompt--visible')).toBe(true);
             expect(message.textContent).toContain('Activities enabled');
             expect(message.textContent).toContain('taxonomy controls will be available');
             expect(taxonomySection.classList.contains('hidden')).toBe(true);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -279,3 +279,100 @@
         filter: blur(10px);
     }
 }
+
+.view-panel {
+    transition: opacity 150ms ease;
+}
+
+.view-panel--hidden {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    pointer-events: none;
+}
+
+.view-panel--visible {
+    opacity: 1;
+    visibility: visible;
+    position: static;
+    pointer-events: auto;
+}
+
+.action-menu-content {
+    transition:
+        opacity 100ms ease,
+        transform 100ms ease;
+    transform-origin: top right;
+}
+
+.action-menu-content--closed {
+    opacity: 0;
+    transform: scale(0.95);
+    pointer-events: none;
+}
+
+.action-menu-content--open {
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
+}
+
+[data-timeline-block-id] {
+    transition:
+        outline-offset 100ms ease,
+        box-shadow 100ms ease;
+}
+
+.settings-reload-prompt {
+    opacity: 0;
+    transition: opacity 150ms ease;
+}
+
+.settings-reload-prompt--visible {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .task-card {
+        transition: none;
+    }
+
+    .task-card:hover {
+        transform: none;
+    }
+
+    .priority-badge::before {
+        transition: none;
+    }
+
+    .pulse-animation,
+    .pulse-animation-indigo {
+        animation: none;
+    }
+
+    .celebration-emoji,
+    .celebration-emoji:nth-child(1),
+    .celebration-emoji:nth-child(2),
+    .celebration-emoji:nth-child(3),
+    .celebration-emoji:nth-child(4),
+    .celebration-emoji:nth-child(5),
+    .celebration-emoji:nth-child(6),
+    .celebration-emoji:nth-child(7) {
+        animation: none;
+    }
+
+    .view-panel,
+    .action-menu-content,
+    [data-timeline-block-id],
+    .settings-reload-prompt {
+        transition: none;
+    }
+
+    *,
+    *::before,
+    *::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}

--- a/public/js/activities/insights-renderer.js
+++ b/public/js/activities/insights-renderer.js
@@ -146,10 +146,15 @@ function renderTimelineBlock(block, type, viewport) {
     const title = `${label}, ${timeRange}, ${duration}`;
     const { style, widthPercent } = getViewportBlockStyle(block, viewport);
     const compact = widthPercent < COMPACT_TIMELINE_BLOCK_PERCENT;
+    const selected = block.id === selectedTimelineBlockId;
+    const selectedClasses = selected
+        ? ' outline outline-2 outline-offset-2 outline-cyan-300 shadow-cyan-300/40'
+        : '';
 
     return `<div data-timeline-block="${type}" data-timeline-block-id="${escapeHtml(block.id)}"
         data-compact="${compact ? 'true' : 'false'}"
-        role="img" class="absolute top-2 h-9 cursor-pointer overflow-hidden rounded border border-white/20 px-2 text-[11px] font-medium leading-9 text-white shadow-sm"
+        data-selected="${selected ? 'true' : 'false'}"
+        role="img" class="absolute top-2 h-9 cursor-pointer overflow-hidden rounded border border-white/20 px-2 text-[11px] font-medium leading-9 text-white shadow-sm${selectedClasses}"
         style="${style}"
         title="${escapeHtml(title)}"
         aria-label="${escapeHtml(title)}">

--- a/public/js/activities/insights-renderer.js
+++ b/public/js/activities/insights-renderer.js
@@ -154,7 +154,7 @@ function renderTimelineBlock(block, type, viewport) {
     return `<div data-timeline-block="${type}" data-timeline-block-id="${escapeHtml(block.id)}"
         data-compact="${compact ? 'true' : 'false'}"
         data-selected="${selected ? 'true' : 'false'}"
-        role="img" class="absolute top-2 h-9 cursor-pointer overflow-hidden rounded border border-white/20 px-2 text-[11px] font-medium leading-9 text-white shadow-sm${selectedClasses}"
+        role="img" class="absolute top-1 min-h-[44px] cursor-pointer overflow-hidden rounded border border-white/20 px-2 text-[11px] font-medium leading-[44px] text-white shadow-sm${selectedClasses}"
         style="${style}"
         title="${escapeHtml(title)}"
         aria-label="${escapeHtml(title)}">
@@ -168,8 +168,8 @@ function renderTimelineTicks(viewport) {
 
     return `<div class="grid grid-cols-3 pl-[5.25rem] pr-1 pb-2 text-[10px] text-slate-500">
         <span>${escapeHtml(formatMinutesAsTime(viewport.startMinutes))}</span>
-        <span class="text-center">${escapeHtml(formatMinutesAsTime(midpoint))}</span>
-        <span class="text-right">${escapeHtml(formatMinutesAsTime(viewport.endMinutes))}</span>
+        <span class="hidden text-center sm:block">${escapeHtml(formatMinutesAsTime(midpoint))}</span>
+        <span class="col-start-3 text-right">${escapeHtml(formatMinutesAsTime(viewport.endMinutes))}</span>
     </div>`;
 }
 
@@ -178,7 +178,7 @@ function renderTimelineRow(label, type, blocks, viewport) {
 
     return `<div class="grid grid-cols-[4.5rem_1fr] items-center gap-3">
         <div class="text-xs font-medium uppercase text-slate-400">${escapeHtml(label)}</div>
-        <div class="relative h-12 rounded-lg border border-slate-700/70 bg-slate-950/60">
+        <div class="relative min-h-[3.5rem] rounded-lg border border-slate-700/70 bg-slate-950/60">
             ${blocksHtml}
         </div>
     </div>`;

--- a/public/js/activities/summary.js
+++ b/public/js/activities/summary.js
@@ -1,8 +1,7 @@
 import {
     resolveCategoryKey,
     getGroupByKey,
-    getCategoryByKey,
-    getTaxonomySnapshot
+    getCategoryByKey
 } from '../taxonomy/taxonomy-selectors.js';
 
 function titleCaseKey(value) {
@@ -99,9 +98,6 @@ export function summarizeExpandedChildCategories(activities, expandedParentGroup
         return null;
     }
 
-    const parentHasChildren = getTaxonomySnapshot().categories.some(
-        (category) => category.groupKey === expandedParentGroupKey
-    );
     const summaryMap = new Map();
 
     for (const activity of activities) {
@@ -128,7 +124,7 @@ export function summarizeExpandedChildCategories(activities, expandedParentGroup
 
             summaryMap.set(syntheticKey, {
                 key: syntheticKey,
-                label: parentHasChildren ? 'Unspecified' : parentGroup.label,
+                label: parentGroup.label,
                 color: parentGroup.color,
                 duration: activity.duration
             });

--- a/public/js/activities/ui-handlers.js
+++ b/public/js/activities/ui-handlers.js
@@ -228,7 +228,7 @@ export function handleActivityListClick(target, deps) {
         return true;
     }
 
-    const taskElement = target.closest('.task-item, .task-card');
+    const taskElement = target.closest('.task-item, .task-card, form[id^="edit-task-"]');
     const deleteButton = target.closest('.btn-delete, .btn-delete-unscheduled');
 
     if (!taskElement && !deleteButton) {

--- a/public/js/activities/view-toggle.js
+++ b/public/js/activities/view-toggle.js
@@ -42,8 +42,21 @@ export function syncActivitiesViewToggle(activitiesEnabled) {
     }
 
     viewToggle?.classList.toggle('hidden', !activitiesEnabled);
-    tasksView?.classList.toggle('hidden', activeView !== 'tasks');
-    insightsView?.classList.toggle('hidden', !activitiesEnabled || activeView !== 'insights');
+
+    const showTasks = activeView === 'tasks';
+    const showInsights = activitiesEnabled && activeView === 'insights';
+
+    if (tasksView) {
+        tasksView.classList.toggle('view-panel--visible', showTasks);
+        tasksView.classList.toggle('view-panel--hidden', !showTasks);
+        tasksView.classList.remove('hidden');
+    }
+    if (insightsView) {
+        insightsView.classList.toggle('view-panel--visible', showInsights);
+        insightsView.classList.toggle('view-panel--hidden', !showInsights);
+        insightsView.classList.remove('hidden');
+    }
+
     setButtonState(tasksButton, activeView === 'tasks');
     setButtonState(insightsButton, activeView === 'insights');
 

--- a/public/js/dom-renderer.js
+++ b/public/js/dom-renderer.js
@@ -264,6 +264,12 @@ function setTaskActionMenuElevation(menu, isElevated) {
     actions?.closest('[data-task-id]')?.classList.toggle('z-40', isElevated);
 }
 
+function setActionMenuTransitionState(menu, isOpen) {
+    menu.classList.add('action-menu-content');
+    menu.classList.toggle('action-menu-content--open', isOpen);
+    menu.classList.toggle('action-menu-content--closed', !isOpen);
+}
+
 function closeScheduledTaskActionMenus(exceptMenu = null) {
     const taskListElement = getScheduledTaskListElement();
     if (!taskListElement) return;
@@ -271,6 +277,7 @@ function closeScheduledTaskActionMenus(exceptMenu = null) {
     taskListElement.querySelectorAll('.task-actions-menu').forEach((menu) => {
         if (menu === exceptMenu) return;
         menu.hidden = true;
+        setActionMenuTransitionState(menu, false);
         setTaskActionMenuElevation(menu, false);
         const trigger = menu.parentElement?.querySelector('.btn-task-actions-menu');
         if (trigger instanceof HTMLElement) {
@@ -286,6 +293,7 @@ function toggleScheduledTaskActionMenu(trigger) {
     const shouldOpen = menu.hidden;
     closeScheduledTaskActionMenus(shouldOpen ? menu : null);
     menu.hidden = !shouldOpen;
+    setActionMenuTransitionState(menu, shouldOpen);
     setTaskActionMenuElevation(menu, shouldOpen);
     trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
 }
@@ -297,6 +305,7 @@ function closeUnscheduledTaskActionMenus(exceptMenu = null) {
     taskListElement.querySelectorAll('.unscheduled-task-actions-menu').forEach((menu) => {
         if (menu === exceptMenu) return;
         menu.hidden = true;
+        setActionMenuTransitionState(menu, false);
         setTaskActionMenuElevation(menu, false);
         const trigger = menu.parentElement?.querySelector('.btn-unscheduled-task-actions-menu');
         if (trigger instanceof HTMLElement) {
@@ -312,6 +321,7 @@ function toggleUnscheduledTaskActionMenu(trigger) {
     const shouldOpen = menu.hidden;
     closeUnscheduledTaskActionMenus(shouldOpen ? menu : null);
     menu.hidden = !shouldOpen;
+    setActionMenuTransitionState(menu, shouldOpen);
     setTaskActionMenuElevation(menu, shouldOpen);
     trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
 }

--- a/public/js/settings-renderer.js
+++ b/public/js/settings-renderer.js
@@ -63,7 +63,7 @@ export function renderSettingsContent(options = {}) {
                 </label>
             </div>
 
-            <div id="reload-prompt" class="hidden bg-slate-700/50 border border-slate-600 rounded-lg p-3 text-sm">
+            <div id="reload-prompt" class="settings-reload-prompt hidden bg-slate-700/50 border border-slate-600 rounded-lg p-3 text-sm">
                 <p class="text-slate-300 mb-2" id="reload-prompt-message"></p>
                 <button id="reload-apply-btn" type="button" class="bg-teal-500 hover:bg-teal-400 text-white px-4 py-1.5 rounded-lg text-sm transition-colors">
                     Reload to Apply
@@ -120,6 +120,7 @@ function wireSettingsEvents(options) {
 
             if (reloadPrompt) {
                 reloadPrompt.classList.remove('hidden');
+                reloadPrompt.classList.add('settings-reload-prompt--visible');
             }
             if (message) {
                 message.textContent = newValue

--- a/public/js/tasks/scheduled-renderer.js
+++ b/public/js/tasks/scheduled-renderer.js
@@ -310,6 +310,54 @@ function replaceScheduledTaskContent(taskListElement, html) {
     taskListElement.insertBefore(fragment, afterBoundary);
 }
 
+function captureScheduledEditDrafts(taskListElement) {
+    const drafts = new Map();
+
+    taskListElement.querySelectorAll('form[id^="edit-task-"][data-task-id]').forEach((form) => {
+        const taskId = form.getAttribute('data-task-id');
+        if (!taskId) {
+            return;
+        }
+
+        drafts.set(taskId, {
+            description: form.querySelector('input[name="description"]')?.value,
+            startTime: form.querySelector('input[name="start-time"]')?.value,
+            durationHours: form.querySelector('input[name="duration-hours"]')?.value,
+            durationMinutes: form.querySelector('input[name="duration-minutes"]')?.value,
+            category: form.querySelector('select[name="category"]')?.value
+        });
+    });
+
+    return drafts;
+}
+
+function applyScheduledEditDrafts(taskListElement, drafts) {
+    taskListElement.querySelectorAll('form[id^="edit-task-"][data-task-id]').forEach((form) => {
+        const draft = drafts.get(form.getAttribute('data-task-id'));
+        if (!draft) {
+            return;
+        }
+
+        const fields = [
+            ['input[name="description"]', draft.description],
+            ['input[name="start-time"]', draft.startTime],
+            ['input[name="duration-hours"]', draft.durationHours],
+            ['input[name="duration-minutes"]', draft.durationMinutes],
+            ['select[name="category"]', draft.category]
+        ];
+
+        fields.forEach(([selector, value]) => {
+            const field = form.querySelector(selector);
+            if (
+                value !== undefined &&
+                (field instanceof HTMLInputElement || field instanceof HTMLSelectElement)
+            ) {
+                field.value = value;
+            }
+        });
+    });
+}
+
 /**
  * Renders all scheduled tasks
  * @param {Array} tasksToRender - All tasks
@@ -349,6 +397,7 @@ export function renderTasks(
 
     const gaps = findScheduleGaps(tasksToRender);
     const gapAfterTask = new Map(gaps.map((g) => [g.afterTaskId, g]));
+    const editDrafts = captureScheduledEditDrafts(taskListElement);
 
     let html = '';
     scheduledTasks.forEach((task) => {
@@ -376,6 +425,7 @@ export function renderTasks(
     beforeBoundary.dataset.boundaryTime = scheduledTasks[0].startDateTime;
     afterBoundary.dataset.boundaryTime = scheduledTasks[scheduledTasks.length - 1].endDateTime;
     replaceScheduledTaskContent(taskListElement, html);
+    applyScheduledEditDrafts(taskListElement, editDrafts);
 
     // Populate end time hints and overlap warnings for any edit forms
     taskListElement.querySelectorAll('form[id^="edit-task-"]').forEach((form) => {

--- a/test_phase6_e2e.py
+++ b/test_phase6_e2e.py
@@ -1,0 +1,83 @@
+"""Phase 6 E2E checks for mobile Insights behavior."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).parent / "scripts"))
+from playwright_preview_smoke import (  # noqa: E402
+    build_relative_day_activity_doc,
+    build_relative_day_scheduled_task_doc,
+    clear_room_storage,
+    dismiss_open_modals,
+    enter_room,
+    install_local_pouchdb_route,
+    seed_docs,
+    wait_for_main_app,
+)
+
+BASE_URL = "http://127.0.0.1:9847"
+ROOM_CODE = "phase6-mobile"
+
+
+@pytest.mark.parametrize("viewport_width", [375, 768])
+def test_mobile_insights_has_no_horizontal_overflow(viewport_width: int):
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True, channel="chrome")
+        context = browser.new_context(viewport={"width": viewport_width, "height": 812})
+        install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
+        page = context.new_page()
+
+        try:
+            page.goto(BASE_URL, wait_until="load")
+            page.evaluate("localStorage.clear()")
+            clear_room_storage(page, ROOM_CODE)
+            seed_docs(
+                page,
+                ROOM_CODE,
+                [
+                    {
+                        "_id": "config-settings",
+                        "id": "config-settings",
+                        "docType": "config",
+                        "activitiesEnabled": True,
+                    },
+                    build_relative_day_scheduled_task_doc(
+                        page,
+                        doc_id="phase6-mobile-task",
+                        description="Mobile planning block",
+                        day_offset=0,
+                        start_hour=9,
+                        start_minute=0,
+                        duration_minutes=45,
+                    ),
+                    build_relative_day_activity_doc(
+                        page,
+                        doc_id="phase6-mobile-activity",
+                        description="Mobile actual block",
+                        day_offset=0,
+                        start_hour=9,
+                        start_minute=15,
+                        duration_minutes=35,
+                    ),
+                ],
+            )
+
+            enter_room(page, ROOM_CODE)
+            wait_for_main_app(page)
+            dismiss_open_modals(page)
+            page.locator("#view-toggle-insights").click()
+            page.locator("#insights-timeline").wait_for(state="visible", timeout=10000)
+
+            has_horizontal_overflow = page.evaluate(
+                "document.documentElement.scrollWidth > document.documentElement.clientWidth"
+            )
+
+            assert has_horizontal_overflow is False
+        finally:
+            context.close()
+            browser.close()

--- a/test_phase6_e2e.py
+++ b/test_phase6_e2e.py
@@ -16,6 +16,7 @@ from playwright_preview_smoke import (  # noqa: E402
     dismiss_open_modals,
     enter_room,
     install_local_pouchdb_route,
+    open_scheduled_edit_form,
     seed_docs,
     wait_for_main_app,
 )
@@ -78,6 +79,58 @@ def test_mobile_insights_has_no_horizontal_overflow(viewport_width: int):
             )
 
             assert has_horizontal_overflow is False
+        finally:
+            context.close()
+            browser.close()
+
+
+def test_mobile_scheduled_edit_draft_survives_delayed_ui_refresh():
+    room_code = "phase6-mobile-edit-draft"
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True, channel="chrome")
+        context = browser.new_context(viewport={"width": 375, "height": 812})
+        install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
+        page = context.new_page()
+
+        try:
+            page.goto(BASE_URL, wait_until="load")
+            page.evaluate("localStorage.clear()")
+            clear_room_storage(page, room_code)
+            seed_docs(
+                page,
+                room_code,
+                [
+                    {
+                        "_id": "config-settings",
+                        "id": "config-settings",
+                        "docType": "config",
+                        "activitiesEnabled": True,
+                    },
+                    build_relative_day_scheduled_task_doc(
+                        page,
+                        doc_id="phase6-edit-draft-task",
+                        description="Draft preservation task",
+                        day_offset=0,
+                        start_hour=9,
+                        start_minute=0,
+                        duration_minutes=30,
+                    ),
+                ],
+            )
+
+            enter_room(page, room_code)
+            wait_for_main_app(page)
+            dismiss_open_modals(page)
+
+            edit_form = open_scheduled_edit_form(page, "phase6-edit-draft-task")
+            duration_minutes = page.locator(f'{edit_form} input[name="duration-minutes"]')
+            duration_minutes.fill("45")
+
+            page.evaluate("import('/js/dom-renderer.js').then(({ refreshUI }) => refreshUI())")
+            page.wait_for_timeout(500)
+
+            assert duration_minutes.input_value() == "45"
         finally:
             context.close()
             browser.close()


### PR DESCRIPTION
## Summary

Combines Phase 6A and 6B polish work:

- Adds reduced-motion coverage and transition classes for view switching, task action menus, reload prompts, and selected timeline blocks.
- Updates Activities view switching to use opacity transition classes for the main panels.
- Adapts Insights timeline rows and blocks for mobile touch targets and responsive tick labels.
- Adds focused Jest coverage plus mobile Playwright coverage at 375px and 768px.

## Stack

Base PR in the Phase 6 stack. Merge this before the onboarding and E2E follow-up PRs.

## Validation

- npm test -- --coverage
- npm run check
- python -m pytest test_phase6_e2e.py -v via local server wrapper for mobile coverage
