### PR TITLE
Phase 6C: add Activities onboarding polish

### DIFF
--- a/__tests__/activity-onboarding.test.js
+++ b/__tests__/activity-onboarding.test.js
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('../public/js/settings-manager.js', () => ({
+    isOnboardingDismissed: jest.fn(() => false),
+    setOnboardingDismissed: jest.fn(() => Promise.resolve())
+}));
+
+import { isOnboardingDismissed, setOnboardingDismissed } from '../public/js/settings-manager.js';
+
+function renderTargets() {
+    document.body.innerHTML = `
+        <div id="activity-toggle-option"></div>
+        <button id="start-timer-btn" type="button"></button>
+        <button id="view-toggle-insights" type="button"></button>
+    `;
+}
+
+describe('activity onboarding walkthrough', () => {
+    beforeEach(() => {
+        document.getElementById('activity-onboarding')?.remove();
+        jest.clearAllMocks();
+        isOnboardingDismissed.mockReturnValue(false);
+        setOnboardingDismissed.mockResolvedValue();
+        renderTargets();
+    });
+
+    test('does nothing when Activities are disabled', async () => {
+        const { maybeShowOnboarding } = await import('../public/js/activities/onboarding.js');
+
+        await maybeShowOnboarding({ activitiesEnabled: false });
+
+        expect(document.querySelector('[data-activity-onboarding]')).toBeNull();
+        expect(setOnboardingDismissed).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when onboarding was already dismissed for the room', async () => {
+        isOnboardingDismissed.mockReturnValue(true);
+        const { maybeShowOnboarding } = await import('../public/js/activities/onboarding.js');
+
+        await maybeShowOnboarding({ activitiesEnabled: true });
+
+        expect(document.querySelector('[data-activity-onboarding]')).toBeNull();
+        expect(setOnboardingDismissed).not.toHaveBeenCalled();
+    });
+
+    test('renders the first tooltip and highlights its target', async () => {
+        const { maybeShowOnboarding } = await import('../public/js/activities/onboarding.js');
+
+        await maybeShowOnboarding({ activitiesEnabled: true });
+
+        const tooltip = document.querySelector('[data-activity-onboarding]');
+        expect(tooltip).not.toBeNull();
+        expect(tooltip.textContent).toContain('Activity mode');
+        expect(tooltip.textContent).toContain('1 of 3');
+        expect(document.getElementById('activity-toggle-option').className).toContain(
+            'activity-onboarding-target'
+        );
+    });
+
+    test('advances through all steps and persists dismissal on Done', async () => {
+        const { maybeShowOnboarding } = await import('../public/js/activities/onboarding.js');
+        await maybeShowOnboarding({ activitiesEnabled: true });
+
+        document.querySelector('[data-activity-onboarding-next]').click();
+        expect(document.querySelector('[data-activity-onboarding]').textContent).toContain(
+            'Live timer'
+        );
+        expect(document.getElementById('start-timer-btn').className).toContain(
+            'activity-onboarding-target'
+        );
+
+        document.querySelector('[data-activity-onboarding-next]').click();
+        expect(document.querySelector('[data-activity-onboarding]').textContent).toContain(
+            'Insights'
+        );
+        expect(document.getElementById('view-toggle-insights').className).toContain(
+            'activity-onboarding-target'
+        );
+
+        document.querySelector('[data-activity-onboarding-next]').click();
+        await Promise.resolve();
+
+        expect(setOnboardingDismissed).toHaveBeenCalledWith(true);
+        expect(document.querySelector('[data-activity-onboarding]')).toBeNull();
+    });
+
+    test('skip persists dismissal and removes the tooltip', async () => {
+        const { maybeShowOnboarding } = await import('../public/js/activities/onboarding.js');
+        await maybeShowOnboarding({ activitiesEnabled: true });
+
+        document.querySelector('[data-activity-onboarding-skip]').click();
+        await Promise.resolve();
+
+        expect(setOnboardingDismissed).toHaveBeenCalledWith(true);
+        expect(document.querySelector('[data-activity-onboarding]')).toBeNull();
+        expect(document.getElementById('activity-toggle-option').className).not.toContain(
+            'activity-onboarding-target'
+        );
+    });
+});

--- a/__tests__/modal-manager.test.js
+++ b/__tests__/modal-manager.test.js
@@ -225,6 +225,23 @@ describe('Modal Manager Tests', () => {
                 const title = document.getElementById('custom-alert-title');
                 expect(title.className).toContain('text-teal-400');
             });
+
+            test('Escape key closes visible alert modal', () => {
+                showCustomAlert('Title', 'Message');
+
+                const modal = document.getElementById('custom-alert-modal');
+                expect(modal.classList.contains('hidden')).toBe(false);
+
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+                expect(modal.classList.contains('hidden')).toBe(true);
+            });
+
+            test('Escape key does not error when no alert modal is visible', () => {
+                expect(() => {
+                    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+                }).not.toThrow();
+            });
         });
 
         describe('Custom Confirm Modal', () => {
@@ -282,6 +299,38 @@ describe('Modal Manager Tests', () => {
 
                 const okBtn = document.getElementById('ok-custom-confirm-modal');
                 okBtn.click();
+            });
+
+            test('Escape key closes visible confirm modal and resolves false', async () => {
+                const resultPromise = showCustomConfirm('Confirm', 'Message');
+                const modal = document.getElementById('custom-confirm-modal');
+
+                expect(modal.classList.contains('hidden')).toBe(false);
+
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+                expect(modal.classList.contains('hidden')).toBe(true);
+                await expect(resultPromise).resolves.toBe(false);
+            });
+
+            test('confirm Escape listener is cleaned up after OK resolves', async () => {
+                const resultPromise = showCustomConfirm('Confirm', 'Message');
+                const okBtn = document.getElementById('ok-custom-confirm-modal');
+
+                okBtn.click();
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+                await expect(resultPromise).resolves.toBe(true);
+            });
+
+            test('confirm Escape listener is cleaned up after cancel resolves', async () => {
+                const resultPromise = showCustomConfirm('Confirm', 'Message');
+                const cancelBtn = document.getElementById('cancel-custom-confirm-modal');
+
+                cancelBtn.click();
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+                await expect(resultPromise).resolves.toBe(false);
             });
         });
 

--- a/__tests__/settings-manager.test.js
+++ b/__tests__/settings-manager.test.js
@@ -22,8 +22,10 @@ import * as storage from '../public/js/storage.js';
 import { initStorage, destroyStorage, loadConfig, putConfig } from '../public/js/storage.js';
 import {
     loadSettings,
+    isOnboardingDismissed,
     isActivitiesEnabled,
     setActivitiesEnabled,
+    setOnboardingDismissed,
     SETTINGS_CONFIG_ID
 } from '../public/js/settings-manager.js';
 
@@ -55,6 +57,14 @@ describe('settings-manager', () => {
         await loadSettings();
 
         expect(isActivitiesEnabled()).toBe(true);
+    });
+
+    test('loadSettings reads onboardingDismissed from PouchDB config doc', async () => {
+        await initStorage(uniqueRoomCode(), { adapter: 'memory' });
+        await putConfig({ id: SETTINGS_CONFIG_ID, onboardingDismissed: true });
+        await loadSettings();
+
+        expect(isOnboardingDismissed()).toBe(true);
     });
 
     test('loadSettings migrates from localStorage when no PouchDB config exists', async () => {
@@ -119,6 +129,18 @@ describe('settings-manager', () => {
         expect(config.activitiesEnabled).toBe(true);
     });
 
+    test('setActivitiesEnabled preserves onboardingDismissed in PouchDB', async () => {
+        await initStorage(uniqueRoomCode(), { adapter: 'memory' });
+        await putConfig({ id: SETTINGS_CONFIG_ID, onboardingDismissed: true });
+        await loadSettings();
+
+        await setActivitiesEnabled(true);
+
+        const config = await loadConfig(SETTINGS_CONFIG_ID);
+        expect(config.activitiesEnabled).toBe(true);
+        expect(config.onboardingDismissed).toBe(true);
+    });
+
     test('setActivitiesEnabled(false) after true updates both cache and PouchDB', async () => {
         await initAndLoadSettings();
 
@@ -127,6 +149,17 @@ describe('settings-manager', () => {
         expect(isActivitiesEnabled()).toBe(false);
 
         const config = await loadConfig(SETTINGS_CONFIG_ID);
+        expect(config.activitiesEnabled).toBe(false);
+    });
+
+    test('setOnboardingDismissed updates cache and persists to PouchDB', async () => {
+        await initAndLoadSettings();
+
+        await setOnboardingDismissed(true);
+
+        expect(isOnboardingDismissed()).toBe(true);
+        const config = await loadConfig(SETTINGS_CONFIG_ID);
+        expect(config.onboardingDismissed).toBe(true);
         expect(config.activitiesEnabled).toBe(false);
     });
 

--- a/__tests__/whats-new.test.js
+++ b/__tests__/whats-new.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe("what's new modal", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        jest.resetModules();
+    });
+
+    test('does nothing when Activities are disabled', async () => {
+        const { maybeShowWhatsNew, WHATS_NEW_KEY } = await import('../public/js/whats-new.js');
+        const showAlert = jest.fn();
+
+        await maybeShowWhatsNew({ activitiesEnabled: false, showAlert });
+
+        expect(showAlert).not.toHaveBeenCalled();
+        expect(localStorage.getItem(WHATS_NEW_KEY)).toBeNull();
+    });
+
+    test('shows announcement when Activities are enabled and key is absent', async () => {
+        const { maybeShowWhatsNew } = await import('../public/js/whats-new.js');
+        const showAlert = jest.fn();
+
+        await maybeShowWhatsNew({ activitiesEnabled: true, showAlert });
+
+        expect(showAlert).toHaveBeenCalledWith(
+            "What's New in Fortudo",
+            expect.stringContaining('Activity Logging'),
+            'sky'
+        );
+    });
+
+    test('does not show announcement when already dismissed', async () => {
+        const { maybeShowWhatsNew, WHATS_NEW_KEY } = await import('../public/js/whats-new.js');
+        const showAlert = jest.fn();
+        localStorage.setItem(WHATS_NEW_KEY, 'dismissed');
+
+        await maybeShowWhatsNew({ activitiesEnabled: true, showAlert });
+
+        expect(showAlert).not.toHaveBeenCalled();
+    });
+
+    test('sets localStorage only after alert completes', async () => {
+        const { maybeShowWhatsNew, WHATS_NEW_KEY } = await import('../public/js/whats-new.js');
+        let resolveAlert;
+        const showAlert = jest.fn(
+            () =>
+                new Promise((resolve) => {
+                    resolveAlert = resolve;
+                })
+        );
+
+        const resultPromise = maybeShowWhatsNew({ activitiesEnabled: true, showAlert });
+
+        expect(localStorage.getItem(WHATS_NEW_KEY)).toBeNull();
+
+        resolveAlert();
+        await resultPromise;
+
+        expect(localStorage.getItem(WHATS_NEW_KEY)).toBe('dismissed');
+    });
+});

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -14,15 +14,25 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 @keyframes pulse-green {
-    0%, 100% { color: rgb(13, 148, 136); }  /* teal-600 */
-    50% { color: rgb(20, 184, 166); }       /* teal-500 */
+    0%,
+    100% {
+        color: rgb(13, 148, 136);
+    } /* teal-600 */
+    50% {
+        color: rgb(20, 184, 166);
+    } /* teal-500 */
 }
 .pulse-animation {
     animation: pulse-green 2s infinite;
 }
 @keyframes pulse-indigo {
-    0%, 100% { color: rgb(165, 180, 252); }  /* indigo-300 */
-    50% { color: rgb(129, 140, 248); }       /* indigo-400 */
+    0%,
+    100% {
+        color: rgb(165, 180, 252);
+    } /* indigo-300 */
+    50% {
+        color: rgb(129, 140, 248);
+    } /* indigo-400 */
 }
 .pulse-animation-indigo {
     animation: pulse-indigo 2s infinite;
@@ -38,7 +48,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, rgba(255,255,255,0.1), rgba(255,255,255,0.2));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.2));
     transform: translateX(-100%);
     transition: transform 0.5s ease;
 }
@@ -323,6 +333,12 @@
         box-shadow 100ms ease;
 }
 
+.activity-onboarding-target {
+    outline: 2px solid rgb(56 189 248 / 0.9);
+    outline-offset: 3px;
+    border-radius: 0.5rem;
+}
+
 .settings-reload-prompt {
     opacity: 0;
     transition: opacity 150ms ease;
@@ -364,6 +380,7 @@
     .view-panel,
     .action-menu-content,
     [data-timeline-block-id],
+    .activity-onboarding-target,
     .settings-reload-prompt {
         transition: none;
     }

--- a/public/js/activities/onboarding.js
+++ b/public/js/activities/onboarding.js
@@ -1,0 +1,105 @@
+import { isOnboardingDismissed, setOnboardingDismissed } from '../settings-manager.js';
+
+const ONBOARDING_ROOT_ID = 'activity-onboarding';
+const TARGET_CLASS = 'activity-onboarding-target';
+
+const STEPS = [
+    {
+        selector: '#activity-toggle-option',
+        title: 'Activity mode',
+        body: 'Use this form mode to log what actually happened without changing your plan.'
+    },
+    {
+        selector: '#start-timer-btn',
+        title: 'Live timer',
+        body: 'Start a timer from an activity or an unscheduled task when you begin focused work.'
+    },
+    {
+        selector: '#view-toggle-insights',
+        title: 'Insights',
+        body: 'Compare planned blocks with actual activity and review each selected day.'
+    }
+];
+
+let currentTarget = null;
+
+function removeExistingOnboarding() {
+    document.getElementById(ONBOARDING_ROOT_ID)?.remove();
+    currentTarget?.classList.remove(TARGET_CLASS);
+    currentTarget = null;
+}
+
+function getStepTarget(step) {
+    const target = document.querySelector(step.selector);
+    return target instanceof HTMLElement ? target : null;
+}
+
+async function dismissOnboarding() {
+    removeExistingOnboarding();
+    await setOnboardingDismissed(true);
+}
+
+function renderStep(stepIndex, { signal }) {
+    removeExistingOnboarding();
+
+    const step = STEPS[stepIndex];
+    const target = getStepTarget(step);
+    if (!target) {
+        return;
+    }
+
+    currentTarget = target;
+    target.classList.add(TARGET_CLASS);
+
+    const root = document.createElement('div');
+    root.id = ONBOARDING_ROOT_ID;
+    root.dataset.activityOnboarding = 'true';
+    root.className =
+        'fixed left-1/2 bottom-5 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 rounded-lg border border-sky-400/40 bg-slate-900 p-4 text-left shadow-2xl shadow-sky-950/50 sm:right-5 sm:left-auto sm:w-96 sm:translate-x-0';
+
+    const isLastStep = stepIndex === STEPS.length - 1;
+    root.innerHTML = `
+        <p class="text-xs font-semibold uppercase tracking-wide text-sky-300">${stepIndex + 1} of ${STEPS.length}</p>
+        <h3 class="mt-1 text-base font-semibold text-slate-100">${step.title}</h3>
+        <p class="mt-2 text-sm leading-6 text-slate-300">${step.body}</p>
+        <div class="mt-4 flex items-center justify-end gap-2">
+            <button type="button" data-activity-onboarding-skip class="rounded-md px-3 py-2 text-sm text-slate-400 hover:text-slate-200">Skip</button>
+            <button type="button" data-activity-onboarding-next class="rounded-md bg-sky-500 px-3 py-2 text-sm font-semibold text-white hover:bg-sky-400">${isLastStep ? 'Done' : 'Next'}</button>
+        </div>
+    `;
+
+    document.body.appendChild(root);
+
+    root.querySelector('[data-activity-onboarding-skip]')?.addEventListener(
+        'click',
+        () => {
+            void dismissOnboarding();
+        },
+        { signal }
+    );
+    root.querySelector('[data-activity-onboarding-next]')?.addEventListener(
+        'click',
+        () => {
+            if (isLastStep) {
+                void dismissOnboarding();
+                return;
+            }
+
+            renderStep(stepIndex + 1, { signal });
+        },
+        { signal }
+    );
+}
+
+/**
+ * Shows the one-time Activities onboarding walkthrough for this room.
+ * @param {{ activitiesEnabled?: boolean, signal?: AbortSignal }} [options]
+ */
+export async function maybeShowOnboarding({ activitiesEnabled = false, signal } = {}) {
+    if (!activitiesEnabled || isOnboardingDismissed() || signal?.aborted) {
+        return;
+    }
+
+    signal?.addEventListener('abort', removeExistingOnboarding, { once: true });
+    renderStep(0, { signal });
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -60,6 +60,7 @@ import {
     openSettingsAfterActivitiesReloadIfNeeded,
     renderSettingsContent
 } from './settings-renderer.js';
+import { maybeShowWhatsNew } from './whats-new.js';
 import { refreshTaskCategoryDropdownUI } from './settings/taxonomy-settings.js';
 import { logger } from './utils.js';
 import { createScheduledTaskCallbacks } from './tasks/scheduled-handlers.js';
@@ -142,6 +143,7 @@ async function initAndBootApp(roomCode) {
     // Load settings before any UI checks that depend on cached flags.
     await loadSettings();
     syncActivitiesUI(isActivitiesEnabled());
+    void maybeShowWhatsNew({ activitiesEnabled: isActivitiesEnabled() });
 
     // Load and initialize state
     await loadAppState();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -50,6 +50,7 @@ import {
     initializeActivitiesViewToggle,
     renderActiveInsightsView
 } from './activities/view-toggle.js';
+import { maybeShowOnboarding } from './activities/onboarding.js';
 import { renderInsightsView } from './activities/insights-renderer.js';
 import { createRoomSessionLifecycle } from './app-lifecycle.js';
 import { prepareStorage, loadTasks } from './storage.js';
@@ -143,7 +144,11 @@ async function initAndBootApp(roomCode) {
     // Load settings before any UI checks that depend on cached flags.
     await loadSettings();
     syncActivitiesUI(isActivitiesEnabled());
-    void maybeShowWhatsNew({ activitiesEnabled: isActivitiesEnabled() });
+    void (async () => {
+        const activitiesEnabled = isActivitiesEnabled();
+        await maybeShowWhatsNew({ activitiesEnabled });
+        await maybeShowOnboarding({ activitiesEnabled, signal });
+    })();
 
     // Load and initialize state
     await loadAppState();

--- a/public/js/modal-manager.js
+++ b/public/js/modal-manager.js
@@ -42,6 +42,8 @@ const saveActivityEditButton = document.getElementById('save-activity-edit-modal
 const activityEditForm = document.getElementById('activity-edit-form');
 const activityEditDescriptionInput = document.getElementById('activity-edit-description');
 
+let cleanupCustomAlertEscape = null;
+
 // --- Helper Functions ---
 function setModalTheme(modal, title, button, theme = 'indigo') {
     const titleClasses = {
@@ -66,6 +68,8 @@ function setModalTheme(modal, title, button, theme = 'indigo') {
 
 // --- Custom Alert Modal ---
 export function hideCustomAlert() {
+    cleanupCustomAlertEscape?.();
+    cleanupCustomAlertEscape = null;
     if (customAlertModal) customAlertModal.classList.add('hidden');
 }
 
@@ -75,6 +79,16 @@ export function showCustomAlert(title, message, theme = 'indigo') {
         customAlertMessage.textContent = message;
         setModalTheme(customAlertModal, customAlertTitle, okCustomAlertButton, theme);
         customAlertModal.classList.remove('hidden');
+        cleanupCustomAlertEscape?.();
+        const handleEscape = (event) => {
+            if (event.key === 'Escape') {
+                hideCustomAlert();
+            }
+        };
+        document.addEventListener('keydown', handleEscape);
+        cleanupCustomAlertEscape = () => {
+            document.removeEventListener('keydown', handleEscape);
+        };
     } else {
         logger.error('Custom alert modal elements not found. Falling back to window.alert.');
         window.alert(`${title}: ${message}`);
@@ -146,6 +160,33 @@ export function showCustomConfirm(
 
             setModalTheme(customConfirmModal, customConfirmTitle, newOkBtn, theme);
             customConfirmModal.classList.remove('hidden');
+
+            let settled = false;
+            const settle = (value) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                document.removeEventListener('keydown', handleEscape);
+                hideCustomConfirm();
+                resolve(value);
+            };
+            const handleEscape = (event) => {
+                if (event.key === 'Escape') {
+                    settle(false);
+                }
+            };
+            document.addEventListener('keydown', handleEscape);
+
+            if (newOkBtn instanceof HTMLElement) {
+                newOkBtn.onclick = () => settle(true);
+            }
+            if (newCancelBtn instanceof HTMLElement) {
+                newCancelBtn.onclick = () => settle(false);
+            }
+            if (newCloseBtn instanceof HTMLElement) {
+                newCloseBtn.onclick = () => settle(false);
+            }
         });
     } else {
         logger.error('Custom confirm modal elements not found or not HTMLElements.');

--- a/public/js/settings-manager.js
+++ b/public/js/settings-manager.js
@@ -4,6 +4,15 @@ export const SETTINGS_CONFIG_ID = 'config-settings';
 const LEGACY_STORAGE_KEY = 'fortudo-activities-enabled';
 
 let activitiesEnabled = false;
+let onboardingDismissed = false;
+
+function getSettingsConfig() {
+    return {
+        id: SETTINGS_CONFIG_ID,
+        activitiesEnabled,
+        onboardingDismissed
+    };
+}
 
 /**
  * Load settings from PouchDB config doc, migrating from localStorage if needed.
@@ -13,6 +22,7 @@ export async function loadSettings() {
     const config = await loadConfig(SETTINGS_CONFIG_ID);
     if (config) {
         activitiesEnabled = !!config.activitiesEnabled;
+        onboardingDismissed = !!config.onboardingDismissed;
         return;
     }
 
@@ -20,7 +30,8 @@ export async function loadSettings() {
         const legacyValue = localStorage.getItem(LEGACY_STORAGE_KEY);
         if (legacyValue === 'true') {
             activitiesEnabled = true;
-            await putConfig({ id: SETTINGS_CONFIG_ID, activitiesEnabled: true });
+            onboardingDismissed = false;
+            await putConfig(getSettingsConfig());
             localStorage.removeItem(LEGACY_STORAGE_KEY);
             return;
         }
@@ -29,6 +40,7 @@ export async function loadSettings() {
     }
 
     activitiesEnabled = false;
+    onboardingDismissed = false;
 }
 
 /**
@@ -41,11 +53,30 @@ export function isActivitiesEnabled() {
 }
 
 /**
+ * Check whether the Activities onboarding walkthrough was dismissed for this room.
+ * Synchronous: reads from in-memory cache populated by loadSettings().
+ * @returns {boolean}
+ */
+export function isOnboardingDismissed() {
+    return onboardingDismissed;
+}
+
+/**
  * Enable or disable the Activities feature.
  * Updates in-memory cache immediately and persists to PouchDB.
  * @param {boolean} enabled
  */
 export async function setActivitiesEnabled(enabled) {
     activitiesEnabled = !!enabled;
-    await putConfig({ id: SETTINGS_CONFIG_ID, activitiesEnabled });
+    await putConfig(getSettingsConfig());
+}
+
+/**
+ * Mark the Activities onboarding walkthrough dismissed or available for this room.
+ * Updates in-memory cache immediately and persists to PouchDB.
+ * @param {boolean} dismissed
+ */
+export async function setOnboardingDismissed(dismissed) {
+    onboardingDismissed = !!dismissed;
+    await putConfig(getSettingsConfig());
 }

--- a/public/js/whats-new.js
+++ b/public/js/whats-new.js
@@ -1,0 +1,33 @@
+import { showCustomAlert } from './modal-manager.js';
+
+export const WHATS_NEW_KEY = 'fortudo-whats-new-activities-v1';
+
+const WHATS_NEW_TITLE = "What's New in Fortudo";
+const WHATS_NEW_MESSAGE = [
+    'Activity Logging - Track what you actually do alongside your plan.',
+    'Live Timer - Start/stop capture with automatic activity logging.',
+    'Insights View - Plan vs actual timeline with trend day cards.'
+].join('\n\n');
+
+/**
+ * Shows the one-time Activities announcement for this browser.
+ * @param {{ activitiesEnabled?: boolean, showAlert?: Function }} [options]
+ */
+export async function maybeShowWhatsNew({
+    activitiesEnabled = false,
+    showAlert = showCustomAlert
+} = {}) {
+    if (!activitiesEnabled) {
+        return;
+    }
+
+    if (typeof localStorage !== 'undefined' && localStorage.getItem(WHATS_NEW_KEY)) {
+        return;
+    }
+
+    await Promise.resolve(showAlert(WHATS_NEW_TITLE, WHATS_NEW_MESSAGE, 'sky'));
+
+    if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(WHATS_NEW_KEY, 'dismissed');
+    }
+}


### PR DESCRIPTION
## Summary

Adds Phase 6C onboarding polish:

- Adds Escape handling for custom alert and confirm modals.
- Adds a one-time browser-scoped Activities what's-new modal.
- Adds room-scoped Activities onboarding backed by the PouchDB settings config doc.
- Preserves settings config fields when toggling Activities.

## Stack

Stacked on #81 / `phase6ab-polish-mobile`. Review after the 6A/B polish PR.

## Validation

- npm test -- --coverage
- npm run check
- focused Jest coverage for modal Escape, what's-new, settings persistence, and onboarding walkthrough behavior
