### PR TITLE
Phase 6D: add persistence E2E coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,7 +90,7 @@ jobs:
 
             - name: Install Playwright
               run: |
-                  pip install playwright
+                  pip install playwright pytest
                   python -m playwright install chromium --with-deps
 
             - name: Run E2E tests

--- a/public/js/activities/app-wiring.js
+++ b/public/js/activities/app-wiring.js
@@ -40,6 +40,18 @@ function getRefreshUiForClickTarget(target, refreshUI) {
     return refreshUI;
 }
 
+/**
+ * Create app-level callbacks that bridge generic task UI events to Activities behavior.
+ * @param {Object} options
+ * @param {Function} options.getActivitiesEnabled
+ * @param {Function} options.refreshUI
+ * @param {Function} options.resetAllConfirmingDeleteFlags
+ * @param {Function} options.handleTaskSubmit
+ * @param {Function} options.focusTaskDescriptionInput
+ * @param {Function} options.resetTaskFormPreviewState
+ * @param {Function} options.initializeTaskTypeToggle
+ * @returns {{ onTaskFormSubmit: Function, onGlobalClick: Function }}
+ */
 export function createActivityAppCallbacks({
     getActivitiesEnabled,
     refreshUI,
@@ -166,6 +178,15 @@ function initializeInsightsTimelineEventHandlers(timelineElement, { signal, rend
     );
 }
 
+/**
+ * Initialize Activities event handlers and timer UI for the current app lifecycle.
+ * @param {Object} options
+ * @param {AbortSignal} options.signal
+ * @param {Function} options.refreshUI
+ * @param {Function} options.refreshTaskDisplays
+ * @param {Function} options.getActivitiesEnabled
+ * @param {Function} [options.renderInsights]
+ */
 export function initializeActivityUi({
     signal,
     refreshUI,
@@ -200,6 +221,10 @@ export function initializeActivityUi({
     });
 }
 
+/**
+ * Sync form mode and timer fields after loading a persisted running timer.
+ * @param {boolean} activitiesEnabled
+ */
 export function syncRestoredRunningTimer(activitiesEnabled) {
     if (!activitiesEnabled) {
         return;
@@ -217,6 +242,10 @@ export function syncRestoredRunningTimer(activitiesEnabled) {
     syncTimerFormState();
 }
 
+/**
+ * Refresh the timer display when the running timer may have changed.
+ * @param {boolean} activitiesEnabled
+ */
 export function syncRunningTimerDisplay(activitiesEnabled) {
     if (!activitiesEnabled) {
         return;

--- a/test_phase6_e2e.py
+++ b/test_phase6_e2e.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -31,6 +32,15 @@ from playwright_preview_smoke import (  # noqa: E402
 
 BASE_URL = "http://127.0.0.1:9847"
 ROOM_CODE = "phase6-mobile"
+BROWSER_CHANNEL = os.environ.get("E2E_BROWSER_CHANNEL", "chromium")
+
+
+def launch_browser(playwright):
+    """Launch chromium; set E2E_BROWSER_CHANNEL=chrome to use system Chrome instead."""
+    options = {"headless": True}
+    if BROWSER_CHANNEL != "chromium":
+        options["channel"] = BROWSER_CHANNEL
+    return playwright.chromium.launch(**options)
 
 
 def get_onboarding_target(page):
@@ -65,7 +75,7 @@ def test_activities_onboarding_prepares_ui_and_persists_dismissal():
     room_code = "phase6-onboarding-sequence"
 
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=True, channel="chrome")
+        browser = launch_browser(playwright)
         context = browser.new_context(viewport={"width": 390, "height": 844})
         install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
         page = context.new_page()
@@ -139,12 +149,7 @@ def test_activities_onboarding_prepares_ui_and_persists_dismissal():
 # onboarding sequence that follows Activities enablement.
 
 
-def launch_seeded_page(playwright, room_code: str, docs: list[dict] | None = None):
-    browser = playwright.chromium.launch(headless=True, channel="chrome")
-    context = browser.new_context(viewport={"width": 1280, "height": 900})
-    install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
-    page = context.new_page()
-
+def seed_and_enter_room(page, room_code: str, docs: list[dict] | None = None) -> None:
     page.goto(BASE_URL, wait_until="load")
     page.evaluate("localStorage.clear()")
     clear_room_storage(page, room_code)
@@ -152,6 +157,14 @@ def launch_seeded_page(playwright, room_code: str, docs: list[dict] | None = Non
     enter_room(page, room_code)
     wait_for_main_app(page)
     dismiss_open_modals(page)
+
+
+def launch_seeded_page(playwright, room_code: str, docs: list[dict] | None = None):
+    browser = launch_browser(playwright)
+    context = browser.new_context(viewport={"width": 1280, "height": 900})
+    install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
+    page = context.new_page()
+    seed_and_enter_room(page, room_code, docs)
 
     return browser, context, page
 
@@ -182,7 +195,7 @@ def format_browser_long_date(page, date_value: str) -> str:
 @pytest.mark.parametrize("viewport_width", [375, 768])
 def test_mobile_insights_has_no_horizontal_overflow(viewport_width: int):
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=True, channel="chrome")
+        browser = launch_browser(playwright)
         context = browser.new_context(viewport={"width": viewport_width, "height": 812})
         install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
         page = context.new_page()
@@ -239,7 +252,7 @@ def test_mobile_scheduled_edit_draft_survives_delayed_ui_refresh():
     room_code = "phase6-mobile-edit-draft"
 
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=True, channel="chrome")
+        browser = launch_browser(playwright)
         context = browser.new_context(viewport={"width": 375, "height": 812})
         install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
         page = context.new_page()
@@ -352,14 +365,16 @@ def test_settings_activities_toggle_persists_across_reload():
 def test_insights_selected_day_scopes_details():
     room_code = "phase6-insights-scope"
     with sync_playwright() as playwright:
-        page_for_dates_browser, page_for_dates_context, page_for_dates = launch_seeded_page(
-            playwright,
-            f"{room_code}-dates",
-            [activities_config()],
-        )
+        browser = launch_browser(playwright)
+        context = browser.new_context(viewport={"width": 1280, "height": 900})
+        install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
+        page = context.new_page()
+
         try:
+            # Doc builders evaluate date math in the browser, so load the page first.
+            page.goto(BASE_URL, wait_until="load")
             today_activity = build_relative_day_activity_doc(
-                page_for_dates,
+                page,
                 doc_id="phase6-today-activity",
                 description="Phase 6 today actual",
                 day_offset=0,
@@ -368,7 +383,7 @@ def test_insights_selected_day_scopes_details():
                 duration_minutes=30,
             )
             prior_activity = build_relative_day_activity_doc(
-                page_for_dates,
+                page,
                 doc_id="phase6-prior-activity",
                 description="Phase 6 prior actual",
                 day_offset=-1,
@@ -377,7 +392,7 @@ def test_insights_selected_day_scopes_details():
                 duration_minutes=45,
             )
             today_task = build_relative_day_scheduled_task_doc(
-                page_for_dates,
+                page,
                 doc_id="phase6-today-task",
                 description="Phase 6 today plan",
                 day_offset=0,
@@ -386,7 +401,7 @@ def test_insights_selected_day_scopes_details():
                 duration_minutes=30,
             )
             prior_task = build_relative_day_scheduled_task_doc(
-                page_for_dates,
+                page,
                 doc_id="phase6-prior-task",
                 description="Phase 6 prior plan",
                 day_offset=-1,
@@ -394,17 +409,13 @@ def test_insights_selected_day_scopes_details():
                 start_minute=30,
                 duration_minutes=30,
             )
-        finally:
-            page_for_dates_context.close()
-            page_for_dates_browser.close()
 
-        browser, context, page = launch_seeded_page(
-            playwright,
-            room_code,
-            [activities_config(), today_task, prior_task, today_activity, prior_activity],
-        )
+            seed_and_enter_room(
+                page,
+                room_code,
+                [activities_config(), today_task, prior_task, today_activity, prior_activity],
+            )
 
-        try:
             page.locator("#view-toggle-insights").click()
             page.locator("#insights-view").wait_for(state="visible", timeout=10000)
 

--- a/test_phase6_e2e.py
+++ b/test_phase6_e2e.py
@@ -1,4 +1,4 @@
-"""Phase 6 E2E checks for mobile Insights behavior."""
+"""Phase 6 E2E checks for mobile and persistence polish."""
 
 from __future__ import annotations
 
@@ -10,15 +10,21 @@ from playwright.sync_api import sync_playwright
 
 sys.path.insert(0, str(Path(__file__).parent / "scripts"))
 from playwright_preview_smoke import (  # noqa: E402
+    assert_trend_day_selection_scopes_details,
     build_relative_day_activity_doc,
     build_relative_day_scheduled_task_doc,
     clear_room_storage,
     dismiss_open_modals,
     enter_room,
+    force_activity_mode,
+    open_settings_modal,
     install_local_pouchdb_route,
     open_scheduled_edit_form,
     read_docs,
     seed_docs,
+    start_activity_timer,
+    wait_for_running_activity_config,
+    wait_for_running_timer_ui,
     wait_until,
     wait_for_main_app,
 )
@@ -133,6 +139,46 @@ def test_activities_onboarding_prepares_ui_and_persists_dismissal():
 # onboarding sequence that follows Activities enablement.
 
 
+def launch_seeded_page(playwright, room_code: str, docs: list[dict] | None = None):
+    browser = playwright.chromium.launch(headless=True, channel="chrome")
+    context = browser.new_context(viewport={"width": 1280, "height": 900})
+    install_local_pouchdb_route(context, repo_root=Path(__file__).parent)
+    page = context.new_page()
+
+    page.goto(BASE_URL, wait_until="load")
+    page.evaluate("localStorage.clear()")
+    clear_room_storage(page, room_code)
+    seed_docs(page, room_code, docs or [])
+    enter_room(page, room_code)
+    wait_for_main_app(page)
+    dismiss_open_modals(page)
+
+    return browser, context, page
+
+
+def activities_config(*, enabled: bool = True, onboarding_dismissed: bool = True) -> dict:
+    return {
+        "_id": "config-settings",
+        "id": "config-settings",
+        "docType": "config",
+        "activitiesEnabled": enabled,
+        "onboardingDismissed": onboarding_dismissed,
+    }
+
+
+def format_browser_long_date(page, date_value: str) -> str:
+    return page.evaluate(
+        """
+        (dateValue) => new Date(`${dateValue}T00:00:00`).toLocaleDateString(undefined, {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric'
+        })
+        """,
+        date_value,
+    )
+
+
 @pytest.mark.parametrize("viewport_width", [375, 768])
 def test_mobile_insights_has_no_horizontal_overflow(viewport_width: int):
     with sync_playwright() as playwright:
@@ -150,11 +196,7 @@ def test_mobile_insights_has_no_horizontal_overflow(viewport_width: int):
                 ROOM_CODE,
                 [
                     {
-                        "_id": "config-settings",
-                        "id": "config-settings",
-                        "docType": "config",
-                        "activitiesEnabled": True,
-                        "onboardingDismissed": True,
+                        **activities_config(),
                     },
                     build_relative_day_scheduled_task_doc(
                         page,
@@ -241,6 +283,140 @@ def test_mobile_scheduled_edit_draft_survives_delayed_ui_refresh():
             page.wait_for_timeout(500)
 
             assert duration_minutes.input_value() == "45"
+        finally:
+            context.close()
+            browser.close()
+
+
+def test_running_timer_restores_after_reload():
+    room_code = "phase6-timer-restore"
+    with sync_playwright() as playwright:
+        browser, context, page = launch_seeded_page(
+            playwright,
+            room_code,
+            [activities_config()],
+        )
+
+        try:
+            start_activity_timer(page, "Phase 6 reload timer", room_code=room_code)
+            running_config = wait_for_running_activity_config(
+                page,
+                room_code,
+                expected_description="Phase 6 reload timer",
+            )
+            assert running_config.get("activityId")
+
+            page.reload(wait_until="load")
+            wait_for_main_app(page)
+            dismiss_open_modals(page)
+
+            wait_for_running_timer_ui(page, "Phase 6 reload timer")
+            restored_config = wait_for_running_activity_config(
+                page,
+                room_code,
+                expected_description="Phase 6 reload timer",
+            )
+            assert restored_config.get("activityId") == running_config.get("activityId")
+        finally:
+            context.close()
+            browser.close()
+
+
+def test_settings_activities_toggle_persists_across_reload():
+    room_code = "phase6-settings-persist"
+    with sync_playwright() as playwright:
+        browser, context, page = launch_seeded_page(
+            playwright,
+            room_code,
+            [activities_config(enabled=False)],
+        )
+
+        try:
+            assert page.locator("#activity-toggle-option").is_hidden()
+
+            open_settings_modal(page)
+            page.locator("label:has(#activities-toggle)").click()
+            page.locator("#reload-apply-btn").click()
+
+            wait_for_main_app(page)
+            dismiss_open_modals(page)
+
+            page.locator("#activity-toggle-option").wait_for(state="visible", timeout=10000)
+            force_activity_mode(page)
+            page.locator("#start-timer-btn").wait_for(state="visible", timeout=10000)
+        finally:
+            context.close()
+            browser.close()
+
+
+def test_insights_selected_day_scopes_details():
+    room_code = "phase6-insights-scope"
+    with sync_playwright() as playwright:
+        page_for_dates_browser, page_for_dates_context, page_for_dates = launch_seeded_page(
+            playwright,
+            f"{room_code}-dates",
+            [activities_config()],
+        )
+        try:
+            today_activity = build_relative_day_activity_doc(
+                page_for_dates,
+                doc_id="phase6-today-activity",
+                description="Phase 6 today actual",
+                day_offset=0,
+                start_hour=9,
+                start_minute=0,
+                duration_minutes=30,
+            )
+            prior_activity = build_relative_day_activity_doc(
+                page_for_dates,
+                doc_id="phase6-prior-activity",
+                description="Phase 6 prior actual",
+                day_offset=-1,
+                start_hour=10,
+                start_minute=0,
+                duration_minutes=45,
+            )
+            today_task = build_relative_day_scheduled_task_doc(
+                page_for_dates,
+                doc_id="phase6-today-task",
+                description="Phase 6 today plan",
+                day_offset=0,
+                start_hour=8,
+                start_minute=30,
+                duration_minutes=30,
+            )
+            prior_task = build_relative_day_scheduled_task_doc(
+                page_for_dates,
+                doc_id="phase6-prior-task",
+                description="Phase 6 prior plan",
+                day_offset=-1,
+                start_hour=9,
+                start_minute=30,
+                duration_minutes=30,
+            )
+        finally:
+            page_for_dates_context.close()
+            page_for_dates_browser.close()
+
+        browser, context, page = launch_seeded_page(
+            playwright,
+            room_code,
+            [activities_config(), today_task, prior_task, today_activity, prior_activity],
+        )
+
+        try:
+            page.locator("#view-toggle-insights").click()
+            page.locator("#insights-view").wait_for(state="visible", timeout=10000)
+
+            assert_trend_day_selection_scopes_details(
+                page,
+                selected_date=prior_activity["localDate"],
+                expected_date_text=format_browser_long_date(page, prior_activity["localDate"]),
+                expected_activity_description="Phase 6 prior actual",
+            )
+            assert "Phase 6 today actual" not in (
+                page.locator("#insights-activity-list").text_content() or ""
+            )
         finally:
             context.close()
             browser.close()

--- a/test_run_all.py
+++ b/test_run_all.py
@@ -16,6 +16,10 @@ scripts = [
     "test_overlap_warnings.py",
 ]
 
+pytest_suites = [
+    "test_phase6_e2e.py",
+]
+
 
 def is_port_in_use(port):
     """Check if a TCP port is already bound."""
@@ -76,6 +80,21 @@ try:
             exit_code = 1
             print(
                 f"\n  *** {script} exited with code {result.returncode} ***\n",
+                flush=True,
+            )
+
+    for suite in pytest_suites:
+        print(f"\n{'='*70}", flush=True)
+        print(f"  RUNNING: {suite} (pytest)", flush=True)
+        print(f"{'='*70}\n", flush=True)
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", suite, "-q"],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+        )
+        if result.returncode != 0:
+            exit_code = 1
+            print(
+                f"\n  *** {suite} exited with code {result.returncode} ***\n",
                 flush=True,
             )
 finally:


### PR DESCRIPTION
## Summary

Adds Phase 6D E2E coverage and public JSDoc review:

- Adds Playwright coverage for running timer reload/restore.
- Adds Playwright coverage for Activities settings persistence across reload.
- Adds Playwright coverage for selected-day Insights scoping.
- Keeps the existing mobile Insights overflow checks at 375px and 768px.
- Adds JSDoc to public exports in `activities/app-wiring.js`.

## Stack

Stacked on #82 / `phase6c-onboarding`. Review after the onboarding PR.

## Open TODO

- [ ] Consolidate and reorganize the repo's E2E test suites. There are now multiple Playwright/Python E2E entry points, and a follow-up pass should rationalize naming, ownership, shared helpers, and CI invocation boundaries.

## Validation

- npm test -- --coverage
- npm run check
- uv run --with pytest --with playwright python scripts/e2e_server.py --server "python -m http.server 9847 --bind 127.0.0.1 --directory public" --port 9847 -- uv run --with pytest --with playwright python -m pytest test_phase6_e2e.py -v
