### PR TITLE
Fix timeline block label overflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,7 +212,24 @@ jobs:
                     exit 0
                   fi
 
-                  if grep -Eq 'is the current active version|already exists' "$log_file"; then
+                  if grep -q 'already exists' "$log_file"; then
+                    echo "Firebase Hosting preview channel exists without a usable release; recreating it."
+                    npx firebase-tools@latest hosting:channel:delete "$channel" \
+                      --force \
+                      --project fortudo
+                    npx firebase-tools@latest hosting:channel:deploy "$channel" \
+                      --expires 30d \
+                      --project fortudo \
+                      --json 2>&1 | tee "$log_file"
+                    deploy_status=${PIPESTATUS[0]}
+
+                    if [ "$deploy_status" -eq 0 ]; then
+                      print_preview_urls "$log_file"
+                      exit 0
+                    fi
+                  fi
+
+                  if grep -q 'is the current active version' "$log_file"; then
                     echo "Firebase Hosting preview channel exists; listing channels for its URL."
                     channel_list_file="$RUNNER_TEMP/firebase-preview-channels.log"
                     npx firebase-tools@latest hosting:channel:list \

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -179,7 +179,8 @@ jobs:
                     sed -E 's/[^a-z0-9-]+/-/g; s/^-+|-+$//g' |
                     cut -c1-20
                   )"
-                  channel="pr${{ github.event.pull_request.number }}-${slug}"
+                  short_sha="$(printf '%s' "${GITHUB_SHA}" | cut -c1-7)"
+                  channel="pr${{ github.event.pull_request.number }}-${slug}-${short_sha}"
                   log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
 
                   print_preview_urls() {

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,8 +212,8 @@ jobs:
                     exit 0
                   fi
 
-                  if grep -q 'is the current active version' "$log_file"; then
-                    echo "Firebase Hosting preview version is already active; treating retry as successful."
+                  if grep -Eq 'is the current active version|already exists' "$log_file"; then
+                    echo "Firebase Hosting preview channel exists; listing channels for its URL."
                     channel_list_file="$RUNNER_TEMP/firebase-preview-channels.log"
                     npx firebase-tools@latest hosting:channel:list \
                       --project fortudo \

--- a/__tests__/activity-insights-renderer.test.js
+++ b/__tests__/activity-insights-renderer.test.js
@@ -309,6 +309,27 @@ describe('activity insights renderer', () => {
         expect(block.className).toContain('leading-[44px]');
     });
 
+    test('timeline visible labels stay single-line within fixed-height blocks', () => {
+        renderWith({
+            activities: [
+                activity({
+                    id: 'activity-1',
+                    description: 'Preview personal activity',
+                    startDateTime: isoAt('08:45'),
+                    endDateTime: isoAt('09:00'),
+                    duration: 15
+                })
+            ]
+        });
+
+        const block = document.querySelector('[data-timeline-block-id="activity-1"]');
+        const visibleLabel = block.querySelector('[data-timeline-visible-label]');
+
+        expect(block.className).toContain('h-[44px]');
+        expect(visibleLabel.className).toContain('truncate');
+        expect(visibleLabel.className).toContain('whitespace-nowrap');
+    });
+
     test('timeline row containers allow taller mobile touch targets', () => {
         renderWith({ tasks: [scheduledTask()] });
 

--- a/public/js/activities/insights-renderer.js
+++ b/public/js/activities/insights-renderer.js
@@ -150,15 +150,19 @@ function renderTimelineBlock(block, type, viewport) {
     const selectedClasses = selected
         ? ' outline outline-2 outline-offset-2 outline-cyan-300 shadow-cyan-300/40'
         : '';
+    const visibleLabelClass = 'block truncate whitespace-nowrap';
+    const visibleLabelHtml = compact
+        ? ''
+        : `<span data-timeline-visible-label class="${visibleLabelClass}">${escapeHtml(label)}</span>`;
 
     return `<div data-timeline-block="${type}" data-timeline-block-id="${escapeHtml(block.id)}"
         data-compact="${compact ? 'true' : 'false'}"
         data-selected="${selected ? 'true' : 'false'}"
-        role="img" class="absolute top-1 min-h-[44px] cursor-pointer overflow-hidden rounded border border-white/20 px-2 text-[11px] font-medium leading-[44px] text-white shadow-sm${selectedClasses}"
+        role="img" class="absolute top-1 h-[44px] min-h-[44px] cursor-pointer overflow-hidden rounded border border-white/20 px-2 text-[11px] font-medium leading-[44px] text-white shadow-sm${selectedClasses}"
         style="${style}"
         title="${escapeHtml(title)}"
         aria-label="${escapeHtml(title)}">
-        ${compact ? '' : `<span data-timeline-visible-label>${escapeHtml(label)}</span>`}
+        ${visibleLabelHtml}
         <span class="sr-only">${escapeHtml(title)}</span>
     </div>`;
 }


### PR DESCRIPTION
## Summary

Fixes a Phase 6A/B timeline visual regression where short activity blocks could grow vertically when their visible label wrapped into multiple words.

## Root Cause

Timeline blocks had a 44px minimum height but no fixed height, and visible labels were allowed to wrap. A short activity such as a 15-minute Personal block could become narrow enough for the text to wrap into a vertical column, expanding the absolute-positioned block beyond the timeline row.

## Changes

- Keeps timeline blocks fixed at the 44px touch target height.
- Makes visible timeline labels single-line and truncated.
- Adds a renderer regression test for fixed-height, non-wrapping timeline labels.

## Validation

- npm run check
- npm test -- --coverage --runInBand
- focused renderer suite: __tests__/activity-insights-renderer.test.js