### PR TITLE
Fix completed unscheduled tasks and activity overlaps

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,8 +41,7 @@ Historical and planned repo tasks for Fortudo.
 - [x] (v3) rename `dom-handler.js` to `dom-renderer.js` or `view.js` (it's a rendering/view layer, not a feature handler)
 
 - [x] (v4) add a version of my `tracks` app to this (either directly or more like a plugin, somehow..?)
-- [x] (v4) clear completed unscheduled tasks on day rollover
-- [x] (v4) complete day rollover by moving unfinished scheduled tasks from prior days back to the backlog
+- [x] (v4) automate day rollover: clear completed unscheduled tasks and move unfinished scheduled tasks from prior days back to the backlog
 
 - [ ] (vNext) add `completedAt` to unscheduled tasks so completed backlog items can be day-scoped and included in historical Insights instead of only being ephemeral cleanup state
 - [ ] (vNext) make Fortudo a PWA: installable and offline-friendly as a first-class web app

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,9 +41,8 @@ Historical and planned repo tasks for Fortudo.
 - [x] (v3) rename `dom-handler.js` to `dom-renderer.js` or `view.js` (it's a rendering/view layer, not a feature handler)
 
 - [x] (v4) add a version of my `tracks` app to this (either directly or more like a plugin, somehow..?)
-- [x] (v4) keep the action menu accessible on completed unscheduled tasks, with unavailable actions disabled
 - [x] (v4) clear completed unscheduled tasks on day rollover
-- [x] (v4) add a one-click Insights action to repair overlapping activities for the selected day
+- [x] (v4) complete day rollover by moving unfinished scheduled tasks from prior days back to the backlog
 
 - [ ] (vNext) add `completedAt` to unscheduled tasks so completed backlog items can be day-scoped and included in historical Insights instead of only being ephemeral cleanup state
 - [ ] (vNext) make Fortudo a PWA: installable and offline-friendly as a first-class web app
@@ -51,12 +50,6 @@ Historical and planned repo tasks for Fortudo.
   - use the same scheduled-to-unscheduled conversion contract as day rollover so both paths behave the same
   - convert the task into an unscheduled task with `estDuration` copied from scheduled `duration` and default `priority` of `medium` unless a better preserved value exists by then
   - show a toast so the user knows the task was moved out of the current day's schedule instead of silently disappearing
-- [ ] (vNext) clear schedule on a new day (unschedule incomplete tasks)
-  - reintroduce a dedicated day-rollover coordinator boundary when this ships, rather than hiding the behavior behind ad hoc timer code
-  - run once per room per local calendar day, including the first app open after midnight, so rollover is idempotent instead of tick-sensitive
-  - delete all completed tasks from the prior day
-  - convert all remaining incomplete scheduled tasks from prior days into unscheduled tasks, copying `duration` into `estDuration` and defaulting `priority` to `medium`
-  - show a summary toast after rollover so the user can see what changed
 - [ ] (vNext) add checkbox to "make a habit" so we can have a second list that gets injected daily
 - [ ] (vNext) support configurable task quick actions so frequently used menu actions can be promoted back onto the task card
 - [ ] (vNext) support pomodoro alarms on running timers (?)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,11 @@ Historical and planned repo tasks for Fortudo.
 - [x] (v3) rename `dom-handler.js` to `dom-renderer.js` or `view.js` (it's a rendering/view layer, not a feature handler)
 
 - [x] (v4) add a version of my `tracks` app to this (either directly or more like a plugin, somehow..?)
+- [x] (v4) keep the action menu accessible on completed unscheduled tasks, with unavailable actions disabled
+- [x] (v4) clear completed unscheduled tasks on day rollover
+- [x] (v4) add a one-click Insights action to repair overlapping activities for the selected day
 
+- [ ] (vNext) add `completedAt` to unscheduled tasks so completed backlog items can be day-scoped and included in historical Insights instead of only being ephemeral cleanup state
 - [ ] (vNext) make Fortudo a PWA: installable and offline-friendly as a first-class web app
 - [ ] (vNext) automatically convert scheduled tasks to unscheduled when rescheduling pushes them past midnight
   - use the same scheduled-to-unscheduled conversion contract as day rollover so both paths behave the same

--- a/__tests__/activity-app-wiring.test.js
+++ b/__tests__/activity-app-wiring.test.js
@@ -17,7 +17,23 @@ jest.mock('../public/js/activities/timer-ui.js', () => ({
 }));
 
 jest.mock('../public/js/activities/manager.js', () => ({
-    getRunningActivity: jest.fn(() => null)
+    getRunningActivity: jest.fn(() => null),
+    getActivityOverlapTruncationPreviewForDate: jest.fn(() => ({
+        success: true,
+        truncatedCount: 2,
+        truncatedActivityIds: ['activity-1', 'activity-2']
+    })),
+    truncateActivityOverlapsForDate: jest.fn(() =>
+        Promise.resolve({ success: true, truncatedCount: 2 })
+    )
+}));
+
+jest.mock('../public/js/modal-manager.js', () => ({
+    askConfirmation: jest.fn(() => Promise.resolve(true))
+}));
+
+jest.mock('../public/js/toast-manager.js', () => ({
+    showToast: jest.fn()
 }));
 
 jest.mock('../public/js/activities/insights-renderer.js', () => ({
@@ -42,7 +58,13 @@ import {
     refreshTodayActivitySummary
 } from '../public/js/activities/ui-handlers.js';
 import { initializeTimerUI, syncTimerFormState } from '../public/js/activities/timer-ui.js';
-import { getRunningActivity } from '../public/js/activities/manager.js';
+import {
+    getActivityOverlapTruncationPreviewForDate,
+    getRunningActivity,
+    truncateActivityOverlapsForDate
+} from '../public/js/activities/manager.js';
+import { askConfirmation } from '../public/js/modal-manager.js';
+import { showToast } from '../public/js/toast-manager.js';
 import {
     expandInsightsActivityLogLimit,
     setInsightsSelectedDate,
@@ -57,7 +79,9 @@ describe('activity app wiring', () => {
             <form id="task-form"></form>
             <div id="activity-list"></div>
             <div id="insights-trends"></div>
-            <div id="insights-activity-list"></div>
+            <div id="insights-activity-log">
+                <div id="insights-activity-list"></div>
+            </div>
             <div id="insights-timeline"></div>
             <input type="radio" id="activity" name="task-type" value="activity">
         `;
@@ -290,6 +314,50 @@ describe('activity app wiring', () => {
 
         expect(expandInsightsActivityLogLimit).toHaveBeenCalledWith(50);
         expect(renderInsights).toHaveBeenCalled();
+    });
+
+    test('clicking truncate overlaps confirms, repairs selected day, refreshes, and shows toast', async () => {
+        const refreshUI = jest.fn();
+        const refreshTaskDisplays = jest.fn();
+        const renderInsights = jest.fn();
+        const signal = new AbortController().signal;
+
+        initializeActivityUi({
+            signal,
+            refreshUI,
+            refreshTaskDisplays,
+            getActivitiesEnabled: () => true,
+            renderInsights
+        });
+
+        const insightsActivityLog = document.getElementById('insights-activity-log');
+        insightsActivityLog.insertAdjacentHTML(
+            'afterbegin',
+            [
+                '<button type="button" data-truncate-activity-overlaps',
+                'data-truncate-activity-overlaps-date="2026-05-07">',
+                'Truncate overlaps</button>'
+            ].join(' ')
+        );
+        insightsActivityLog
+            .querySelector('[data-truncate-activity-overlaps]')
+            .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(askConfirmation).toHaveBeenCalledWith(
+            expect.stringContaining('This will shorten 2 activities'),
+            { ok: 'Fix overlaps', cancel: 'Cancel' },
+            'amber'
+        );
+        expect(getActivityOverlapTruncationPreviewForDate).toHaveBeenCalledWith('2026-05-07');
+        expect(truncateActivityOverlapsForDate).toHaveBeenCalledWith('2026-05-07');
+        expect(refreshUI).toHaveBeenCalled();
+        expect(renderInsights).not.toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith('Truncated 2 overlapping activities.', {
+            theme: 'amber'
+        });
     });
 
     test('restores activity mode before syncing timer ui when a running timer exists', () => {

--- a/__tests__/activity-insights-renderer.test.js
+++ b/__tests__/activity-insights-renderer.test.js
@@ -527,6 +527,55 @@ describe('activity insights renderer', () => {
         );
     });
 
+    test('renders truncate overlaps action only when the selected Activity Log has overlaps', () => {
+        renderWith({
+            selectedDate: '2026-05-07',
+            activities: [
+                activity({
+                    id: 'activity-overlapped',
+                    startDateTime: isoAt('09:00'),
+                    endDateTime: isoAt('10:00'),
+                    source: 'manual',
+                    sourceTaskId: null
+                }),
+                activity({
+                    id: 'activity-overlapping',
+                    startDateTime: isoAt('09:30'),
+                    endDateTime: isoAt('10:30'),
+                    source: 'manual',
+                    sourceTaskId: null
+                })
+            ]
+        });
+
+        const action = document.querySelector('[data-truncate-activity-overlaps]');
+        expect(action).not.toBeNull();
+        expect(action.dataset.truncateActivityOverlapsDate).toBe('2026-05-07');
+        expect(action.textContent).toContain('Fix overlaps');
+
+        renderWith({
+            selectedDate: '2026-05-07',
+            activities: [
+                activity({
+                    id: 'activity-clean-1',
+                    startDateTime: isoAt('09:00'),
+                    endDateTime: isoAt('09:30'),
+                    source: 'manual',
+                    sourceTaskId: null
+                }),
+                activity({
+                    id: 'activity-clean-2',
+                    startDateTime: isoAt('09:30'),
+                    endDateTime: isoAt('10:00'),
+                    source: 'manual',
+                    sourceTaskId: null
+                })
+            ]
+        });
+
+        expect(document.querySelector('[data-truncate-activity-overlaps]')).toBeNull();
+    });
+
     test('renderInsightsView preserves caller activity issue annotations with model issues', () => {
         const existingIssue = {
             type: 'manual-review',

--- a/__tests__/activity-insights-renderer.test.js
+++ b/__tests__/activity-insights-renderer.test.js
@@ -778,7 +778,7 @@ describe('activity insights renderer', () => {
 
         expect(cleanDay.querySelector('[data-trend-day-issue]')).toBeNull();
         expect(indicator).not.toBeNull();
-        expect(indicator.textContent).toContain('!');
+        expect(indicator.querySelector('.fa-triangle-exclamation')).not.toBeNull();
         expect(indicator.getAttribute('aria-label')).toBe('1 data issue on this day');
         expect(indicator.getAttribute('title')).toBe('1 data issue on this day');
     });

--- a/__tests__/activity-insights-renderer.test.js
+++ b/__tests__/activity-insights-renderer.test.js
@@ -741,6 +741,48 @@ describe('activity insights renderer', () => {
         );
     });
 
+    test('renderInsightsView flags trend day cards that contain data issues', () => {
+        renderWith({
+            activities: [
+                activity({
+                    id: 'clean-day',
+                    startDateTime: isoOn('2026-05-06', '09:00'),
+                    endDateTime: isoOn('2026-05-06', '09:30'),
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                }),
+                activity({
+                    id: 'overlapped',
+                    startDateTime: isoOn('2026-05-07', '09:00'),
+                    endDateTime: isoOn('2026-05-07', '10:00'),
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                }),
+                activity({
+                    id: 'overlapping',
+                    startDateTime: isoOn('2026-05-07', '09:30'),
+                    endDateTime: isoOn('2026-05-07', '10:15'),
+                    duration: 45,
+                    source: 'manual',
+                    sourceTaskId: null
+                })
+            ],
+            now: new Date(isoAt('12:00'))
+        });
+
+        const cleanDay = document.querySelector('[data-trend-day="2026-05-06"]');
+        const issueDay = document.querySelector('[data-trend-day="2026-05-07"]');
+        const indicator = issueDay.querySelector('[data-trend-day-issue]');
+
+        expect(cleanDay.querySelector('[data-trend-day-issue]')).toBeNull();
+        expect(indicator).not.toBeNull();
+        expect(indicator.textContent).toContain('!');
+        expect(indicator.getAttribute('aria-label')).toBe('1 data issue on this day');
+        expect(indicator.getAttribute('title')).toBe('1 data issue on this day');
+    });
+
     test('renderInsightsView scrolls only the horizontal trend strip to the selected day', () => {
         const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
         const originalRequestAnimationFrame = window.requestAnimationFrame;

--- a/__tests__/activity-insights-trends.test.js
+++ b/__tests__/activity-insights-trends.test.js
@@ -139,4 +139,42 @@ describe('activity insights trends', () => {
             expect.objectContaining({ key: 'work', minutes: 60 })
         ]);
     });
+
+    test('buildTrendModel marks daily buckets with activity data issue counts', () => {
+        const model = buildTrendModel({
+            activities: [
+                activity({
+                    id: 'clean-day',
+                    startDateTime: isoOn('2026-05-06', '09:00'),
+                    endDateTime: isoOn('2026-05-06', '09:30'),
+                    duration: 30
+                }),
+                activity({
+                    id: 'overlapped',
+                    startDateTime: isoOn('2026-05-07', '09:00'),
+                    endDateTime: isoOn('2026-05-07', '10:00'),
+                    duration: 60
+                }),
+                activity({
+                    id: 'overlapping',
+                    startDateTime: isoOn('2026-05-07', '09:30'),
+                    endDateTime: isoOn('2026-05-07', '10:15'),
+                    duration: 45
+                })
+            ],
+            dateRange: { startDate: '2026-05-06', endDate: '2026-05-07' },
+            now: new Date(isoOn('2026-05-07', '12:00'))
+        });
+
+        expect(model.dailyHours).toEqual([
+            expect.objectContaining({
+                date: '2026-05-06',
+                issueCount: 0
+            }),
+            expect.objectContaining({
+                date: '2026-05-07',
+                issueCount: 1
+            })
+        ]);
+    });
 });

--- a/__tests__/activity-manager.test.js
+++ b/__tests__/activity-manager.test.js
@@ -18,9 +18,11 @@ import {
     getTodaysActivities,
     getLiveTodayActivitySummary,
     getSuggestedActivityStartTime,
+    getActivityOverlapTruncationPreviewForDate,
     loadActivitiesState,
     removeActivity,
     editActivity,
+    truncateActivityOverlapsForDate,
     resetActivityState,
     updateActivityState,
     createActivityFromTask,
@@ -565,6 +567,115 @@ describe('activity manager', () => {
             expect(activity.startDateTime).toBe('2026-04-07T08:00:00.000Z');
             expect(activity.endDateTime).toBe('2026-04-07T09:00:00.000Z');
             expect(activity.duration).toBe(60);
+        });
+    });
+
+    describe('truncateActivityOverlapsForDate', () => {
+        test('previews the selected-day activities that would be truncated', () => {
+            updateActivityState([
+                {
+                    id: 'activity-1',
+                    description: 'Writing',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Call',
+                    startDateTime: '2026-04-07T09:45:00.000Z',
+                    endDateTime: '2026-04-07T10:15:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-3',
+                    description: 'Break',
+                    startDateTime: '2026-04-07T10:15:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 15,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ]);
+
+            expect(getActivityOverlapTruncationPreviewForDate('2026-04-07')).toEqual({
+                success: true,
+                truncatedCount: 1,
+                truncatedActivityIds: ['activity-1']
+            });
+        });
+
+        test('shortens selected-day activity ends to the next activity start and persists changes', async () => {
+            updateActivityState([
+                {
+                    id: 'previous-day',
+                    description: 'Previous day',
+                    startDateTime: '2026-04-06T23:00:00.000Z',
+                    endDateTime: '2026-04-07T08:30:00.000Z',
+                    duration: 570,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-1',
+                    description: 'Writing',
+                    startDateTime: '2026-04-07T09:00:00.000Z',
+                    endDateTime: '2026-04-07T10:00:00.000Z',
+                    duration: 60,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-2',
+                    description: 'Call',
+                    startDateTime: '2026-04-07T09:45:00.000Z',
+                    endDateTime: '2026-04-07T10:15:00.000Z',
+                    duration: 30,
+                    source: 'manual',
+                    sourceTaskId: null
+                },
+                {
+                    id: 'activity-3',
+                    description: 'Break',
+                    startDateTime: '2026-04-07T10:15:00.000Z',
+                    endDateTime: '2026-04-07T10:30:00.000Z',
+                    duration: 15,
+                    source: 'manual',
+                    sourceTaskId: null
+                }
+            ]);
+
+            const result = await truncateActivityOverlapsForDate('2026-04-07');
+
+            expect(result).toEqual({
+                success: true,
+                truncatedCount: 1,
+                truncatedActivityIds: ['activity-1']
+            });
+            expect(getActivityById('activity-1')).toEqual(
+                expect.objectContaining({
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 45
+                })
+            );
+            expect(getActivityById('activity-2')).toEqual(
+                expect.objectContaining({
+                    endDateTime: '2026-04-07T10:15:00.000Z',
+                    duration: 30
+                })
+            );
+            expect(putActivity).toHaveBeenCalledTimes(1);
+            expect(putActivity).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: 'activity-1',
+                    endDateTime: '2026-04-07T09:45:00.000Z',
+                    duration: 45
+                })
+            );
         });
     });
 });

--- a/__tests__/app-lifecycle.test.js
+++ b/__tests__/app-lifecycle.test.js
@@ -28,6 +28,7 @@ describe('app room/session lifecycle', () => {
             refreshStartTimeField: jest.fn(),
             getRunningActivity: jest.fn(() => null),
             stopTimerAt: jest.fn(async () => ({ success: true })),
+            deleteCompletedUnscheduledTasks: jest.fn(() => ({ success: true, tasksDeleted: 0 })),
             syncTimerFormState: jest.fn(),
             refreshTaskDisplays: jest.fn(),
             onSyncStatusChange: jest.fn(() => jest.fn()),
@@ -220,5 +221,28 @@ describe('app room/session lifecycle', () => {
         expect(deps.syncTimerFormState).not.toHaveBeenCalled();
         expect(deps.refreshTaskDisplays).not.toHaveBeenCalled();
         expect(deps.refreshStartTimeField).toHaveBeenCalledTimes(1);
+    });
+
+    test('clears completed unscheduled tasks when the local date changes', async () => {
+        jest.setSystemTime(new Date('2026-04-21T23:59:59'));
+        const { deps, lifecycle } = createLifecycle({
+            deleteCompletedUnscheduledTasks: jest.fn(() => ({
+                success: true,
+                tasksDeleted: 2
+            }))
+        });
+        const abortController = new AbortController();
+
+        lifecycle.start({ signal: abortController.signal });
+        deps.loadAppState.mockClear();
+        deps.refreshUI.mockClear();
+
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.deleteCompletedUnscheduledTasks).toHaveBeenCalledTimes(1);
+        expect(deps.loadAppState).toHaveBeenCalledTimes(1);
+        expect(deps.refreshUI).toHaveBeenCalledTimes(1);
     });
 });

--- a/__tests__/app-lifecycle.test.js
+++ b/__tests__/app-lifecycle.test.js
@@ -29,6 +29,12 @@ describe('app room/session lifecycle', () => {
             getRunningActivity: jest.fn(() => null),
             stopTimerAt: jest.fn(async () => ({ success: true })),
             deleteCompletedUnscheduledTasks: jest.fn(() => ({ success: true, tasksDeleted: 0 })),
+            rolloverPriorDayScheduledTasks: jest.fn(() => ({
+                success: true,
+                tasksMoved: 0,
+                message: 'No unfinished scheduled tasks to move.'
+            })),
+            showToast: jest.fn(),
             syncTimerFormState: jest.fn(),
             refreshTaskDisplays: jest.fn(),
             onSyncStatusChange: jest.fn(() => jest.fn()),
@@ -244,5 +250,35 @@ describe('app room/session lifecycle', () => {
         expect(deps.deleteCompletedUnscheduledTasks).toHaveBeenCalledTimes(1);
         expect(deps.loadAppState).toHaveBeenCalledTimes(1);
         expect(deps.refreshUI).toHaveBeenCalledTimes(1);
+    });
+
+    test('moves stale incomplete scheduled tasks and shows a toast when the local date changes', async () => {
+        jest.setSystemTime(new Date('2026-04-21T23:59:59'));
+        const { deps, lifecycle } = createLifecycle({
+            rolloverPriorDayScheduledTasks: jest.fn(() => ({
+                success: true,
+                tasksMoved: 2,
+                message: '2 unfinished scheduled tasks moved to backlog.'
+            }))
+        });
+        const abortController = new AbortController();
+
+        lifecycle.start({ signal: abortController.signal });
+        deps.loadAppState.mockClear();
+        deps.refreshUI.mockClear();
+
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.rolloverPriorDayScheduledTasks).toHaveBeenCalledTimes(1);
+        expect(deps.loadAppState).toHaveBeenCalledTimes(1);
+        expect(deps.refreshUI).toHaveBeenCalledTimes(1);
+        expect(deps.showToast).toHaveBeenCalledWith(
+            '2 unfinished scheduled tasks moved to backlog.',
+            {
+                theme: 'teal'
+            }
+        );
     });
 });

--- a/__tests__/dom-interaction.test.js
+++ b/__tests__/dom-interaction.test.js
@@ -1182,6 +1182,25 @@ describe('DOM Handler Interaction Tests', () => {
             expect(mockUnscheduledTaskCallbacks.onScheduleUnscheduledTask).not.toHaveBeenCalled();
         });
 
+        test('completed task actions menu can still open and delete the task', () => {
+            setupUnscheduledTask('unsched-1', true);
+
+            const trigger = document.querySelector('.btn-unscheduled-task-actions-menu');
+            const menu = document.querySelector('.unscheduled-task-actions-menu');
+            trigger.click();
+
+            expect(trigger.getAttribute('aria-expanded')).toBe('true');
+            expect(menu.hidden).toBe(false);
+
+            const deleteBtn = document.querySelector('.btn-delete-unscheduled');
+            deleteBtn.dispatchEvent(new Event('click', { bubbles: true }));
+
+            expect(mockUnscheduledTaskCallbacks.onDeleteUnscheduledTask).toHaveBeenCalledWith(
+                'unsched-1'
+            );
+            expect(menu.hidden).toBe(true);
+        });
+
         test('edit button calls onEditUnscheduledTask', () => {
             setupUnscheduledTask('unsched-1');
 

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -18,6 +18,7 @@ import {
     cancelEdit,
     deleteAllTasks,
     deleteAllScheduledTasks,
+    deleteCompletedUnscheduledTasks,
     performReschedule,
     confirmAddTaskAndReschedule,
     confirmScheduleUnscheduledTask,
@@ -2527,6 +2528,57 @@ describe('Task Management Functions (task-manager.js)', () => {
             updateTaskState([task]);
 
             const result = deleteCompletedTasks();
+            expect(result.success).toBe(true);
+            expect(result.tasksDeleted).toBe(0);
+        });
+
+        test('deleteCompletedUnscheduledTasks removes only completed unscheduled tasks', () => {
+            const completedScheduled = createTaskWithDateTime({
+                description: 'Completed Scheduled',
+                startTime: '11:00',
+                duration: 30,
+                status: 'completed',
+                editing: false,
+                confirmingDelete: false
+            });
+            const incompleteUnscheduled = {
+                id: 'unsched-incomplete',
+                type: 'unscheduled',
+                description: 'Incomplete Unscheduled',
+                priority: 'medium',
+                estDuration: 30,
+                status: 'incomplete'
+            };
+            const completedUnscheduled = {
+                id: 'unsched-completed',
+                type: 'unscheduled',
+                description: 'Completed Unscheduled',
+                priority: 'medium',
+                estDuration: 30,
+                status: 'completed'
+            };
+            updateTaskState([completedScheduled, incompleteUnscheduled, completedUnscheduled]);
+
+            const result = deleteCompletedUnscheduledTasks();
+
+            expect(result.success).toBe(true);
+            expect(result.tasksDeleted).toBe(1);
+            expect(getTaskState()).toEqual([completedScheduled, incompleteUnscheduled]);
+        });
+
+        test('deleteCompletedUnscheduledTasks returns zero deleted when none exist', () => {
+            const task = {
+                id: 'unsched-incomplete',
+                type: 'unscheduled',
+                description: 'Incomplete Unscheduled',
+                priority: 'medium',
+                estDuration: 30,
+                status: 'incomplete'
+            };
+            updateTaskState([task]);
+
+            const result = deleteCompletedUnscheduledTasks();
+
             expect(result.success).toBe(true);
             expect(result.tasksDeleted).toBe(0);
         });

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -19,6 +19,7 @@ import {
     deleteAllTasks,
     deleteAllScheduledTasks,
     deleteCompletedUnscheduledTasks,
+    rolloverPriorDayScheduledTasks,
     performReschedule,
     confirmAddTaskAndReschedule,
     confirmScheduleUnscheduledTask,
@@ -2581,6 +2582,98 @@ describe('Task Management Functions (task-manager.js)', () => {
 
             expect(result.success).toBe(true);
             expect(result.tasksDeleted).toBe(0);
+        });
+
+        test('rolloverPriorDayScheduledTasks converts stale incomplete scheduled tasks to unscheduled', () => {
+            const staleScheduledTask = createTaskWithDateTime({
+                description: 'Yesterday unfinished',
+                startTime: '09:00',
+                duration: 45,
+                date: '2026-04-21',
+                status: 'incomplete',
+                locked: true,
+                isEditingInline: true
+            });
+            staleScheduledTask.category = 'work/deep';
+            const todayScheduledTask = createTaskWithDateTime({
+                description: 'Today scheduled',
+                startTime: '10:00',
+                duration: 30,
+                date: '2026-04-22',
+                status: 'incomplete'
+            });
+            const completedStaleScheduledTask = createTaskWithDateTime({
+                description: 'Yesterday completed',
+                startTime: '11:00',
+                duration: 30,
+                date: '2026-04-21',
+                status: 'completed'
+            });
+            const existingUnscheduledTask = {
+                id: 'unsched-existing',
+                type: 'unscheduled',
+                description: 'Existing backlog',
+                priority: 'high',
+                estDuration: 20,
+                status: 'incomplete'
+            };
+            updateTaskState([
+                staleScheduledTask,
+                todayScheduledTask,
+                completedStaleScheduledTask,
+                existingUnscheduledTask
+            ]);
+
+            const result = rolloverPriorDayScheduledTasks(new Date('2026-04-22T08:00:00'));
+
+            expect(result).toEqual({
+                success: true,
+                message: '1 unfinished scheduled task moved to backlog.',
+                tasksMoved: 1
+            });
+            const movedTask = getTaskState().find((task) => task.id === staleScheduledTask.id);
+            expect(movedTask).toEqual(
+                expect.objectContaining({
+                    id: staleScheduledTask.id,
+                    type: 'unscheduled',
+                    description: 'Yesterday unfinished',
+                    status: 'incomplete',
+                    category: 'work/deep',
+                    priority: 'medium',
+                    estDuration: 45
+                })
+            );
+            expect(movedTask).not.toHaveProperty('startDateTime');
+            expect(movedTask).not.toHaveProperty('endDateTime');
+            expect(movedTask).not.toHaveProperty('duration');
+            expect(movedTask).not.toHaveProperty('locked');
+            expect(movedTask).not.toHaveProperty('isEditingInline');
+            expect(getTaskState()).toEqual([
+                completedStaleScheduledTask,
+                todayScheduledTask,
+                movedTask,
+                existingUnscheduledTask
+            ]);
+        });
+
+        test('rolloverPriorDayScheduledTasks returns zero moved when no stale incomplete scheduled tasks exist', () => {
+            const todayScheduledTask = createTaskWithDateTime({
+                description: 'Today scheduled',
+                startTime: '10:00',
+                duration: 30,
+                date: '2026-04-22',
+                status: 'incomplete'
+            });
+            updateTaskState([todayScheduledTask]);
+
+            const result = rolloverPriorDayScheduledTasks(new Date('2026-04-22T08:00:00'));
+
+            expect(result).toEqual({
+                success: true,
+                message: 'No unfinished scheduled tasks to move.',
+                tasksMoved: 0
+            });
+            expect(getTaskState()).toEqual([todayScheduledTask]);
         });
     });
 

--- a/__tests__/task-management.test.js
+++ b/__tests__/task-management.test.js
@@ -2324,7 +2324,8 @@ describe('Task Management Functions (task-manager.js)', () => {
                 duration: 30,
                 status: 'incomplete',
                 editing: false,
-                confirmingDelete: false
+                confirmingDelete: false,
+                locked: true
             });
             updateTaskState([task]);
 
@@ -2334,6 +2335,10 @@ describe('Task Management Functions (task-manager.js)', () => {
             const tasks = getTaskState();
             expect(tasks[0].type).toBe('unscheduled');
             expect(tasks[0].estDuration).toBe(30);
+            expect(tasks[0]).not.toHaveProperty('startDateTime');
+            expect(tasks[0]).not.toHaveProperty('endDateTime');
+            expect(tasks[0]).not.toHaveProperty('duration');
+            expect(tasks[0]).not.toHaveProperty('locked');
         });
 
         test('unscheduleTask preserves category on the converted task', () => {

--- a/__tests__/unscheduled-task-renderer.test.js
+++ b/__tests__/unscheduled-task-renderer.test.js
@@ -65,6 +65,35 @@ describe('unscheduled task renderer', () => {
         );
     });
 
+    test('keeps edit and delete actions available for completed unscheduled tasks', () => {
+        renderUnscheduledTasks(
+            [
+                {
+                    id: 'unsched-completed',
+                    type: 'unscheduled',
+                    description: 'Completed backlog item',
+                    priority: 'medium',
+                    estDuration: 30,
+                    status: 'completed'
+                }
+            ],
+            {},
+            jest.fn()
+        );
+
+        const actionsTrigger = document.querySelector('.btn-unscheduled-task-actions-menu');
+        const startTimerButton = document.querySelector('.btn-start-unscheduled-timer');
+        const scheduleButton = document.querySelector('.btn-schedule-task');
+        const editButton = document.querySelector('.btn-edit-unscheduled');
+        const deleteButton = document.querySelector('.btn-delete-unscheduled');
+
+        expect(actionsTrigger.hasAttribute('disabled')).toBe(false);
+        expect(startTimerButton.hasAttribute('disabled')).toBe(true);
+        expect(scheduleButton.hasAttribute('disabled')).toBe(true);
+        expect(editButton.hasAttribute('disabled')).toBe(false);
+        expect(deleteButton.hasAttribute('disabled')).toBe(false);
+    });
+
     test('renders the linked source task with a subdued in-progress badge and fully disabled while its timer runs', () => {
         getRunningActivity.mockReturnValue({
             description: 'Inbox zero',

--- a/public/js/activities/app-wiring.js
+++ b/public/js/activities/app-wiring.js
@@ -7,7 +7,13 @@ import {
     refreshTodayActivitySummary
 } from './ui-handlers.js';
 import { initializeTimerUI, syncTimerFormState } from './timer-ui.js';
-import { getRunningActivity } from './manager.js';
+import {
+    getActivityOverlapTruncationPreviewForDate,
+    getRunningActivity,
+    truncateActivityOverlapsForDate
+} from './manager.js';
+import { askConfirmation } from '../modal-manager.js';
+import { showToast } from '../toast-manager.js';
 import {
     expandInsightsActivityLogLimit,
     setInsightsSelectedDate,
@@ -138,14 +144,58 @@ function initializeInsightsTrendEventHandlers(trendsElement, { signal, renderIns
     );
 }
 
-function initializeInsightsActivityListEventHandlers(listElement, { signal, renderInsights }) {
-    if (!listElement) {
+function getTruncatedActivitiesMessage(count) {
+    return count === 1
+        ? 'Truncated 1 overlapping activity.'
+        : `Truncated ${count} overlapping activities.`;
+}
+
+async function handleTruncateActivityOverlaps(date, { refreshUI }) {
+    const preview = getActivityOverlapTruncationPreviewForDate(date);
+    if (!preview?.success || !preview.truncatedCount) {
         return;
     }
 
-    listElement.addEventListener(
+    const activityLabel = preview.truncatedCount === 1 ? 'activity' : 'activities';
+    const confirmed = await askConfirmation(
+        `This will shorten ${preview.truncatedCount} ${activityLabel} so each one ends when the next one starts.`,
+        { ok: 'Fix overlaps', cancel: 'Cancel' },
+        'amber'
+    );
+
+    if (!confirmed) {
+        return;
+    }
+
+    const result = await truncateActivityOverlapsForDate(date);
+    if (!result?.success) {
+        return;
+    }
+
+    refreshUI();
+    showToast(getTruncatedActivitiesMessage(result.truncatedCount || 0), { theme: 'amber' });
+}
+
+function initializeInsightsActivityLogEventHandlers(
+    logElement,
+    { signal, refreshUI, renderInsights }
+) {
+    if (!logElement) {
+        return;
+    }
+
+    logElement.addEventListener(
         'click',
         (event) => {
+            const truncateButton = event.target.closest('[data-truncate-activity-overlaps]');
+            if (truncateButton) {
+                const date = truncateButton.dataset.truncateActivityOverlapsDate;
+                if (date) {
+                    void handleTruncateActivityOverlaps(date, { refreshUI });
+                }
+                return;
+            }
+
             const showMoreButton = event.target.closest('[data-show-more-activities]');
             if (!showMoreButton) {
                 return;
@@ -215,8 +265,9 @@ export function initializeActivityUi({
         signal,
         renderInsights
     });
-    initializeInsightsActivityListEventHandlers(document.getElementById('insights-activity-list'), {
+    initializeInsightsActivityLogEventHandlers(document.getElementById('insights-activity-log'), {
         signal,
+        refreshUI,
         renderInsights
     });
 }

--- a/public/js/activities/insights-renderer.js
+++ b/public/js/activities/insights-renderer.js
@@ -536,6 +536,15 @@ function renderSelectedDayContext(selectedDate) {
 
 function renderTrendDayCard(day, selectedDate) {
     const minutes = Number(day.minutes) || 0;
+    const issueCount = Number(day.issueCount) || 0;
+    const issueLabel = `${issueCount} data ${issueCount === 1 ? 'issue' : 'issues'} on this day`;
+    const issueIndicator =
+        issueCount > 0
+            ? `<span data-trend-day-issue
+                class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-amber-400/50 bg-amber-400/15 text-[10px] font-bold leading-none text-amber-200"
+                aria-label="${escapeHtml(issueLabel)}"
+                title="${escapeHtml(issueLabel)}">!</span>`
+            : '';
     const segments = (day.categorySegments || [])
         .map((segment) => {
             const segmentMinutes = Number(segment.minutes) || 0;
@@ -563,7 +572,10 @@ function renderTrendDayCard(day, selectedDate) {
         }">
         <div class="flex items-center justify-between text-[11px] font-semibold uppercase text-sky-300">
             <span>${escapeHtml(formatWeekday(day.date))}</span>
-            <span>${escapeHtml(day.activityCount || 0)}</span>
+            <span class="flex items-center gap-1.5">
+                ${issueIndicator}
+                <span>${escapeHtml(day.activityCount || 0)}</span>
+            </span>
         </div>
         <div class="mt-1 text-sm font-semibold text-slate-100">${escapeHtml(formatShortDate(day.date))}</div>
         <div class="mt-3 flex h-3 overflow-hidden rounded-full bg-slate-800">

--- a/public/js/activities/insights-renderer.js
+++ b/public/js/activities/insights-renderer.js
@@ -541,9 +541,11 @@ function renderTrendDayCard(day, selectedDate) {
     const issueIndicator =
         issueCount > 0
             ? `<span data-trend-day-issue
-                class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-amber-400/50 bg-amber-400/15 text-[10px] font-bold leading-none text-amber-200"
+                class="inline-flex items-center justify-center text-[11px] leading-none text-amber-200"
                 aria-label="${escapeHtml(issueLabel)}"
-                title="${escapeHtml(issueLabel)}">!</span>`
+                title="${escapeHtml(issueLabel)}">
+                <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+            </span>`
             : '';
     const segments = (day.categorySegments || [])
         .map((segment) => {

--- a/public/js/activities/insights-renderer.js
+++ b/public/js/activities/insights-renderer.js
@@ -261,6 +261,35 @@ function renderShowMoreButton(hiddenCount) {
     listContainer.append(button);
 }
 
+function renderActivityLogActions(model) {
+    const logContainer = document.getElementById('insights-activity-log');
+    if (!logContainer) {
+        return;
+    }
+
+    logContainer.querySelector('[data-activity-log-actions]')?.remove();
+
+    const hasOverlaps = model.activityLogIssues.some((issue) => issue.type === 'overlap');
+    if (!hasOverlaps) {
+        return;
+    }
+
+    const actions = document.createElement('div');
+    actions.dataset.activityLogActions = 'true';
+    actions.className = 'mb-3 flex justify-end px-2';
+    actions.innerHTML = `<button type="button" data-truncate-activity-overlaps data-truncate-activity-overlaps-date="${escapeHtml(model.date)}" class="inline-flex items-center gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-xs font-medium text-amber-100 transition-colors hover:bg-amber-500/20 sm:px-3 sm:text-sm">
+        <i class="fa-solid fa-scissors" aria-hidden="true"></i>
+        <span>Fix overlaps</span>
+    </button>`;
+
+    const listContainer = document.getElementById('insights-activity-list');
+    if (listContainer) {
+        logContainer.insertBefore(actions, listContainer);
+    } else {
+        logContainer.append(actions);
+    }
+}
+
 function renderActivityLog(model, activityRenderOptions = {}) {
     const listContainer = document.getElementById('insights-activity-list');
     if (!listContainer) {
@@ -275,6 +304,8 @@ function renderActivityLog(model, activityRenderOptions = {}) {
     if (heading) {
         heading.textContent = 'Activity Log';
     }
+
+    renderActivityLogActions(model);
 
     if (model.activityLog.length === 0) {
         listContainer.innerHTML = `<div class="rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-4 text-sm text-slate-400">

--- a/public/js/activities/insights-trends.js
+++ b/public/js/activities/insights-trends.js
@@ -1,10 +1,12 @@
 import { getGroupByKey, resolveCategoryKey } from '../taxonomy/taxonomy-selectors.js';
 import { extractDateFromDateTime } from '../utils.js';
+import { detectActivityDataIssues } from './insights-issues.js';
 import {
     getDateRangeInterval,
     getDayInterval,
     getDurationCapableInterval,
     getLastLocalDaysDateRange,
+    invalidActivityTouchesInterval,
     getOverlapDuration,
     intervalsOverlap,
     parseLocalDate
@@ -58,12 +60,29 @@ export function buildTrendModel({
         }
     }
 
+    for (const activityItem of activities.filter(isCompletedActivity)) {
+        for (const dailyBucket of dailyBuckets.values()) {
+            const bucketInterval = getDayInterval(dailyBucket.date);
+            const activityInterval = getDurationCapableInterval(activityItem, now);
+
+            if (
+                (activityInterval && intervalsOverlap(activityInterval, bucketInterval)) ||
+                invalidActivityTouchesInterval(activityItem, bucketInterval)
+            ) {
+                dailyBucket.issueActivities.push(activityItem);
+            }
+        }
+    }
+
     return {
         dateRange: selectedDateRange,
-        dailyHours: [...dailyBuckets.values()].map((bucket) => ({
-            ...bucket,
-            categorySegments: sortCategoryEntries(bucket.categorySegments)
-        })),
+        dailyHours: [...dailyBuckets.values()].map(
+            ({ categorySegments, issueActivities, ...bucket }) => ({
+                ...bucket,
+                issueCount: detectActivityDataIssues(issueActivities).length,
+                categorySegments: sortCategoryEntries(categorySegments)
+            })
+        ),
         categoryTotals: sortCategoryEntries(categoryTotals)
     };
 }
@@ -89,7 +108,8 @@ function buildDailyBuckets(dateRange) {
             date,
             minutes: 0,
             activityCount: 0,
-            categorySegments: new Map()
+            categorySegments: new Map(),
+            issueActivities: []
         });
         cursor.setDate(cursor.getDate() + 1);
     }

--- a/public/js/activities/manager.js
+++ b/public/js/activities/manager.js
@@ -9,6 +9,7 @@ import {
     saveRunningActivityConfig,
     deleteRunningActivityConfig
 } from './running-activity-repository.js';
+import { getDayInterval, itemOverlapsInterval } from './insights-intervals.js';
 
 /** @type {Array<Object>} */
 let activities = [];
@@ -245,6 +246,116 @@ export async function editActivity(activityId, updates = {}) {
     sortByStartDateTime(activities);
 
     return { success: true, activity: cloneActivity(nextActivity) };
+}
+
+function buildActivityOverlapTruncationsForDate(selectedDate) {
+    if (!selectedDate) {
+        return { success: false, reason: 'Selected date is required.' };
+    }
+
+    const dayInterval = getDayInterval(selectedDate);
+    const selectedActivities = activities
+        .filter(
+            (activity) =>
+                activity.docType === 'activity' &&
+                activity.endDateTime &&
+                itemOverlapsInterval(activity, dayInterval)
+        )
+        .slice()
+        .sort((left, right) => new Date(left.startDateTime) - new Date(right.startDateTime));
+
+    const truncatedActivities = [];
+
+    for (let index = 0; index < selectedActivities.length - 1; index += 1) {
+        const activity = selectedActivities[index];
+        const nextActivity = selectedActivities[index + 1];
+        const startDate = new Date(activity.startDateTime);
+        const endDate = new Date(activity.endDateTime);
+        const nextStartDate = new Date(nextActivity.startDateTime);
+
+        if (
+            !isFinite(startDate.getTime()) ||
+            !isFinite(endDate.getTime()) ||
+            !isFinite(nextStartDate.getTime()) ||
+            endDate <= nextStartDate ||
+            nextStartDate <= startDate
+        ) {
+            continue;
+        }
+
+        truncatedActivities.push(
+            normalizeActivity({
+                ...activity,
+                endDateTime: nextStartDate.toISOString(),
+                duration: calculateDurationMinutes(activity.startDateTime, nextStartDate)
+            })
+        );
+    }
+
+    return {
+        success: true,
+        truncatedActivities
+    };
+}
+
+/**
+ * Previews overlapping saved activities that would be truncated for a selected local day.
+ * @param {string} selectedDate - Local date in YYYY-MM-DD format.
+ * @returns {{
+ *   success: boolean,
+ *   truncatedCount?: number,
+ *   truncatedActivityIds?: Array<string>,
+ *   reason?: string
+ * }}
+ */
+export function getActivityOverlapTruncationPreviewForDate(selectedDate) {
+    const result = buildActivityOverlapTruncationsForDate(selectedDate);
+    if (!result.success) {
+        return result;
+    }
+
+    return {
+        success: true,
+        truncatedCount: result.truncatedActivities.length,
+        truncatedActivityIds: result.truncatedActivities.map((activity) => activity.id)
+    };
+}
+
+/**
+ * Truncates overlapping saved activities for a selected local day.
+ * @param {string} selectedDate - Local date in YYYY-MM-DD format.
+ * @returns {Promise<{
+ *   success: boolean,
+ *   truncatedCount?: number,
+ *   truncatedActivityIds?: Array<string>,
+ *   reason?: string
+ * }>}
+ */
+export async function truncateActivityOverlapsForDate(selectedDate) {
+    const result = buildActivityOverlapTruncationsForDate(selectedDate);
+    if (!result.success) {
+        return result;
+    }
+
+    const { truncatedActivities } = result;
+
+    for (const activity of truncatedActivities) {
+        await putActivity(activity);
+    }
+
+    if (truncatedActivities.length > 0) {
+        const truncatedById = new Map(
+            truncatedActivities.map((activity) => [activity.id, activity])
+        );
+        activities = activities.map((activity) => truncatedById.get(activity.id) || activity);
+        sortByStartDateTime(activities);
+    }
+
+    return {
+        success: true,
+        truncatedCount: truncatedActivities.length,
+        truncatedActivityIds: truncatedActivities.map((activity) => activity.id)
+    };
 }
 
 export async function removeActivity(activityId) {

--- a/public/js/app-lifecycle.js
+++ b/public/js/app-lifecycle.js
@@ -13,6 +13,8 @@ export function createRoomSessionLifecycle({
     getRunningActivity,
     stopTimerAt,
     deleteCompletedUnscheduledTasks,
+    rolloverPriorDayScheduledTasks,
+    showToast,
     onSyncStatusChange,
     updateSyncStatusUI,
     triggerSync,
@@ -114,6 +116,23 @@ export function createRoomSessionLifecycle({
         });
     }
 
+    function runDayRollover(now) {
+        const cleanupResult = deleteCompletedUnscheduledTasks?.();
+        const rolloverResult = rolloverPriorDayScheduledTasks?.(now);
+        const deletedTasksCount = cleanupResult?.tasksDeleted || 0;
+        const movedTasksCount = rolloverResult?.tasksMoved || 0;
+
+        if (movedTasksCount > 0 && rolloverResult?.message) {
+            showToast?.(rolloverResult.message, { theme: 'teal' });
+        }
+
+        if (deletedTasksCount > 0 || movedTasksCount > 0) {
+            refreshFromStorage().catch((err) => {
+                logger.error('Failed to refresh tasks after midnight task rollover:', err);
+            });
+        }
+    }
+
     function startClockTickLoop() {
         activeTaskColorInterval = setInterval(() => {
             const now = new Date();
@@ -121,16 +140,7 @@ export function createRoomSessionLifecycle({
 
             if (currentDate !== lastObservedDate) {
                 lastObservedDate = currentDate;
-
-                const cleanupResult = deleteCompletedUnscheduledTasks?.();
-                if (cleanupResult?.tasksDeleted > 0) {
-                    refreshFromStorage().catch((err) => {
-                        logger.error(
-                            'Failed to refresh tasks after midnight unscheduled cleanup:',
-                            err
-                        );
-                    });
-                }
+                runDayRollover(now);
 
                 if (getActivitiesEnabled() && getRunningActivity() && !midnightTimerStopInFlight) {
                     midnightTimerStopInFlight = true;

--- a/public/js/app-lifecycle.js
+++ b/public/js/app-lifecycle.js
@@ -12,6 +12,7 @@ export function createRoomSessionLifecycle({
     refreshStartTimeField,
     getRunningActivity,
     stopTimerAt,
+    deleteCompletedUnscheduledTasks,
     onSyncStatusChange,
     updateSyncStatusUI,
     triggerSync,
@@ -120,6 +121,16 @@ export function createRoomSessionLifecycle({
 
             if (currentDate !== lastObservedDate) {
                 lastObservedDate = currentDate;
+
+                const cleanupResult = deleteCompletedUnscheduledTasks?.();
+                if (cleanupResult?.tasksDeleted > 0) {
+                    refreshFromStorage().catch((err) => {
+                        logger.error(
+                            'Failed to refresh tasks after midnight unscheduled cleanup:',
+                            err
+                        );
+                    });
+                }
 
                 if (getActivitiesEnabled() && getRunningActivity() && !midnightTimerStopInFlight) {
                     midnightTimerStopInFlight = true;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4,7 +4,8 @@ import {
     getTaskState,
     resetAllConfirmingDeleteFlags,
     getSortedUnscheduledTasks,
-    getTodaysScheduledTasks
+    getTodaysScheduledTasks,
+    deleteCompletedUnscheduledTasks
 } from './tasks/manager.js';
 import { initializeModalEventListeners } from './modal-manager.js';
 import {
@@ -210,6 +211,7 @@ async function initAndBootApp(roomCode) {
         refreshStartTimeField,
         getRunningActivity,
         stopTimerAt,
+        deleteCompletedUnscheduledTasks,
         onSyncStatusChange,
         updateSyncStatusUI,
         triggerSync,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,7 +5,8 @@ import {
     resetAllConfirmingDeleteFlags,
     getSortedUnscheduledTasks,
     getTodaysScheduledTasks,
-    deleteCompletedUnscheduledTasks
+    deleteCompletedUnscheduledTasks,
+    rolloverPriorDayScheduledTasks
 } from './tasks/manager.js';
 import { initializeModalEventListeners } from './modal-manager.js';
 import {
@@ -70,6 +71,7 @@ import { createUnscheduledTaskCallbacks } from './tasks/unscheduled-handlers.js'
 import { handleAddTaskProcess } from './tasks/add-handler.js';
 import { initializeClearTasksHandlers } from './tasks/clear-handler.js';
 import { showRoomEntryScreen, showMainApp, updateSyncStatusUI } from './room-renderer.js';
+import { showToast } from './toast-manager.js';
 import { getActiveRoom } from './room-manager.js';
 import { onSyncStatusChange, triggerSync, waitForIdleSync } from './sync-manager.js';
 import { COUCHDB_URL } from './config.js';
@@ -212,6 +214,8 @@ async function initAndBootApp(roomCode) {
         getRunningActivity,
         stopTimerAt,
         deleteCompletedUnscheduledTasks,
+        rolloverPriorDayScheduledTasks,
+        showToast,
         onSyncStatusChange,
         updateSyncStatusUI,
         triggerSync,

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -276,6 +276,26 @@ const stripUIFlags = (task) => {
     return persistable;
 };
 
+function convertScheduledTaskToUnscheduled(task) {
+    const {
+        startDateTime: _startDateTime,
+        endDateTime: _endDateTime,
+        duration,
+        locked: _locked,
+        editing: _editing,
+        confirmingDelete: _confirmingDelete,
+        isEditingInline: _isEditingInline,
+        ...remainingTask
+    } = task;
+
+    return {
+        ...remainingTask,
+        type: 'unscheduled',
+        priority: 'medium',
+        estDuration: duration ?? null
+    };
+}
+
 const finalizeTaskModification = (changedTasks) => {
     logger.debug('Finalizing task modification (invalidate cache, save)');
     invalidateTaskCaches();
@@ -1326,23 +1346,7 @@ export function rolloverPriorDayScheduledTasks(now = new Date()) {
         }
 
         movedTasksCount++;
-        const {
-            startDateTime: _startDateTime,
-            endDateTime: _endDateTime,
-            duration,
-            locked: _locked,
-            editing: _editing,
-            confirmingDelete: _confirmingDelete,
-            isEditingInline: _isEditingInline,
-            ...remainingTask
-        } = task;
-
-        return {
-            ...remainingTask,
-            type: 'unscheduled',
-            priority: 'medium',
-            estDuration: duration ?? null
-        };
+        return convertScheduledTaskToUnscheduled(task);
     });
 
     if (movedTasksCount === 0) {
@@ -1518,33 +1522,12 @@ export function unscheduleTask(taskId) {
         return { success: false, reason: 'Task is not currently scheduled.' };
     }
 
-    const formerScheduledDuration = task.duration; // Capture the duration before deleting it
+    const unscheduledTask = convertScheduledTaskToUnscheduled(task);
+    tasks[taskIndex] = unscheduledTask;
+    finalizeTaskModification(unscheduledTask);
 
-    // Convert to unscheduled
-    task.type = 'unscheduled';
-    delete task.startDateTime;
-    delete task.endDateTime;
-    delete task.duration; // Delete the original 'duration' property for scheduled tasks
-
-    // Add properties typical for unscheduled tasks
-    task.priority = 'medium'; // Default priority
-    // Use the captured former scheduled duration as the new estimated duration.
-    // If it wasn't defined (though it should be for a scheduled task), set to null or a default.
-    // createTaskObject allows estDuration to be null.
-    task.estDuration =
-        formerScheduledDuration !== undefined && formerScheduledDuration !== null
-            ? formerScheduledDuration
-            : null;
-    task.isEditingInline = false; // Ensure it's not in edit mode by default
-
-    // Remove properties not relevant to unscheduled tasks (if any) - Placeholder if needed
-    // delete task.someScheduledOnlyProperty;
-
-    tasks[taskIndex] = task;
-    finalizeTaskModification(task);
-
-    logger.info('Task unscheduled:', task);
-    return { success: true, task };
+    logger.info('Task unscheduled:', unscheduledTask);
+    return { success: true, task: unscheduledTask };
 }
 
 // ============================================================================

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -1285,6 +1285,33 @@ export function deleteCompletedTasks() {
     };
 }
 
+export function deleteCompletedUnscheduledTasks() {
+    const currentTasks = getTaskState();
+    const remainingTasks = currentTasks.filter(
+        (task) => !(task.type === 'unscheduled' && task.status === 'completed')
+    );
+    const completedUnscheduledTasksCount = currentTasks.length - remainingTasks.length;
+
+    if (completedUnscheduledTasksCount === 0) {
+        logger.info('deleteCompletedUnscheduledTasks: No completed unscheduled tasks to delete.');
+        return {
+            success: true,
+            message: 'No completed unscheduled tasks to delete.',
+            tasksDeleted: 0
+        };
+    }
+
+    updateTaskState(remainingTasks);
+    logger.info(
+        `deleteCompletedUnscheduledTasks: ${completedUnscheduledTasksCount} completed unscheduled tasks have been deleted.`
+    );
+    return {
+        success: true,
+        message: `${completedUnscheduledTasksCount} completed unscheduled tasks deleted.`,
+        tasksDeleted: completedUnscheduledTasksCount
+    };
+}
+
 export function scheduleUnscheduledTask(taskId, startTime, duration) {
     const taskIndex = tasks.findIndex((t) => t.id === taskId && t.type === 'unscheduled');
     if (taskIndex === -1) return { success: false, reason: 'Unscheduled task not found.' };

--- a/public/js/tasks/manager.js
+++ b/public/js/tasks/manager.js
@@ -1312,6 +1312,59 @@ export function deleteCompletedUnscheduledTasks() {
     };
 }
 
+export function rolloverPriorDayScheduledTasks(now = new Date()) {
+    const currentDate = extractDateFromDateTime(now);
+    let movedTasksCount = 0;
+    const nextTasks = getTaskState().map((task) => {
+        if (
+            task.type !== 'scheduled' ||
+            task.status === 'completed' ||
+            !task.startDateTime ||
+            isTaskScheduledForLocalDate(task, currentDate)
+        ) {
+            return task;
+        }
+
+        movedTasksCount++;
+        const {
+            startDateTime: _startDateTime,
+            endDateTime: _endDateTime,
+            duration,
+            locked: _locked,
+            editing: _editing,
+            confirmingDelete: _confirmingDelete,
+            isEditingInline: _isEditingInline,
+            ...remainingTask
+        } = task;
+
+        return {
+            ...remainingTask,
+            type: 'unscheduled',
+            priority: 'medium',
+            estDuration: duration ?? null
+        };
+    });
+
+    if (movedTasksCount === 0) {
+        logger.info('rolloverPriorDayScheduledTasks: No unfinished scheduled tasks to move.');
+        return {
+            success: true,
+            message: 'No unfinished scheduled tasks to move.',
+            tasksMoved: 0
+        };
+    }
+
+    updateTaskState(nextTasks);
+    const taskWord = movedTasksCount === 1 ? 'task' : 'tasks';
+    const message = `${movedTasksCount} unfinished scheduled ${taskWord} moved to backlog.`;
+    logger.info(`rolloverPriorDayScheduledTasks: ${message}`);
+    return {
+        success: true,
+        message,
+        tasksMoved: movedTasksCount
+    };
+}
+
 export function scheduleUnscheduledTask(taskId, startTime, duration) {
     const taskIndex = tasks.findIndex((t) => t.id === taskId && t.type === 'unscheduled');
     if (taskIndex === -1) return { success: false, reason: 'Unscheduled task not found.' };

--- a/public/js/tasks/unscheduled-renderer.js
+++ b/public/js/tasks/unscheduled-renderer.js
@@ -62,35 +62,47 @@ function getDurationText(estDuration) {
     return calculateHoursAndMinutes(estDuration, true).text;
 }
 
-function renderUnscheduledTaskActionsMenu(task, disabledAttr, disabledButtonClasses) {
+function renderUnscheduledTaskActionsMenu(task, actionState) {
     const actionMenuExpanded = task.confirmingDelete ? 'true' : 'false';
     const actionMenuHidden = task.confirmingDelete ? '' : ' hidden';
     const openMenuActionsClass = task.confirmingDelete ? ' z-50' : '';
+    const menuTriggerDisabledAttr = actionState.menuTriggerDisabled ? 'disabled' : '';
+    const menuTriggerDisabledClasses = actionState.menuTriggerDisabled
+        ? ' opacity-50 cursor-not-allowed'
+        : '';
+    const blockedActionDisabledAttr = actionState.blockedActionsDisabled ? 'disabled' : '';
+    const blockedActionDisabledClasses = actionState.blockedActionsDisabled
+        ? ' opacity-50 cursor-not-allowed'
+        : '';
+    const editDeleteDisabledAttr = actionState.editDeleteDisabled ? 'disabled' : '';
+    const editDeleteDisabledClasses = actionState.editDeleteDisabled
+        ? ' opacity-50 cursor-not-allowed'
+        : '';
 
     return `
         <div class="unscheduled-task-actions relative ml-auto -mt-1 -mr-1${openMenuActionsClass}">
-            <button class="btn-unscheduled-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition-colors${disabledButtonClasses}" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="${actionMenuExpanded}" ${disabledAttr}>
+            <button class="btn-unscheduled-task-actions-menu inline-grid place-items-center w-9 h-9 rounded-lg border border-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-700 hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition-colors${menuTriggerDisabledClasses}" type="button" aria-label="Actions for ${task.description}" aria-haspopup="menu" aria-expanded="${actionMenuExpanded}" ${menuTriggerDisabledAttr}>
                 <i class="fa-solid fa-ellipsis text-sm" aria-hidden="true"></i>
             </button>
             <div class="unscheduled-task-actions-menu absolute right-0 top-11 z-20 w-56 p-1.5 rounded-xl border border-slate-600 bg-slate-800 shadow-2xl sm:origin-top-right max-sm:fixed max-sm:left-3 max-sm:right-3 max-sm:bottom-3 max-sm:top-auto max-sm:w-auto" role="menu" aria-label="Task actions"${actionMenuHidden}>
                 <div class="unscheduled-task-actions-menu-group">
-                    <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-primary btn-start-unscheduled-timer grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-indigo-400/10 hover:bg-indigo-400/20 text-indigo-200 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                    <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-primary btn-start-unscheduled-timer grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md bg-indigo-400/10 hover:bg-indigo-400/20 text-indigo-200 font-semibold text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${blockedActionDisabledClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${blockedActionDisabledAttr}>
                         <i class="fa-solid fa-stopwatch text-indigo-300 text-center" aria-hidden="true"></i>
                         <span>Start timer</span>
                     </button>
                 </div>
                 <div class="unscheduled-task-actions-menu-group mt-1.5 pt-1.5 border-t border-slate-700">
-                    <button class="unscheduled-task-actions-menu-item btn-schedule-task grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                    <button class="unscheduled-task-actions-menu-item btn-schedule-task grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${blockedActionDisabledClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${blockedActionDisabledAttr}>
                         <i class="fa-regular fa-calendar-plus text-slate-400 text-center" aria-hidden="true"></i>
                         <span>Schedule</span>
                     </button>
-                    <button class="unscheduled-task-actions-menu-item btn-edit-unscheduled grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                    <button class="unscheduled-task-actions-menu-item btn-edit-unscheduled grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-slate-300 hover:bg-slate-700 text-sm text-left focus:outline-none focus:ring-2 focus:ring-indigo-300${editDeleteDisabledClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${editDeleteDisabledAttr}>
                         <i class="fa-solid fa-pen text-slate-400 text-center" aria-hidden="true"></i>
                         <span>Edit task</span>
                     </button>
                 </div>
                 <div class="unscheduled-task-actions-menu-group mt-1.5 pt-1.5 border-t border-slate-700">
-                    <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-danger btn-delete-unscheduled grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-rose-300 hover:bg-rose-400/10 text-sm text-left focus:outline-none focus:ring-2 focus:ring-rose-400${disabledButtonClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${disabledAttr}>
+                    <button class="unscheduled-task-actions-menu-item unscheduled-task-actions-menu-item-danger btn-delete-unscheduled grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2 w-full min-h-10 px-2.5 rounded-md text-rose-300 hover:bg-rose-400/10 text-sm text-left focus:outline-none focus:ring-2 focus:ring-rose-400${editDeleteDisabledClasses}" type="button" role="menuitem" data-task-id="${task.id}" ${editDeleteDisabledAttr}>
                         <i class="fa-regular ${task.confirmingDelete ? 'fa-check-circle' : 'fa-trash-can'} text-rose-400 text-center" aria-hidden="true"></i>
                         <span>${task.confirmingDelete ? 'Confirm delete' : 'Delete task'}</span>
                     </button>
@@ -117,8 +129,11 @@ function createTaskDisplayHTML(task, priorityClasses, durationText, isCompleted)
     const checkIcon = isCompleted ? 'fa-check-square text-indigo-400' : 'fa-square text-slate-500';
     const textStrike = isCompleted ? 'line-through opacity-70' : '';
     const priorityLabel = task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
-    const disabledAttr = isDisabled ? 'disabled' : '';
-    const disabledButtonClasses = isDisabled ? ' opacity-50 cursor-not-allowed' : '';
+    const actionState = {
+        menuTriggerDisabled: isLinkedToRunningTimer,
+        blockedActionsDisabled: isCompleted || isLinkedToRunningTimer,
+        editDeleteDisabled: isLinkedToRunningTimer
+    };
     const inProgressBadge = isLinkedToRunningTimer
         ? '<span class="unscheduled-in-progress-badge inline-flex items-center px-2 py-0.5 rounded-full text-[10px] tracking-normal bg-slate-700/70 text-sky-200 border border-slate-500/40">In progress</span>'
         : '';
@@ -140,7 +155,7 @@ function createTaskDisplayHTML(task, priorityClasses, durationText, isCompleted)
                 </div>
             </div>
         </div>
-        ${renderUnscheduledTaskActionsMenu(task, disabledAttr, disabledButtonClasses)}
+        ${renderUnscheduledTaskActionsMenu(task, actionState)}
     `;
 }
 


### PR DESCRIPTION
## Summary

- Fix completed unscheduled task handling so its action menu remains reachable and invalid actions are disabled instead of hiding the menu.
- Complete day rollover cleanup: completed unscheduled tasks are cleared, and unfinished scheduled tasks from prior days are moved back to the backlog with their duration copied to `estDuration`.
- Add an Insights action to fix overlapping activities for the selected day by shortening each overlapping activity to end when the next one starts, with a counted confirmation.
- Add a compact warning indicator to Insights trend day cards when that day contains activity data issues, so users can spot days that need cleanup.
- Keep a roadmap note for adding `completedAt` to unscheduled tasks later so historical Insights can eventually include completed backlog items by day.

## Validation

- `npm run check`
- `npm test -- --coverage` - 57 suites, 1257 tests

## Manual verification already performed locally

- Completed unscheduled task menu is accessible; timer/schedule actions are disabled while edit/delete remain available.
- Completed unscheduled tasks are cleared on simulated day rollover.
- Unfinished scheduled tasks from prior days move back to the backlog on day rollover.
- Activity overlap repair appears only when selected-day activities overlap.
- Repair confirmation includes the affected activity count and persists repaired activity end times.
- Insights day-card issue indicator appears on days with overlapping activities and stays visually unobtrusive beside the activity count.