### PR TITLE
ci: restore preview URL PR comment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -287,10 +287,6 @@ jobs:
                       const expiryLines = Number.isNaN(expires.getTime())
                         ? []
                         : [`(expires ${expires.toUTCString()})`, ''];
-                      const signature = require('node:crypto')
-                        .createHash('sha1')
-                        .update('fortudo')
-                        .digest('hex');
                       const body = [
                         marker,
                         `Visit the preview URL for this PR (updated for commit ${shortSha}):`,
@@ -298,9 +294,6 @@ jobs:
                         `[${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL})`,
                         '',
                         ...expiryLines,
-                        '🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎',
-                        '',
-                        `Sign: ${signature}`,
                       ].join('\n');
 
                       const issue = {

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -202,7 +202,7 @@ jobs:
                   channel="pr${{ github.event.pull_request.number }}-${slug}-${short_sha}"
                   log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
 
-                  export_preview_url() {
+                  export_preview_details() {
                     local source_file="$1"
                     local preview_url
                     preview_url="$(
@@ -211,10 +211,20 @@ jobs:
                       sort -u |
                       head -n 1
                     )"
+                    local preview_expires
+                    preview_expires="$(
+                      grep -Eo '"expireTime":[[:space:]]*"[^"]+"' "$source_file" |
+                      head -n 1 |
+                      sed -E 's/^"expireTime":[[:space:]]*"([^"]+)"$/\1/'
+                    )"
 
                     if [ -n "$preview_url" ]; then
                       echo "Firebase Hosting preview URL: $preview_url"
                       echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+                      if [ -n "$preview_expires" ]; then
+                        echo "Firebase Hosting preview expiry: $preview_expires"
+                        echo "preview_expires=$preview_expires" >> "$GITHUB_OUTPUT"
+                      fi
                     else
                       echo "Firebase Hosting preview URL was not present in $source_file."
                     fi
@@ -227,7 +237,7 @@ jobs:
                   deploy_status=${PIPESTATUS[0]}
 
                   if [ "$deploy_status" -eq 0 ]; then
-                    export_preview_url "$log_file"
+                    export_preview_details "$log_file"
                     exit 0
                   fi
 
@@ -243,7 +253,7 @@ jobs:
                     deploy_status=${PIPESTATUS[0]}
 
                     if [ "$deploy_status" -eq 0 ]; then
-                      export_preview_url "$log_file"
+                      export_preview_details "$log_file"
                       exit 0
                     fi
                   fi
@@ -254,7 +264,7 @@ jobs:
                     npx firebase-tools@latest hosting:channel:list \
                       --project fortudo \
                       --json 2>&1 | tee "$channel_list_file"
-                    export_preview_url "$channel_list_file"
+                    export_preview_details "$channel_list_file"
                     exit 0
                   fi
 
@@ -267,17 +277,30 @@ jobs:
               uses: actions/github-script@v9
               env:
                   PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}
+                  PREVIEW_EXPIRES: ${{ steps.deploy-preview.outputs.preview_expires }}
                   DEPLOYED_SHA: ${{ github.event.pull_request.head.sha }}
               with:
                   script: |
                       const marker = '<!-- firebase-hosting-preview -->';
+                      const shortSha = process.env.DEPLOYED_SHA.slice(0, 7);
+                      const expires = new Date(process.env.PREVIEW_EXPIRES);
+                      const expiryLines = Number.isNaN(expires.getTime())
+                        ? []
+                        : [`(expires ${expires.toUTCString()})`, ''];
+                      const signature = require('node:crypto')
+                        .createHash('sha1')
+                        .update('fortudo')
+                        .digest('hex');
                       const body = [
                         marker,
-                        '## Firebase Hosting preview',
+                        `Visit the preview URL for this PR (updated for commit ${shortSha}):`,
                         '',
-                        `[Open preview](${process.env.PREVIEW_URL})`,
+                        `[${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL})`,
                         '',
-                        `Preview for commit \`${process.env.DEPLOYED_SHA.slice(0, 7)}\`.`,
+                        ...expiryLines,
+                        '🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎',
+                        '',
+                        `Sign: ${signature}`,
                       ].join('\n');
 
                       const issue = {

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -163,6 +163,9 @@ jobs:
         runs-on: ubuntu-latest
         needs: [test, build, check_for_code_changes]
         if: github.event_name == 'pull_request' && needs.check_for_code_changes.outputs.has_code_changes == 'true' && github.actor != 'dependabot[bot]'
+        permissions:
+            contents: read
+            pull-requests: write
 
         steps:
             - name: Checkout code
@@ -183,6 +186,7 @@ jobs:
                   echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
 
             - name: Deploy to Firebase Hosting (Preview)
+              id: deploy-preview
               shell: bash
               run: |
                   set +e
@@ -198,19 +202,19 @@ jobs:
                   channel="pr${{ github.event.pull_request.number }}-${slug}-${short_sha}"
                   log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
 
-                  print_preview_urls() {
+                  export_preview_url() {
                     local source_file="$1"
-                    local urls
-                    urls="$(
+                    local preview_url
+                    preview_url="$(
                       grep -Eo 'https://[^"[:space:]]+' "$source_file" |
                       grep -E 'web\.app|firebaseapp\.com' |
-                      sort -u
-                      true
+                      sort -u |
+                      head -n 1
                     )"
 
-                    if [ -n "$urls" ]; then
-                      echo "Firebase Hosting preview URL(s):"
-                      printf '%s\n' "$urls"
+                    if [ -n "$preview_url" ]; then
+                      echo "Firebase Hosting preview URL: $preview_url"
+                      echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
                     else
                       echo "Firebase Hosting preview URL was not present in $source_file."
                     fi
@@ -223,7 +227,7 @@ jobs:
                   deploy_status=${PIPESTATUS[0]}
 
                   if [ "$deploy_status" -eq 0 ]; then
-                    print_preview_urls "$log_file"
+                    export_preview_url "$log_file"
                     exit 0
                   fi
 
@@ -239,7 +243,7 @@ jobs:
                     deploy_status=${PIPESTATUS[0]}
 
                     if [ "$deploy_status" -eq 0 ]; then
-                      print_preview_urls "$log_file"
+                      export_preview_url "$log_file"
                       exit 0
                     fi
                   fi
@@ -250,13 +254,56 @@ jobs:
                     npx firebase-tools@latest hosting:channel:list \
                       --project fortudo \
                       --json 2>&1 | tee "$channel_list_file"
-                    print_preview_urls "$channel_list_file"
+                    export_preview_url "$channel_list_file"
                     exit 0
                   fi
 
                   exit "$deploy_status"
               env:
                   FIREBASE_CLI_EXPERIMENTS: webframeworks
+
+            - name: Comment preview URL on pull request
+              if: steps.deploy-preview.outputs.preview_url != ''
+              uses: actions/github-script@v9
+              env:
+                  PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}
+                  DEPLOYED_SHA: ${{ github.event.pull_request.head.sha }}
+              with:
+                  script: |
+                      const marker = '<!-- firebase-hosting-preview -->';
+                      const body = [
+                        marker,
+                        '## Firebase Hosting preview',
+                        '',
+                        `[Open preview](${process.env.PREVIEW_URL})`,
+                        '',
+                        `Preview for commit \`${process.env.DEPLOYED_SHA.slice(0, 7)}\`.`,
+                      ].join('\n');
+
+                      const issue = {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      };
+                      const comments = await github.paginate(
+                        github.rest.issues.listComments,
+                        issue,
+                      );
+                      const existing = comments.find(
+                        (comment) =>
+                          comment.user?.type === 'Bot' && comment.body?.includes(marker),
+                      );
+
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: issue.owner,
+                          repo: issue.repo,
+                          comment_id: existing.id,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.createComment({ ...issue, body });
+                      }
 
     deploy-production:
         name: Deploy to Production

--- a/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
+++ b/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
@@ -33,20 +33,17 @@ active channels produce the same output.
 A following `actions/github-script@v9` step will run only when the deploy output contains
 a URL. It will use a stable HTML marker to find a previous bot-authored preview comment on
 the pull request. If found, it updates that comment; otherwise, it creates one. The body
-will reproduce the former Firebase Hosting action's presentation: “Visit the preview URL
-for this PR,” the short deployed commit SHA, the full linked preview URL, the actual
-Firebase expiration time, the Firebase Hosting GitHub Action attribution, and the legacy
-site signature. The signature is the SHA-1 digest of the sorted Firebase site names; it is
-a stable deployment identifier, not a security claim. The hidden marker remains the
-authoritative identifier for updates. Updating one comment avoids notification noise and
-prevents stale URLs after subsequent pushes.
+will retain the useful parts of the former Firebase Hosting action's presentation: “Visit
+the preview URL for this PR,” the short deployed commit SHA, the full linked preview URL,
+and the actual Firebase expiration time. It will not attribute the deployment to the
+retired action or display that action's legacy site signature. The hidden marker remains
+the authoritative identifier for updates. Updating one comment avoids notification noise
+and prevents stale URLs after subsequent pushes.
 
 The deploy helper will export both the URL and Firebase's `expireTime` value from the CLI
 JSON. The comment step will format the timestamp with JavaScript's `toUTCString()`, matching
 the former action. If the successful CLI response unexpectedly lacks an expiration time,
-the comment will omit the expiry line rather than inventing one. The site signature will
-be derived from the known Firebase site name using Node's SHA-1 implementation, matching
-the former action without using it as the update key.
+the comment will omit the expiry line rather than inventing one.
 
 The deploy job will declare the minimum required permissions: read access to repository
 contents and write access to pull requests. Preview deployment remains disabled for
@@ -67,8 +64,8 @@ A static workflow regression test will assert that:
 - the deploy step exports a preview URL;
 - the deploy step exports the Firebase expiration time;
 - the comment step consumes that output;
-- the comment body retains the former action's wording, attribution, and stable site
-  signature;
+- the comment body retains the useful commit, URL, and expiry information without stale
+  action attribution or signature content;
 - the stable marker and update-or-create behavior remain present; and
 - the job has pull-request write permission.
 

--- a/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
+++ b/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
@@ -59,8 +59,8 @@ A static workflow regression test will assert that:
 The test will be observed failing before the workflow change and passing afterward. The
 normal JavaScript, formatting, and Python suites will run before publication.
 
-Workflow-only changes are deliberately excluded from preview deployment by the existing
-path filter, so this CI-only PR cannot exercise the comment against Firebase itself. The
-final end-to-end check will occur on the next eligible application PR: its successful
-deploy must create the preview comment, and a subsequent push must update the same comment
-rather than duplicate it.
+Workflow-only and Markdown-only changes are deliberately excluded from preview deployment
+by the existing path filter. This implementation also adds a Python regression test,
+which makes its PR eligible for preview deployment. Its first successful deploy must
+create the preview comment, and the follow-up documentation push must update the same
+comment rather than duplicate it.

--- a/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
+++ b/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
@@ -33,8 +33,20 @@ active channels produce the same output.
 A following `actions/github-script@v9` step will run only when the deploy output contains
 a URL. It will use a stable HTML marker to find a previous bot-authored preview comment on
 the pull request. If found, it updates that comment; otherwise, it creates one. The body
-will contain a clear preview link and the deployed commit SHA. Updating one comment avoids
-notification noise and prevents stale URLs after subsequent pushes.
+will reproduce the former Firebase Hosting action's presentation: “Visit the preview URL
+for this PR,” the short deployed commit SHA, the full linked preview URL, the actual
+Firebase expiration time, the Firebase Hosting GitHub Action attribution, and the legacy
+site signature. The signature is the SHA-1 digest of the sorted Firebase site names; it is
+a stable deployment identifier, not a security claim. The hidden marker remains the
+authoritative identifier for updates. Updating one comment avoids notification noise and
+prevents stale URLs after subsequent pushes.
+
+The deploy helper will export both the URL and Firebase's `expireTime` value from the CLI
+JSON. The comment step will format the timestamp with JavaScript's `toUTCString()`, matching
+the former action. If the successful CLI response unexpectedly lacks an expiration time,
+the comment will omit the expiry line rather than inventing one. The site signature will
+be derived from the known Firebase site name using Node's SHA-1 implementation, matching
+the former action without using it as the update key.
 
 The deploy job will declare the minimum required permissions: read access to repository
 contents and write access to pull requests. Preview deployment remains disabled for
@@ -45,14 +57,18 @@ Dependabot, matching current behavior.
 Deployment remains the source of truth. A deployment failure stops the job before the
 comment step. If deployment succeeds but no URL can be extracted, the existing diagnostic
 message remains in the job log and the comment step is skipped rather than posting a
-broken link.
+broken link. If the expiration time is absent or invalid, the remaining legacy-style
+content is still posted and the expiry line is omitted.
 
 ## Verification
 
 A static workflow regression test will assert that:
 
 - the deploy step exports a preview URL;
+- the deploy step exports the Firebase expiration time;
 - the comment step consumes that output;
+- the comment body retains the former action's wording, attribution, and stable site
+  signature;
 - the stable marker and update-or-create behavior remain present; and
 - the job has pull-request write permission.
 

--- a/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
+++ b/docs/plans/design/2026-07-14-preview-deploy-pr-comment-design.md
@@ -1,0 +1,66 @@
+# Preview Deployment PR Comment Design
+
+## Goal
+
+Restore the Firebase Hosting preview URL comment on pull requests without giving up the
+retry and stale-channel handling provided by the current Firebase CLI deployment step.
+
+## Root cause
+
+The original workflow used `FirebaseExtended/action-hosting-deploy`, which posted and
+updated a pull-request comment automatically. Commit `cd0390c` replaced that action with
+direct `firebase-tools` commands to make preview deployments reliable when channels
+already existed. The replacement preserved URL logging but did not replace the action's
+commenting behavior.
+
+## Considered approaches
+
+1. Return to `FirebaseExtended/action-hosting-deploy`. This restores comments but also
+   removes the explicit retry and stale-channel recovery that motivated the CLI switch.
+2. Add a dedicated third-party PR-comment action. This is concise but introduces another
+   dependency for behavior GitHub's maintained script action can provide directly.
+3. Keep the Firebase CLI deployment and add `actions/github-script`. This preserves the
+   reliable deploy path, uses an action already present in the repository, and allows the
+   comment to be updated idempotently. This is the selected approach.
+
+## Design
+
+The preview deployment step will receive an `id` and expose the first discovered
+`web.app` or `firebaseapp.com` URL through `$GITHUB_OUTPUT`. Every successful path uses
+the existing URL-discovery helper, so normal deploys, recreated channels, and already
+active channels produce the same output.
+
+A following `actions/github-script@v9` step will run only when the deploy output contains
+a URL. It will use a stable HTML marker to find a previous bot-authored preview comment on
+the pull request. If found, it updates that comment; otherwise, it creates one. The body
+will contain a clear preview link and the deployed commit SHA. Updating one comment avoids
+notification noise and prevents stale URLs after subsequent pushes.
+
+The deploy job will declare the minimum required permissions: read access to repository
+contents and write access to pull requests. Preview deployment remains disabled for
+Dependabot, matching current behavior.
+
+## Failure behavior
+
+Deployment remains the source of truth. A deployment failure stops the job before the
+comment step. If deployment succeeds but no URL can be extracted, the existing diagnostic
+message remains in the job log and the comment step is skipped rather than posting a
+broken link.
+
+## Verification
+
+A static workflow regression test will assert that:
+
+- the deploy step exports a preview URL;
+- the comment step consumes that output;
+- the stable marker and update-or-create behavior remain present; and
+- the job has pull-request write permission.
+
+The test will be observed failing before the workflow change and passing afterward. The
+normal JavaScript, formatting, and Python suites will run before publication.
+
+Workflow-only changes are deliberately excluded from preview deployment by the existing
+path filter, so this CI-only PR cannot exercise the comment against Firebase itself. The
+final end-to-end check will occur on the next eligible application PR: its successful
+deploy must create the preview comment, and a subsequent push must update the same comment
+rather than duplicate it.

--- a/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+++ b/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -216,7 +216,7 @@ Expected: GitHub creates a draft PR targeting `main`. The new Python regression 
 - Consumes: Firebase CLI JSON fields `result.<site>.url` and `result.<site>.expireTime`
 - Produces: `steps.deploy-preview.outputs.preview_url`, `steps.deploy-preview.outputs.preview_expires`, and the existing marker-tagged PR comment in the former Firebase action's format
 
-- [ ] **Step 1: Extend the workflow regression test**
+- [x] **Step 1: Extend the workflow regression test**
 
 Add these assertions to `test_preview_deploy_exports_url_and_updates_one_pr_comment` after the existing preview URL assertions:
 
@@ -230,7 +230,7 @@ assert "createHash('sha1')" in workflow
 assert ".update('fortudo')" in workflow
 ```
 
-- [ ] **Step 2: Run the focused test to verify RED**
+- [x] **Step 2: Run the focused test to verify RED**
 
 Run:
 
@@ -240,7 +240,7 @@ uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
 
 Expected: `1 failed` because `preview_expires` is not exported yet.
 
-- [ ] **Step 3: Export the actual Firebase expiration time**
+- [x] **Step 3: Export the actual Firebase expiration time**
 
 Rename `export_preview_url` to `export_preview_details`. After the existing `preview_url` extraction, add:
 
@@ -264,7 +264,7 @@ fi
 
 Update all three callers from `export_preview_url` to `export_preview_details`.
 
-- [ ] **Step 4: Render the former Firebase action's comment format**
+- [x] **Step 4: Render the former Firebase action's comment format**
 
 Add the expiry output to the comment step environment:
 
@@ -300,7 +300,7 @@ const body = [
 
 Keep the existing marker lookup and update-or-create logic unchanged.
 
-- [ ] **Step 5: Run the focused test to verify GREEN**
+- [x] **Step 5: Run the focused test to verify GREEN**
 
 Run:
 
@@ -310,7 +310,7 @@ uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
 
 Expected: `1 passed`.
 
-- [ ] **Step 6: Run formatting and full verification**
+- [x] **Step 6: Run formatting and full verification**
 
 Run:
 
@@ -329,7 +329,7 @@ Expected:
 - Pytest: 111 tests pass.
 - `git diff --check` reports no errors.
 
-- [ ] **Step 7: Commit and publish the follow-up**
+- [x] **Step 7: Commit and publish the follow-up**
 
 ```bash
 git add .github/workflows/ci-cd.yml tests/test_ci_preview_comment.py docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md

--- a/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+++ b/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -16,7 +16,7 @@
 - Grant only `contents: read` and `pull-requests: write` to the preview job.
 - Keep Dependabot preview deployment disabled.
 - Workflow-only pull requests remain excluded from preview deployment by the existing path filter.
-- Match the former Firebase Hosting action's comment wording, expiry, attribution, and site signature.
+- Retain the useful commit SHA, full preview URL, and expiry; do not attribute deployment to the retired action or display its legacy signature.
 - Omit the expiry line when Firebase does not return a valid `expireTime`; never synthesize one.
 
 ---
@@ -338,3 +338,105 @@ git push
 ```
 
 Expected: the pre-commit hook passes without `--no-verify`; PR #95 updates and its preview comment retains the same comment ID while adopting the legacy content.
+
+---
+
+### Task 3: Remove stale action metadata
+
+**Files:**
+
+- Modify: `tests/test_ci_preview_comment.py`
+- Modify: `.github/workflows/ci-cd.yml:284-305`
+
+**Interfaces:**
+
+- Consumes: `PREVIEW_URL`, `PREVIEW_EXPIRES`, and `DEPLOYED_SHA`
+- Produces: the existing marker-tagged PR comment containing only the deployed commit SHA, full preview URL, and valid Firebase expiry
+
+- [ ] **Step 1: Change the regression test to reject stale metadata**
+
+Replace the three positive assertions for action attribution and signature generation with:
+
+```python
+assert "Firebase Hosting GitHub Action" not in workflow
+assert "createHash('sha1')" not in workflow
+assert ".update('fortudo')" not in workflow
+assert "Sign: ${signature}" not in workflow
+```
+
+Keep the positive assertions for the commit wording, preview URL output, and `toUTCString()` expiry formatting.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```bash
+uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
+```
+
+Expected: `1 failed` because the workflow still contains `Firebase Hosting GitHub Action`.
+
+- [ ] **Step 3: Remove the retired action metadata**
+
+Delete the signature construction:
+
+```javascript
+const signature = require('node:crypto')
+  .createHash('sha1')
+  .update('fortudo')
+  .digest('hex');
+```
+
+Replace the body construction with:
+
+```javascript
+const body = [
+  marker,
+  `Visit the preview URL for this PR (updated for commit ${shortSha}):`,
+  '',
+  `[${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL})`,
+  '',
+  ...expiryLines
+].join('\n');
+```
+
+Keep the hidden marker, actual expiry parsing, and existing update-or-create logic unchanged.
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5: Run formatting and full verification**
+
+Run:
+
+```bash
+npm run format
+npm test -- --coverage --runInBand
+npm run check
+uv run --with pytest --with playwright python -m pytest tests -q
+git diff --check
+```
+
+Expected:
+
+- Jest: 61 suites and 1,290 tests pass with coverage thresholds satisfied.
+- ESLint and Prettier pass.
+- Pytest: 111 tests pass.
+- `git diff --check` reports no errors.
+
+- [ ] **Step 6: Commit and publish the cleanup**
+
+```bash
+git add .github/workflows/ci-cd.yml tests/test_ci_preview_comment.py docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+git commit -m "ci: remove stale preview comment metadata"
+git push
+```
+
+Expected: the pre-commit hook passes without `--no-verify`; PR #95 updates and the same marker comment no longer attributes deployment to the retired action or displays its signature.

--- a/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+++ b/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -1,0 +1,201 @@
+# Preview Deployment PR Comment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore one automatically updated Firebase preview URL comment on eligible pull requests.
+
+**Architecture:** Keep the hardened Firebase CLI deployment intact. Export the discovered preview URL as a deploy-step output, then use `actions/github-script@v9` to create or update a marker-tagged pull-request comment.
+
+**Tech Stack:** GitHub Actions YAML, Bash, `actions/github-script@v9`, Python/pytest static workflow regression test
+
+## Global Constraints
+
+- Preserve the existing Firebase CLI retry and stale-channel recovery behavior.
+- Use one marker-tagged bot comment and update it on later pushes; do not create duplicates.
+- Skip commenting when deployment does not produce a preview URL.
+- Grant only `contents: read` and `pull-requests: write` to the preview job.
+- Keep Dependabot preview deployment disabled.
+- Workflow-only pull requests remain excluded from preview deployment by the existing path filter.
+
+---
+
+### Task 1: Export and comment the preview URL
+
+**Files:**
+
+- Create: `tests/test_ci_preview_comment.py`
+- Modify: `.github/workflows/ci-cd.yml:161-263`
+
+**Interfaces:**
+
+- Consumes: the preview URL printed by `firebase-tools hosting:channel:deploy` or `hosting:channel:list`
+- Produces: `steps.deploy-preview.outputs.preview_url`, and one PR comment containing `<!-- firebase-hosting-preview -->`
+
+- [x] **Step 1: Write the failing workflow regression test**
+
+Create `tests/test_ci_preview_comment.py`:
+
+```python
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci-cd.yml"
+
+
+def test_preview_deploy_exports_url_and_updates_one_pr_comment():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull-requests: write" in workflow
+    assert "id: deploy-preview" in workflow
+    assert 'echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"' in workflow
+    assert "if: steps.deploy-preview.outputs.preview_url != ''" in workflow
+    assert "PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}" in workflow
+    assert "<!-- firebase-hosting-preview -->" in workflow
+    assert "await github.paginate(" in workflow
+    assert "github.rest.issues.listComments" in workflow
+    assert "github.rest.issues.updateComment" in workflow
+    assert "github.rest.issues.createComment" in workflow
+```
+
+- [x] **Step 2: Run the regression test to verify RED**
+
+Run:
+
+```bash
+uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
+```
+
+Expected: `1 failed`; the first missing assertion is `pull-requests: write`.
+
+- [x] **Step 3: Export the preview URL from every successful deploy path**
+
+In `.github/workflows/ci-cd.yml`, add least-privilege permissions to `deploy-preview`:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+Give the deploy step an ID:
+
+```yaml
+- name: Deploy to Firebase Hosting (Preview)
+  id: deploy-preview
+```
+
+Replace `print_preview_urls` with the following helper and update all three callers to use `export_preview_url`:
+
+```bash
+export_preview_url() {
+  local source_file="$1"
+  local preview_url
+  preview_url="$(
+    grep -Eo 'https://[^"[:space:]]+' "$source_file" |
+    grep -E 'web\.app|firebaseapp\.com' |
+    sort -u |
+    head -n 1
+  )"
+
+  if [ -n "$preview_url" ]; then
+    echo "Firebase Hosting preview URL: $preview_url"
+    echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+  else
+    echo "Firebase Hosting preview URL was not present in $source_file."
+  fi
+}
+```
+
+- [x] **Step 4: Add the idempotent PR comment step**
+
+After the preview deployment step, add:
+
+```yaml
+- name: Comment preview URL on pull request
+  if: steps.deploy-preview.outputs.preview_url != ''
+  uses: actions/github-script@v9
+  env:
+    PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}
+    DEPLOYED_SHA: ${{ github.event.pull_request.head.sha }}
+  with:
+    script: |
+      const marker = '<!-- firebase-hosting-preview -->';
+      const body = [
+        marker,
+        '## Firebase Hosting preview',
+        '',
+        `[Open preview](${process.env.PREVIEW_URL})`,
+        '',
+        `Preview for commit \`${process.env.DEPLOYED_SHA.slice(0, 7)}\`.`,
+      ].join('\n');
+
+      const issue = {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+      };
+      const comments = await github.paginate(
+        github.rest.issues.listComments,
+        issue,
+      );
+      const existing = comments.find(
+        (comment) =>
+          comment.user?.type === 'Bot' && comment.body?.includes(marker),
+      );
+
+      if (existing) {
+        await github.rest.issues.updateComment({
+          owner: issue.owner,
+          repo: issue.repo,
+          comment_id: existing.id,
+          body,
+        });
+      } else {
+        await github.rest.issues.createComment({ ...issue, body });
+      }
+```
+
+- [x] **Step 5: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
+```
+
+Expected: `1 passed`.
+
+- [x] **Step 6: Run formatting and full verification**
+
+Run:
+
+```bash
+npm run format
+npm test -- --coverage --runInBand
+npm run check
+uv run --with pytest --with playwright python -m pytest tests -q
+```
+
+Expected:
+
+- Jest: 61 suites and 1,290 tests pass with coverage thresholds satisfied.
+- ESLint and Prettier pass.
+- Pytest: 111 tests pass.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add .github/workflows/ci-cd.yml tests/test_ci_preview_comment.py docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+git commit -m "ci: restore preview URL PR comment"
+```
+
+Expected: the pre-commit hook passes without `--no-verify`.
+
+- [ ] **Step 8: Publish the separate PR**
+
+```bash
+git push -u origin codex/restore-preview-comment
+gh pr create --draft --base main --head codex/restore-preview-comment --fill
+```
+
+Expected: GitHub creates a draft PR targeting `main`. Because `.github/**` and Markdown-only changes do not trigger preview deployment, live comment creation will be verified on the next eligible application PR after merge.

--- a/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+++ b/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -16,6 +16,8 @@
 - Grant only `contents: read` and `pull-requests: write` to the preview job.
 - Keep Dependabot preview deployment disabled.
 - Workflow-only pull requests remain excluded from preview deployment by the existing path filter.
+- Match the former Firebase Hosting action's comment wording, expiry, attribution, and site signature.
+- Omit the expiry line when Firebase does not return a valid `expireTime`; never synthesize one.
 
 ---
 
@@ -199,3 +201,140 @@ gh pr create --draft --base main --head codex/restore-preview-comment --fill
 ```
 
 Expected: GitHub creates a draft PR targeting `main`. The new Python regression test makes this PR eligible for preview deployment, so its first workflow run creates the marker-tagged comment. A follow-up documentation push updates the same comment instead of creating a duplicate.
+
+---
+
+### Task 2: Match the legacy Firebase comment content
+
+**Files:**
+
+- Modify: `tests/test_ci_preview_comment.py`
+- Modify: `.github/workflows/ci-cd.yml:187-299`
+
+**Interfaces:**
+
+- Consumes: Firebase CLI JSON fields `result.<site>.url` and `result.<site>.expireTime`
+- Produces: `steps.deploy-preview.outputs.preview_url`, `steps.deploy-preview.outputs.preview_expires`, and the existing marker-tagged PR comment in the former Firebase action's format
+
+- [ ] **Step 1: Extend the workflow regression test**
+
+Add these assertions to `test_preview_deploy_exports_url_and_updates_one_pr_comment` after the existing preview URL assertions:
+
+```python
+assert 'echo "preview_expires=$preview_expires" >> "$GITHUB_OUTPUT"' in workflow
+assert "PREVIEW_EXPIRES: ${{ steps.deploy-preview.outputs.preview_expires }}" in workflow
+assert "Visit the preview URL for this PR (updated for commit" in workflow
+assert "toUTCString()" in workflow
+assert "Firebase Hosting GitHub Action" in workflow
+assert "createHash('sha1')" in workflow
+assert ".update('fortudo')" in workflow
+```
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```bash
+uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
+```
+
+Expected: `1 failed` because `preview_expires` is not exported yet.
+
+- [ ] **Step 3: Export the actual Firebase expiration time**
+
+Rename `export_preview_url` to `export_preview_details`. After the existing `preview_url` extraction, add:
+
+```bash
+local preview_expires
+preview_expires="$(
+  grep -Eo '"expireTime":[[:space:]]*"[^"]+"' "$source_file" |
+  head -n 1 |
+  sed -E 's/^"expireTime":[[:space:]]*"([^"]+)"$/\1/'
+)"
+```
+
+Inside the successful URL branch, export the timestamp only when Firebase supplied it:
+
+```bash
+if [ -n "$preview_expires" ]; then
+  echo "Firebase Hosting preview expiry: $preview_expires"
+  echo "preview_expires=$preview_expires" >> "$GITHUB_OUTPUT"
+fi
+```
+
+Update all three callers from `export_preview_url` to `export_preview_details`.
+
+- [ ] **Step 4: Render the former Firebase action's comment format**
+
+Add the expiry output to the comment step environment:
+
+```yaml
+PREVIEW_EXPIRES: ${{ steps.deploy-preview.outputs.preview_expires }}
+```
+
+Replace the comment body's construction with:
+
+```javascript
+const marker = '<!-- firebase-hosting-preview -->';
+const shortSha = process.env.DEPLOYED_SHA.slice(0, 7);
+const expires = new Date(process.env.PREVIEW_EXPIRES);
+const expiryLines = Number.isNaN(expires.getTime())
+  ? []
+  : [`(expires ${expires.toUTCString()})`, ''];
+const signature = require('node:crypto')
+  .createHash('sha1')
+  .update('fortudo')
+  .digest('hex');
+const body = [
+  marker,
+  `Visit the preview URL for this PR (updated for commit ${shortSha}):`,
+  '',
+  `[${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL})`,
+  '',
+  ...expiryLines,
+  '🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎',
+  '',
+  `Sign: ${signature}`
+].join('\n');
+```
+
+Keep the existing marker lookup and update-or-create logic unchanged.
+
+- [ ] **Step 5: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 6: Run formatting and full verification**
+
+Run:
+
+```bash
+npm run format
+npm test -- --coverage --runInBand
+npm run check
+uv run --with pytest --with playwright python -m pytest tests -q
+git diff --check
+```
+
+Expected:
+
+- Jest: 61 suites and 1,290 tests pass with coverage thresholds satisfied.
+- ESLint and Prettier pass.
+- Pytest: 111 tests pass.
+- `git diff --check` reports no errors.
+
+- [ ] **Step 7: Commit and publish the follow-up**
+
+```bash
+git add .github/workflows/ci-cd.yml tests/test_ci_preview_comment.py docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+git commit -m "ci: match legacy preview comment content"
+git push
+```
+
+Expected: the pre-commit hook passes without `--no-verify`; PR #95 updates and its preview comment retains the same comment ID while adopting the legacy content.

--- a/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+++ b/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -353,7 +353,7 @@ Expected: the pre-commit hook passes without `--no-verify`; PR #95 updates and i
 - Consumes: `PREVIEW_URL`, `PREVIEW_EXPIRES`, and `DEPLOYED_SHA`
 - Produces: the existing marker-tagged PR comment containing only the deployed commit SHA, full preview URL, and valid Firebase expiry
 
-- [ ] **Step 1: Change the regression test to reject stale metadata**
+- [x] **Step 1: Change the regression test to reject stale metadata**
 
 Replace the three positive assertions for action attribution and signature generation with:
 
@@ -366,7 +366,7 @@ assert "Sign: ${signature}" not in workflow
 
 Keep the positive assertions for the commit wording, preview URL output, and `toUTCString()` expiry formatting.
 
-- [ ] **Step 2: Run the focused test to verify RED**
+- [x] **Step 2: Run the focused test to verify RED**
 
 Run:
 
@@ -376,7 +376,7 @@ uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
 
 Expected: `1 failed` because the workflow still contains `Firebase Hosting GitHub Action`.
 
-- [ ] **Step 3: Remove the retired action metadata**
+- [x] **Step 3: Remove the retired action metadata**
 
 Delete the signature construction:
 
@@ -402,7 +402,7 @@ const body = [
 
 Keep the hidden marker, actual expiry parsing, and existing update-or-create logic unchanged.
 
-- [ ] **Step 4: Run the focused test to verify GREEN**
+- [x] **Step 4: Run the focused test to verify GREEN**
 
 Run:
 
@@ -412,7 +412,7 @@ uv run --with pytest python -m pytest tests/test_ci_preview_comment.py -q
 
 Expected: `1 passed`.
 
-- [ ] **Step 5: Run formatting and full verification**
+- [x] **Step 5: Run formatting and full verification**
 
 Run:
 
@@ -431,7 +431,7 @@ Expected:
 - Pytest: 111 tests pass.
 - `git diff --check` reports no errors.
 
-- [ ] **Step 6: Commit and publish the cleanup**
+- [x] **Step 6: Commit and publish the cleanup**
 
 ```bash
 git add .github/workflows/ci-cd.yml tests/test_ci_preview_comment.py docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md

--- a/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
+++ b/docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -182,7 +182,7 @@ Expected:
 - ESLint and Prettier pass.
 - Pytest: 111 tests pass.
 
-- [ ] **Step 7: Commit the implementation**
+- [x] **Step 7: Commit the implementation**
 
 ```bash
 git add .github/workflows/ci-cd.yml tests/test_ci_preview_comment.py docs/plans/implementation/2026-07-14-preview-deploy-pr-comment.md
@@ -191,11 +191,11 @@ git commit -m "ci: restore preview URL PR comment"
 
 Expected: the pre-commit hook passes without `--no-verify`.
 
-- [ ] **Step 8: Publish the separate PR**
+- [x] **Step 8: Publish the separate PR**
 
 ```bash
 git push -u origin codex/restore-preview-comment
 gh pr create --draft --base main --head codex/restore-preview-comment --fill
 ```
 
-Expected: GitHub creates a draft PR targeting `main`. Because `.github/**` and Markdown-only changes do not trigger preview deployment, live comment creation will be verified on the next eligible application PR after merge.
+Expected: GitHub creates a draft PR targeting `main`. The new Python regression test makes this PR eligible for preview deployment, so its first workflow run creates the marker-tagged comment. A follow-up documentation push updates the same comment instead of creating a duplicate.

--- a/tests/test_ci_preview_comment.py
+++ b/tests/test_ci_preview_comment.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci-cd.yml"
+
+
+def test_preview_deploy_exports_url_and_updates_one_pr_comment():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull-requests: write" in workflow
+    assert "id: deploy-preview" in workflow
+    assert 'echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"' in workflow
+    assert "if: steps.deploy-preview.outputs.preview_url != ''" in workflow
+    assert "PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}" in workflow
+    assert "<!-- firebase-hosting-preview -->" in workflow
+    assert "await github.paginate(" in workflow
+    assert "github.rest.issues.listComments" in workflow
+    assert "github.rest.issues.updateComment" in workflow
+    assert "github.rest.issues.createComment" in workflow

--- a/tests/test_ci_preview_comment.py
+++ b/tests/test_ci_preview_comment.py
@@ -10,8 +10,15 @@ def test_preview_deploy_exports_url_and_updates_one_pr_comment():
     assert "pull-requests: write" in workflow
     assert "id: deploy-preview" in workflow
     assert 'echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"' in workflow
+    assert 'echo "preview_expires=$preview_expires" >> "$GITHUB_OUTPUT"' in workflow
     assert "if: steps.deploy-preview.outputs.preview_url != ''" in workflow
     assert "PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}" in workflow
+    assert "PREVIEW_EXPIRES: ${{ steps.deploy-preview.outputs.preview_expires }}" in workflow
+    assert "Visit the preview URL for this PR (updated for commit" in workflow
+    assert "toUTCString()" in workflow
+    assert "Firebase Hosting GitHub Action" in workflow
+    assert "createHash('sha1')" in workflow
+    assert ".update('fortudo')" in workflow
     assert "<!-- firebase-hosting-preview -->" in workflow
     assert "await github.paginate(" in workflow
     assert "github.rest.issues.listComments" in workflow

--- a/tests/test_ci_preview_comment.py
+++ b/tests/test_ci_preview_comment.py
@@ -16,9 +16,10 @@ def test_preview_deploy_exports_url_and_updates_one_pr_comment():
     assert "PREVIEW_EXPIRES: ${{ steps.deploy-preview.outputs.preview_expires }}" in workflow
     assert "Visit the preview URL for this PR (updated for commit" in workflow
     assert "toUTCString()" in workflow
-    assert "Firebase Hosting GitHub Action" in workflow
-    assert "createHash('sha1')" in workflow
-    assert ".update('fortudo')" in workflow
+    assert "Firebase Hosting GitHub Action" not in workflow
+    assert "createHash('sha1')" not in workflow
+    assert ".update('fortudo')" not in workflow
+    assert "Sign: ${signature}" not in workflow
     assert "<!-- firebase-hosting-preview -->" in workflow
     assert "await github.paginate(" in workflow
     assert "github.rest.issues.listComments" in workflow


### PR DESCRIPTION
## Summary

- export the Firebase Hosting preview URL and actual expiration time from the deploy step
- create or update one marker-based GitHub Actions comment on the pull request
- show only useful deployment information: commit SHA, full preview URL, and expiry
- grant only the required pull-request write permission
- add a regression test covering the workflow contract

## Why

The direct Firebase CLI deployment retained preview creation and retry behavior, but no longer posted the resulting URL to pull requests. This restores that discoverability without reverting the hardened deployment implementation or attributing the deploy to the retired Firebase action.

## Validation

- focused regression test: observed RED, then 1 passed
- Jest: 61 suites, 1,290 tests passed; coverage thresholds satisfied
- `npm run check`: passed
- Python/Playwright: 111 passed
- pre-commit hooks: passed on every commit
- GitHub Actions: all required checks passed, including E2E and Deploy Preview
- live idempotency check: comment `4975475409` remained the sole marker comment across updates
- live content check: comment `4975475409` now contains only commit `ee61bc8`, the full preview URL, and the actual Firebase expiry
