### PR TITLE
Harden Cloudant target state binding

### DIFF
--- a/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
+++ b/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
@@ -1,6 +1,6 @@
 # Document-contract migration runbook
 
-This runbook is the operational companion to the entity and taxonomy identity hardening. It does not authorize a production write by itself. Stop whenever a database name, UUID, opaque update sequence, `_security` hash, validator revision, leaf set, or required approval differs from the locked private manifest.
+This runbook is the operational companion to the entity and taxonomy identity hardening. It does not authorize a production write by itself. Stop whenever a target-binding checksum, database name, opaque update sequence, `_security` hash, validator revision, leaf set, or required approval differs from the locked private manifest.
 
 Never paste the Cloudant credential URL, document bodies, descriptions, or private manifests into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only in the local process environment. Store inventories, snapshots, and journals on an encrypted user-only volume outside the repository by default.
 
@@ -54,12 +54,14 @@ python scripts/document_contract_ops.py inventory `
 
 For the approved temporary-unencrypted exception, replace the final flag with `--confirm-temporary-unencrypted`.
 
-The normal output contains aggregate counts and the manifest checksum only. Locate the private manifest inside the operator-supplied root; its path and exact database list stay off normal command output. Obtain explicit approval for the fresh database list. Do not reuse an older count.
+The normal output contains aggregate counts, the credential-free account checksum, and the manifest checksum only. Locate the private manifest inside the operator-supplied root; its path and exact database list stay off normal command output. Obtain explicit approval for the fresh database list and account checksum. Do not reuse an older count.
+
+IBM Cloudant does not expose the per-database UUID returned by Apache CouchDB. Snapshot format 2 therefore uses a versioned target binding over the credential-free account-endpoint hash, exact database name, partitioning state, opaque update sequence, `_security` checksum, canonical complete leaf-graph checksum, and winner-revision-map checksum. The binding checksum is the operator-visible lock; credentials and the account endpoint remain private.
 
 ## Fence and migrate `fortudo-dat-411`
 
 1. Stop the timer and close known active clients.
-2. Lock the database name, UUID, opaque update sequence, `_security` checksum, taxonomy mapping, current winners, and every conflict leaf from the private inventory/dry-run.
+2. Lock the target-binding checksum, opaque update sequence, taxonomy mapping, current winners, and every conflict leaf from the private inventory/dry-run.
 3. Create `S0` before installing the fence:
 
    ```powershell
@@ -78,9 +80,7 @@ The normal output contains aggregate counts and the manifest checksum only. Loca
    python scripts/document_contract_ops.py install `
      --database fortudo-dat-411 `
      --confirm-database fortudo-dat-411 `
-     --expected-uuid <private-uuid> `
-     --expected-update-seq <private-opaque-sequence> `
-     --expected-security-checksum <private-hash> `
+     --expected-target-binding-checksum <private-S0-binding-checksum> `
      --snapshot <S0-path>
    ```
 
@@ -103,7 +103,17 @@ The tool applies identity revisions and conflict tombstones first, verifies all 
 
 8. Create `S2` only after marker, fingerprint, counts, winners, conflict resolution, locked labels, and nonidentity invariants all verify.
 
-Direct production restore is disabled. Reconstruct a new `fortudo-quarantine-*` database with `restore-quarantine`; legacy leaf trees load before the validator. Reconciliation back into production remains manual and selective.
+Direct production restore is disabled. Reconstruct a new `fortudo-quarantine-*` database only in the approved Cloudant account; legacy leaf trees load before the validator:
+
+```powershell
+python scripts/document_contract_ops.py restore-quarantine `
+  --database fortudo-quarantine-<id> `
+  --confirm-database fortudo-quarantine-<id> `
+  --expected-account-checksum <approved-private-inventory-account-checksum> `
+  --snapshot <snapshot-path>
+```
+
+The external account checksum must match both the active credential and the snapshot binding before the quarantine database is created. Direct cross-account reconstruction is not authorized by this runbook. Reconciliation back into production remains manual and selective.
 
 ## Other existing rooms
 
@@ -124,9 +134,10 @@ Provision future remote rooms manually and fence-first:
 ```powershell
 python scripts/document_contract_ops.py provision `
   --database fortudo-<room> `
-  --confirm-database fortudo-<room>
+  --confirm-database fortudo-<room> `
+  --expected-account-checksum <approved-private-inventory-account-checksum>
 ```
 
 Exercise each known client. It must either pass a stable divergence audit and sync, or export/reset, pull, and then pass. Create `S3` after that exercise; it is an aggregate observation, not proof that no dormant replica exists.
 
-The final record must include exact test and coverage results, CI and deployment status, commit and service-worker SHAs, live asset hashes, inventory/snapshot/journal paths and checksums, migration and fence counts, validator revision, completion fingerprint, and every post-migration invariant.
+The final record must include exact test and coverage results, CI and deployment status, commit and service-worker SHAs, live asset hashes, inventory/snapshot/journal paths and checksums, target-binding checksums, migration and fence counts, validator revision, completion fingerprint, and every post-migration invariant.

--- a/scripts/document_contract_ops.py
+++ b/scripts/document_contract_ops.py
@@ -41,6 +41,9 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_MODULE = REPOSITORY_ROOT / "public" / "js" / "document-contract.js"
 CONTRACT_DESIGN_ID = "_design/fortudo-document-contract"
 CONTRACT_VERSION = 1
+SNAPSHOT_FORMAT_VERSION = 2
+TARGET_BINDING_FORMAT_VERSION = 1
+TARGET_BINDING_SCHEME = "ibm-cloudant-account-database-state-v1"
 TEMPORARY_UNENCRYPTED_RETENTION = "delete-after-s3-and-known-client-exercise"
 
 
@@ -59,6 +62,7 @@ class InventoryResult:
     path: Path
     checksum: str
     counts: dict[str, int]
+    account_checksum: str
 
 
 def _sha256_bytes(value: bytes) -> str:
@@ -158,10 +162,29 @@ def _leaf_set(leaves: Sequence[Mapping[str, Any]]) -> list[tuple[str, str, bool]
     return sorted(identities)
 
 
+def _leaf_body_map(leaves: Sequence[Mapping[str, Any]]) -> dict[tuple[str, str, bool], str]:
+    identities = _leaf_set(leaves)
+    by_identity = {
+        _leaf_identity(leaf): _canonical_json(leaf)
+        for leaf in leaves
+    }
+    if len(by_identity) != len(identities):
+        raise ContractOpsSafetyError("leaf graph contains duplicate identities")
+    return by_identity
+
+
 def _ndjson_bytes(rows: Sequence[Mapping[str, Any]]) -> bytes:
     if not rows:
         return b""
+    _leaf_set(rows)
     return ("\n".join(_canonical_json(row) for row in rows) + "\n").encode("utf-8")
+
+
+def _canonical_leaf_graph_checksum(rows: Sequence[Mapping[str, Any]]) -> str:
+    _leaf_set(rows)
+    ordered = sorted(rows, key=_leaf_identity)
+    content = ("\n".join(_canonical_json(row) for row in ordered) + "\n").encode("utf-8")
+    return _sha256_bytes(content)
 
 
 def _read_json(path: Path) -> Any:
@@ -182,6 +205,142 @@ def _manifest_checksum(manifest: Mapping[str, Any]) -> str:
     unsigned = dict(manifest)
     unsigned.pop("manifestChecksum", None)
     return _sha256_bytes(_canonical_json(unsigned).encode("utf-8"))
+
+
+def _partitioned(info: Mapping[str, Any]) -> bool:
+    return bool(
+        info.get("partitioned") is True
+        or info.get("props", {}).get("partitioned", False)
+    )
+
+
+def _account_checksum(client: Any) -> str:
+    try:
+        checksum = client.get_account_checksum()
+    except (AttributeError, TypeError) as error:
+        raise ContractOpsSafetyError("Cloudant account identity is unavailable") from error
+    return _require_sha256(checksum, field="Cloudant account identity")
+
+
+def _require_sha256(value: Any, *, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ContractOpsSafetyError(f"{field} is invalid")
+    return value
+
+
+def _target_binding_from_parts(
+    *,
+    account_checksum: str,
+    database: str,
+    partitioned: bool,
+    update_seq: Any,
+    security_checksum_value: str,
+    leaf_graph_checksum: str,
+    winner_revisions: Mapping[str, str],
+) -> dict[str, Any]:
+    if not isinstance(database, str):
+        raise ContractOpsSafetyError("database identity is invalid")
+    _require_database_name(database)
+    if not isinstance(partitioned, bool):
+        raise ContractOpsSafetyError("database partitioning metadata is invalid")
+    if not isinstance(winner_revisions, Mapping):
+        raise ContractOpsSafetyError("winner metadata is invalid")
+    account_checksum = _require_sha256(
+        account_checksum, field="Cloudant account identity"
+    )
+    security_checksum_value = _require_sha256(
+        security_checksum_value, field="security checksum"
+    )
+    leaf_graph_checksum = _require_sha256(
+        leaf_graph_checksum, field="leaf graph checksum"
+    )
+    if not isinstance(update_seq, str) or not update_seq:
+        raise ContractOpsSafetyError("database update sequence is incomplete")
+    if any(
+        not isinstance(document_id, str) or not isinstance(revision, str)
+        for document_id, revision in winner_revisions.items()
+    ):
+        raise ContractOpsSafetyError("winner metadata is invalid")
+    body = {
+        "formatVersion": TARGET_BINDING_FORMAT_VERSION,
+        "scheme": TARGET_BINDING_SCHEME,
+        "accountChecksum": account_checksum,
+        "databaseName": database,
+        "partitioned": partitioned,
+        "databaseUpdateSeq": update_seq,
+        "securityChecksum": security_checksum_value,
+        "leafGraphChecksum": leaf_graph_checksum,
+        "winnerRevisionsChecksum": _sha256_bytes(
+            _canonical_json(dict(sorted(winner_revisions.items()))).encode("utf-8")
+        ),
+    }
+    return {**body, "checksum": _sha256_bytes(_canonical_json(body).encode("utf-8"))}
+
+
+def capture_target_binding(
+    client: Any,
+    *,
+    database: str,
+    info: Mapping[str, Any],
+    security: Mapping[str, Any],
+    leaves: Sequence[Mapping[str, Any]],
+    winners: Mapping[str, str],
+) -> dict[str, Any]:
+    """Bind one exact Cloudant account/database state without a database UUID."""
+    if info.get("db_name") != database:
+        raise ContractOpsSafetyError("Cloudant reported a different database name")
+    return _target_binding_from_parts(
+        account_checksum=_account_checksum(client),
+        database=database,
+        partitioned=_partitioned(info),
+        update_seq=info.get("update_seq"),
+        security_checksum_value=security_checksum(security),
+        leaf_graph_checksum=_canonical_leaf_graph_checksum(leaves),
+        winner_revisions=winners,
+    )
+
+
+def _database_observation(
+    client: Any, database: str, info: Mapping[str, Any]
+) -> dict[str, Any]:
+    if info.get("db_name") != database:
+        raise ContractOpsSafetyError("Cloudant reported a different database name")
+    update_seq = info.get("update_seq")
+    if not isinstance(update_seq, str) or not update_seq:
+        raise ContractOpsSafetyError("database update sequence is incomplete")
+    return {
+        "accountChecksum": _account_checksum(client),
+        "databaseName": database,
+        "partitioned": _partitioned(info),
+        "databaseUpdateSeq": update_seq,
+    }
+
+
+def _validate_snapshot_target_binding(
+    manifest: Mapping[str, Any], *, leaf_graph_checksum: str
+) -> None:
+    if manifest.get("formatVersion") != SNAPSHOT_FORMAT_VERSION:
+        raise ContractOpsSafetyError("snapshot format version is unsupported")
+    binding = manifest.get("targetBinding")
+    if not isinstance(binding, Mapping):
+        raise ContractOpsSafetyError("snapshot target binding is missing")
+    if not isinstance(manifest.get("partitioned"), bool):
+        raise ContractOpsSafetyError("snapshot partitioning metadata is invalid")
+    expected = _target_binding_from_parts(
+        account_checksum=binding.get("accountChecksum"),
+        database=manifest.get("databaseName"),
+        partitioned=manifest["partitioned"],
+        update_seq=manifest.get("databaseUpdateSeq"),
+        security_checksum_value=manifest.get("securityChecksum"),
+        leaf_graph_checksum=leaf_graph_checksum,
+        winner_revisions=manifest.get("winnerRevisions", {}),
+    )
+    if dict(binding) != expected:
+        raise ContractOpsSafetyError("snapshot target binding is invalid")
 
 
 def create_snapshot(
@@ -205,13 +364,19 @@ def create_snapshot(
     path = _exact_artifact_path(root, f"fortudo-contract-{label}-{timestamp}")
 
     info_before = client.get_database_info(database)
-    if info_before.get("db_name") != database or not isinstance(info_before.get("uuid"), str):
-        raise ContractOpsSafetyError("database identity metadata is incomplete")
     security_before = client.get_security(database)
     leaves, winners = client.get_current_leaf_graph(database)
     leaf_identities = _leaf_set(leaves)
     if not isinstance(winners, Mapping):
         raise ContractOpsSafetyError("winner metadata is invalid")
+    target_binding = capture_target_binding(
+        client,
+        database=database,
+        info=info_before,
+        security=security_before,
+        leaves=leaves,
+        winners=winners,
+    )
 
     try:
         path.mkdir(parents=True, mode=0o700)
@@ -227,22 +392,22 @@ def create_snapshot(
         security_bytes = (json.dumps(security_before, indent=2, sort_keys=True) + "\n").encode()
         metadata = {
             "databaseName": database,
-            "databaseUuid": info_before["uuid"],
             "databaseUpdateSeq": info_before.get("update_seq"),
             "docCount": info_before.get("doc_count"),
             "deletedDocCount": info_before.get("doc_del_count"),
-            "partitioned": bool(info_before.get("props", {}).get("partitioned", False)),
+            "partitioned": _partitioned(info_before),
         }
         metadata_bytes = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode()
         design_leaf = next(
             (leaf for leaf in leaves if leaf.get("_id") == CONTRACT_DESIGN_ID), None
         )
         manifest_base = {
-            "formatVersion": 1,
+            "formatVersion": SNAPSHOT_FORMAT_VERSION,
             "label": label,
             "createdAt": timestamp,
             "backupProtection": backup_protection,
             **metadata,
+            "targetBinding": target_binding,
             "leafCount": len(leaves),
             "winnerCount": len(winners),
             "winnerRevisions": dict(sorted(winners.items())),
@@ -270,13 +435,15 @@ def create_snapshot(
         info_after = client.get_database_info(database)
         security_after = client.get_security(database)
         leaves_after, winners_after = client.get_current_leaf_graph(database)
-        if (
-            info_after.get("uuid") != info_before["uuid"]
-            or info_after.get("update_seq") != info_before.get("update_seq")
-            or security_checksum(security_after) != manifest["securityChecksum"]
-            or _leaf_set(leaves_after) != leaf_identities
-            or dict(winners_after) != dict(winners)
-        ):
+        target_binding_after = capture_target_binding(
+            client,
+            database=database,
+            info=info_after,
+            security=security_after,
+            leaves=leaves_after,
+            winners=winners_after,
+        )
+        if target_binding_after != target_binding:
             raise ContractOpsSafetyError("database changed during snapshot")
         verify_snapshot(path)
         return SnapshotResult(path=path, checksum=manifest["manifestChecksum"])
@@ -288,8 +455,15 @@ def create_snapshot(
 def verify_snapshot(snapshot_path: str | Path) -> dict[str, Any]:
     path = Path(snapshot_path).resolve()
     manifest = _read_json(path / "manifest.json")
+    if not isinstance(manifest, Mapping):
+        raise ContractOpsSafetyError("snapshot manifest is invalid")
     _validate_backup_protection(manifest.get("backupProtection"))
-    for filename, checksum in manifest.get("files", {}).items():
+    files = manifest.get("files")
+    expected_files = {"leaf-graph.ndjson", "security.json", "database-metadata.json"}
+    if not isinstance(files, Mapping) or set(files) != expected_files:
+        raise ContractOpsSafetyError("snapshot file manifest is invalid")
+    for filename, checksum in files.items():
+        _require_sha256(checksum, field="snapshot file checksum")
         try:
             content = (path / filename).read_bytes()
         except OSError as error:
@@ -299,13 +473,35 @@ def verify_snapshot(snapshot_path: str | Path) -> dict[str, Any]:
     if _manifest_checksum(manifest) != manifest.get("manifestChecksum"):
         raise ContractOpsSafetyError("snapshot manifest checksum mismatch")
     leaves = _read_ndjson(path / "leaf-graph.ndjson")
+    _validate_snapshot_target_binding(
+        manifest, leaf_graph_checksum=_canonical_leaf_graph_checksum(leaves)
+    )
     if len(leaves) != manifest.get("leafCount"):
         raise ContractOpsSafetyError("snapshot leaf count mismatch")
     if [list(identity) for identity in _leaf_set(leaves)] != manifest.get("leafIdentities"):
         raise ContractOpsSafetyError("snapshot leaf identity mismatch")
+    winners = manifest.get("winnerRevisions")
+    if not isinstance(winners, Mapping) or len(winners) != manifest.get("winnerCount"):
+        raise ContractOpsSafetyError("snapshot winner metadata is invalid")
+    live_identities = {(identity[0], identity[1]) for identity in _leaf_set(leaves)}
+    if any((document_id, revision) not in live_identities for document_id, revision in winners.items()):
+        raise ContractOpsSafetyError("snapshot winner identity is missing")
     security = _read_json(path / "security.json")
     if security_checksum(security) != manifest.get("securityChecksum"):
         raise ContractOpsSafetyError("snapshot security checksum mismatch")
+    metadata = _read_json(path / "database-metadata.json")
+    expected_metadata = {
+        key: manifest.get(key)
+        for key in (
+            "databaseName",
+            "databaseUpdateSeq",
+            "docCount",
+            "deletedDocCount",
+            "partitioned",
+        )
+    }
+    if metadata != expected_metadata:
+        raise ContractOpsSafetyError("snapshot database metadata mismatch")
     return manifest
 
 
@@ -329,33 +525,30 @@ def install_validator(
     *,
     database: str,
     confirmation: str,
-    expected_uuid: str,
-    expected_update_seq: Any,
-    expected_security_checksum: str,
+    expected_target_binding_checksum: str,
     snapshot_path: str | Path,
 ) -> dict[str, Any]:
     _require_database_name(database)
     _require_confirmation(database, confirmation)
     manifest = verify_snapshot(snapshot_path)
-    if (
-        manifest.get("databaseName") != database
-        or manifest.get("databaseUuid") != expected_uuid
-        or manifest.get("databaseUpdateSeq") != expected_update_seq
-        or manifest.get("securityChecksum") != expected_security_checksum
-    ):
+    expected_target_binding_checksum = _require_sha256(
+        expected_target_binding_checksum, field="expected target binding checksum"
+    )
+    if manifest.get("targetBinding", {}).get("checksum") != expected_target_binding_checksum:
         raise ContractOpsSafetyError("snapshot does not match the locked installation target")
 
     info = client.get_database_info(database)
     security_before = client.get_security(database)
     leaves_before, winners_before = client.get_current_leaf_graph(database)
-    if (
-        info.get("uuid") != expected_uuid
-        or info.get("update_seq") != expected_update_seq
-        or security_checksum(security_before) != expected_security_checksum
-        or [list(identity) for identity in _leaf_set(leaves_before)]
-        != manifest.get("leafIdentities")
-        or dict(winners_before) != manifest.get("winnerRevisions")
-    ):
+    live_target_binding = capture_target_binding(
+        client,
+        database=database,
+        info=info,
+        security=security_before,
+        leaves=leaves_before,
+        winners=winners_before,
+    )
+    if live_target_binding != manifest.get("targetBinding"):
         raise ContractOpsSafetyError("database state differs from the locked snapshot")
     if any(leaf.get("_id") == CONTRACT_DESIGN_ID for leaf in leaves_before):
         raise ContractOpsSafetyError("validator already exists; use verify instead")
@@ -367,7 +560,17 @@ def install_validator(
     if verified.get("state") != "compatible":
         raise ContractOpsSafetyError("installed validator verification failed")
 
+    info_after = client.get_database_info(database)
+    security_after = client.get_security(database)
     leaves_after, winners_after = client.get_current_leaf_graph(database)
+    after_target_binding = capture_target_binding(
+        client,
+        database=database,
+        info=info_after,
+        security=security_after,
+        leaves=leaves_after,
+        winners=winners_after,
+    )
     before_without_design = _leaf_set(
         [leaf for leaf in leaves_before if leaf.get("_id") != CONTRACT_DESIGN_ID]
     )
@@ -375,8 +578,15 @@ def install_validator(
         [leaf for leaf in leaves_after if leaf.get("_id") != CONTRACT_DESIGN_ID]
     )
     design_after = [leaf for leaf in leaves_after if leaf.get("_id") == CONTRACT_DESIGN_ID]
+    bodies_before = _leaf_body_map(
+        [leaf for leaf in leaves_before if leaf.get("_id") != CONTRACT_DESIGN_ID]
+    )
+    bodies_after = _leaf_body_map(
+        [leaf for leaf in leaves_after if leaf.get("_id") != CONTRACT_DESIGN_ID]
+    )
     if (
         before_without_design != after_without_design
+        or bodies_before != bodies_after
         or len(design_after) != 1
         or {
             key: value
@@ -384,7 +594,10 @@ def install_validator(
             if key != CONTRACT_DESIGN_ID
         }
         != dict(winners_before)
-        or security_checksum(client.get_security(database)) != expected_security_checksum
+        or any(
+            after_target_binding.get(key) != manifest["targetBinding"].get(key)
+            for key in ("accountChecksum", "databaseName", "partitioned", "securityChecksum")
+        )
     ):
         raise ContractOpsSafetyError("installation changed state beyond the design document")
     return {
@@ -394,9 +607,20 @@ def install_validator(
     }
 
 
-def provision_database(client: Any, *, database: str, confirmation: str) -> dict[str, Any]:
+def provision_database(
+    client: Any,
+    *,
+    database: str,
+    confirmation: str,
+    expected_account_checksum: str,
+) -> dict[str, Any]:
     _require_database_name(database)
     _require_confirmation(database, confirmation)
+    expected_account_checksum = _require_sha256(
+        expected_account_checksum, field="expected Cloudant account checksum"
+    )
+    if _account_checksum(client) != expected_account_checksum:
+        raise ContractOpsSafetyError("credential does not match the approved Cloudant account")
     client.create_database(database)
     info = client.get_database_info(database)
     if info.get("db_name") != database or info.get("doc_count") != 0:
@@ -411,7 +635,7 @@ def provision_database(client: Any, *, database: str, confirmation: str) -> dict
     if len(final_leaves) != 1 or final_leaves[0].get("_id") != CONTRACT_DESIGN_ID:
         raise ContractOpsSafetyError("validator was not the first database document")
     return {
-        "databaseUuid": info.get("uuid"),
+        "targetAccountChecksum": _account_checksum(client),
         "validatorRevision": result.get("rev"),
         "validatorChecksum": load_design_document()["fortudoDocumentContract"]["checksum"],
     }
@@ -423,9 +647,8 @@ def _read_stable_leaf_graph(
     before = client.get_database_info(database)
     leaves, winners = client.get_current_leaf_graph(database)
     after = client.get_database_info(database)
-    if (
-        before.get("uuid") != after.get("uuid")
-        or before.get("update_seq") != after.get("update_seq")
+    if _database_observation(client, database, before) != _database_observation(
+        client, database, after
     ):
         raise ContractOpsSafetyError("quarantine state changed during verification")
     return leaves, winners
@@ -436,13 +659,21 @@ def restore_quarantine(
     *,
     database: str,
     confirmation: str,
+    expected_account_checksum: str,
     snapshot_path: str | Path,
 ) -> dict[str, Any]:
     if not database.startswith("fortudo-quarantine-"):
         raise ContractOpsSafetyError("restore target must be a new quarantine database")
     _require_database_name(database)
     _require_confirmation(database, confirmation)
+    expected_account_checksum = _require_sha256(
+        expected_account_checksum, field="expected Cloudant account checksum"
+    )
+    if _account_checksum(client) != expected_account_checksum:
+        raise ContractOpsSafetyError("credential does not match the approved Cloudant account")
     manifest = verify_snapshot(snapshot_path)
+    if manifest["targetBinding"]["accountChecksum"] != expected_account_checksum:
+        raise ContractOpsSafetyError("snapshot Cloudant account is not the approved account")
     leaves = _read_ndjson(Path(snapshot_path) / "leaf-graph.ndjson")
     legacy_leaves = [leaf for leaf in leaves if leaf.get("_id") != CONTRACT_DESIGN_ID]
     expected_leaf_bodies = {
@@ -527,6 +758,7 @@ def create_inventory(
         temporary_unencrypted_confirmed=temporary_unencrypted_confirmed,
     )
     root = validate_backup_root(manifest_root)
+    account_checksum = _account_checksum(client)
     timestamp = timestamp or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     path = _exact_artifact_path(root, f"fortudo-inventory-{timestamp}")
     try:
@@ -551,7 +783,7 @@ def create_inventory(
             rows.append(
                 {
                     "databaseName": database,
-                    "databaseUuid": info.get("uuid"),
+                    "accountChecksum": account_checksum,
                     "updateSequence": info.get("update_seq"),
                     "documentCount": info.get("doc_count"),
                     "deletedDocumentCount": info.get("doc_del_count"),
@@ -561,9 +793,10 @@ def create_inventory(
                 }
             )
         manifest_base = {
-            "formatVersion": 1,
+            "formatVersion": 2,
             "createdAt": timestamp,
             "backupProtection": backup_protection,
+            "accountChecksum": account_checksum,
             "counts": counts,
             "databases": rows,
         }
@@ -574,7 +807,10 @@ def create_inventory(
             (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(),
         )
         return InventoryResult(
-            path=manifest_path, checksum=manifest["manifestChecksum"], counts=counts
+            path=manifest_path,
+            checksum=manifest["manifestChecksum"],
+            counts=counts,
+            account_checksum=account_checksum,
         )
     except Exception:
         _remove_exact_artifact(path, root)
@@ -675,18 +911,18 @@ def _parser() -> argparse.ArgumentParser:
     install = subparsers.add_parser("install")
     install.add_argument("--database", required=True)
     install.add_argument("--confirm-database", required=True)
-    install.add_argument("--expected-uuid", required=True)
-    install.add_argument("--expected-update-seq", required=True)
-    install.add_argument("--expected-security-checksum", required=True)
+    install.add_argument("--expected-target-binding-checksum", required=True)
     install.add_argument("--snapshot", required=True)
 
     provision = subparsers.add_parser("provision")
     provision.add_argument("--database", required=True)
     provision.add_argument("--confirm-database", required=True)
+    provision.add_argument("--expected-account-checksum", required=True)
 
     quarantine = subparsers.add_parser("restore-quarantine")
     quarantine.add_argument("--database", required=True)
     quarantine.add_argument("--confirm-database", required=True)
+    quarantine.add_argument("--expected-account-checksum", required=True)
     quarantine.add_argument("--snapshot", required=True)
     return parser
 
@@ -722,6 +958,7 @@ def execute(
         report = {
             "mode": args.mode,
             "counts": result.counts,
+            "accountChecksum": result.account_checksum,
             "manifestPath": str(result.path),
             "manifestChecksum": result.checksum,
         }
@@ -734,10 +971,12 @@ def execute(
             encrypted_volume_confirmed=args.confirm_encrypted_volume,
             temporary_unencrypted_confirmed=args.confirm_temporary_unencrypted,
         )
+        snapshot_manifest = verify_snapshot(result.path)
         report = {
             "mode": args.mode,
             "snapshotPath": str(result.path),
             "snapshotChecksum": result.checksum,
+            "targetBindingChecksum": snapshot_manifest["targetBinding"]["checksum"],
         }
     elif args.mode == "verify":
         report = {"mode": args.mode, **verify_validator(client, args.database)}
@@ -748,9 +987,7 @@ def execute(
                 client,
                 database=args.database,
                 confirmation=args.confirm_database,
-                expected_uuid=args.expected_uuid,
-                expected_update_seq=args.expected_update_seq,
-                expected_security_checksum=args.expected_security_checksum,
+                expected_target_binding_checksum=args.expected_target_binding_checksum,
                 snapshot_path=args.snapshot,
             ),
         }
@@ -758,7 +995,10 @@ def execute(
         report = {
             "mode": args.mode,
             **provision_database(
-                client, database=args.database, confirmation=args.confirm_database
+                client,
+                database=args.database,
+                confirmation=args.confirm_database,
+                expected_account_checksum=args.expected_account_checksum,
             ),
         }
     else:
@@ -768,6 +1008,7 @@ def execute(
                 client,
                 database=args.database,
                 confirmation=args.confirm_database,
+                expected_account_checksum=args.expected_account_checksum,
                 snapshot_path=args.snapshot,
             ),
         }

--- a/scripts/migrate_taxonomy_identity.py
+++ b/scripts/migrate_taxonomy_identity.py
@@ -770,12 +770,37 @@ def _read_stable_leaf_graph(
     before = client.get_database_info(database)
     leaves, winners = client.get_current_leaf_graph(database)
     after = client.get_database_info(database)
-    if (
-        before.get("uuid") != after.get("uuid")
-        or before.get("update_seq") != after.get("update_seq")
+    if _database_observation(client, database, before) != _database_observation(
+        client, database, after
     ):
         raise MigrationSafetyError("database changed during journal classification")
     return leaves, winners
+
+
+def _database_observation(
+    client: Any, database: str, info: Mapping[str, Any]
+) -> dict[str, Any]:
+    try:
+        account_checksum = client.get_account_checksum()
+    except (AttributeError, TypeError) as error:
+        raise MigrationSafetyError("Cloudant account identity is unavailable") from error
+    if (
+        not isinstance(account_checksum, str)
+        or len(account_checksum) != 64
+        or any(character not in "0123456789abcdef" for character in account_checksum)
+        or info.get("db_name") != database
+        or not isinstance(info.get("update_seq"), str)
+    ):
+        raise MigrationSafetyError("database identity metadata is incomplete")
+    return {
+        "accountChecksum": account_checksum,
+        "databaseName": database,
+        "partitioned": bool(
+            info.get("partitioned") is True
+            or info.get("props", {}).get("partitioned", False)
+        ),
+        "databaseUpdateSeq": info["update_seq"],
+    }
 
 
 def _classify_journal_entries(
@@ -950,19 +975,27 @@ def _validate_snapshot_and_fence(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     # Lazy import avoids a module cycle: the operations module reuses this file's HTTP client.
     from scripts.document_contract_ops import (
+        ContractOpsSafetyError,
+        capture_target_binding,
         security_checksum,
         verify_snapshot,
         verify_validator,
     )
 
-    snapshot = verify_snapshot(snapshot_path)
+    try:
+        snapshot = verify_snapshot(snapshot_path)
+    except ContractOpsSafetyError as error:
+        raise MigrationSafetyError("S1 snapshot verification failed") from error
     if (
         snapshot.get("databaseName") != database
         or snapshot.get("databaseUpdateSeq") != expected_update_seq
         or snapshot.get("label") != "S1"
     ):
         raise MigrationSafetyError("S1 snapshot does not match the locked migration state")
-    validator = verify_validator(client, database)
+    try:
+        validator = verify_validator(client, database)
+    except ContractOpsSafetyError as error:
+        raise MigrationSafetyError("document validator verification failed") from error
     if validator.get("state") != "compatible":
         raise MigrationSafetyError("compatible document validator is not installed")
     if snapshot.get("validatorRevision") != validator.get("validatorRevision"):
@@ -973,35 +1006,31 @@ def _validate_snapshot_and_fence(
     leaves, winners = client.get_current_leaf_graph(database)
     info_after = client.get_database_info(database)
     security_after = client.get_security(database)
-    unsorted_leaf_identities = [
-        [leaf.get("_id"), leaf.get("_rev"), bool(leaf.get("_deleted"))]
-        for leaf in leaves
-    ]
-    if any(
-        not isinstance(identity[0], str) or not isinstance(identity[1], str)
-        for identity in unsorted_leaf_identities
-    ):
-        raise MigrationSafetyError("live S1 leaf identity is incomplete")
-    live_leaf_identities = sorted(unsorted_leaf_identities)
-    partitioned = bool(
-        info_before.get("partitioned") is True
-        or info_before.get("props", {}).get("partitioned", False)
-    )
+    before_observation = _database_observation(client, database, info_before)
+    after_observation = _database_observation(client, database, info_after)
+    try:
+        live_target_binding = capture_target_binding(
+            client,
+            database=database,
+            info=info_before,
+            security=security_before,
+            leaves=leaves,
+            winners=winners,
+        )
+    except ContractOpsSafetyError as error:
+        raise MigrationSafetyError("live target binding is invalid") from error
+    snapshot_target_binding = snapshot.get("targetBinding", {})
     if (
-        info_before.get("db_name") != database
-        or info_before.get("uuid") != snapshot.get("databaseUuid")
-        or info_after.get("uuid") != info_before.get("uuid")
-        or info_after.get("update_seq") != info_before.get("update_seq")
-        or partitioned != bool(snapshot.get("partitioned"))
+        before_observation != after_observation
         or security_checksum(security_before) != snapshot.get("securityChecksum")
         or security_checksum(security_after) != snapshot.get("securityChecksum")
+        or any(
+            live_target_binding.get(key) != snapshot_target_binding.get(key)
+            for key in ("accountChecksum", "databaseName", "partitioned")
+        )
     ):
         raise MigrationSafetyError("live database state differs from the complete S1 snapshot")
-    if require_exact_state and (
-        info_before.get("update_seq") != snapshot.get("databaseUpdateSeq")
-        or live_leaf_identities != snapshot.get("leafIdentities")
-        or dict(winners) != snapshot.get("winnerRevisions")
-    ):
+    if require_exact_state and live_target_binding != snapshot_target_binding:
         raise MigrationSafetyError("live database state differs from the complete S1 snapshot")
     return snapshot, validator
 
@@ -1349,6 +1378,10 @@ class CloudantClient:
             f"{urllib.parse.unquote(parsed.username)}:{urllib.parse.unquote(parsed.password)}".encode()
         ).decode("ascii")
         self._authorization = f"Basic {token}"
+
+    def get_account_checksum(self) -> str:
+        """Return a credential-free binding for the exact Cloudant account endpoint."""
+        return _sha256_bytes(self._base_url.encode("utf-8"))
 
     def _request(
         self,

--- a/tests/test_document_contract_ops.py
+++ b/tests/test_document_contract_ops.py
@@ -34,7 +34,6 @@ class FakeCloudant:
         self.database = "fortudo-dat-411"
         self.info = {
             "db_name": self.database,
-            "uuid": "database-uuid-1",
             "update_seq": "10-seq",
             "doc_count": 2,
             "doc_del_count": 1,
@@ -76,6 +75,10 @@ class FakeCloudant:
         }
         self.created: list[str] = []
         self.write_order: list[str] = []
+        self.account_checksum = "a" * 64
+
+    def get_account_checksum(self) -> str:
+        return self.account_checksum
 
     def list_databases(self) -> list[str]:
         return [self.database, "fortudo-family", "system-database"]
@@ -117,7 +120,6 @@ class FakeCloudant:
         self.database = database
         self.info = {
             "db_name": database,
-            "uuid": "new-database-uuid",
             "update_seq": "0-seq",
             "doc_count": 0,
             "doc_del_count": 0,
@@ -160,13 +162,44 @@ def test_snapshot_captures_complete_leaf_graph_security_and_stable_winners(tmp_p
 
     manifest = ops.verify_snapshot(result.path)
     assert manifest["label"] == "S0"
+    assert manifest["formatVersion"] == 2
     assert manifest["leafCount"] == 4
     assert manifest["winnerCount"] == 3
-    assert manifest["databaseUuid"] == "database-uuid-1"
+    assert "databaseUuid" not in manifest
+    assert manifest["targetBinding"]["accountChecksum"] == "a" * 64
+    assert manifest["targetBinding"]["databaseName"] == "fortudo-dat-411"
+    assert len(manifest["targetBinding"]["checksum"]) == 64
     assert manifest["securityChecksum"] == ops.security_checksum(client.security)
     assert manifest["manifestChecksum"] == result.checksum
     leaf_text = (result.path / "leaf-graph.ndjson").read_text(encoding="utf-8")
     assert "never print" in leaf_text
+    metadata = json.loads((result.path / "database-metadata.json").read_text(encoding="utf-8"))
+    assert "databaseUuid" not in metadata
+
+
+def test_target_binding_is_semantic_and_independent_of_leaf_enumeration_order():
+    client = FakeCloudant()
+    leaves, winners = client.get_current_leaf_graph(client.database)
+    info = client.get_database_info(client.database)
+
+    first = ops.capture_target_binding(
+        client,
+        database=client.database,
+        info=info,
+        security=client.security,
+        leaves=leaves,
+        winners=winners,
+    )
+    second = ops.capture_target_binding(
+        client,
+        database=client.database,
+        info=info,
+        security=client.security,
+        leaves=list(reversed(leaves)),
+        winners=dict(reversed(list(winners.items()))),
+    )
+
+    assert first == second
 
 
 def test_snapshot_deletes_incomplete_output_and_halts_on_leaf_drift(tmp_path):
@@ -193,6 +226,27 @@ def test_snapshot_deletes_incomplete_output_and_halts_on_leaf_drift(tmp_path):
     assert list(tmp_path.iterdir()) == []
 
 
+def test_snapshot_halts_if_the_cloudant_account_binding_changes_during_capture(tmp_path):
+    class AccountDriftCloudant(FakeCloudant):
+        account_reads = 0
+
+        def get_account_checksum(self) -> str:
+            self.account_reads += 1
+            return ("a" if self.account_reads == 1 else "b") * 64
+
+    with pytest.raises(ops.ContractOpsSafetyError, match="changed during snapshot"):
+        ops.create_snapshot(
+            AccountDriftCloudant(),
+            database="fortudo-dat-411",
+            backup_root=tmp_path,
+            label="S0",
+            encrypted_volume_confirmed=True,
+            timestamp="20260721T120000Z",
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_install_requires_locked_snapshot_and_changes_only_the_design_leaf(tmp_path):
     client = FakeCloudant()
     snapshot = ops.create_snapshot(
@@ -208,15 +262,49 @@ def test_install_requires_locked_snapshot_and_changes_only_the_design_leaf(tmp_p
         client,
         database=client.database,
         confirmation=client.database,
-        expected_uuid="database-uuid-1",
-        expected_update_seq="10-seq",
-        expected_security_checksum=ops.security_checksum(client.security),
+        expected_target_binding_checksum=ops.verify_snapshot(snapshot.path)[
+            "targetBinding"
+        ]["checksum"],
         snapshot_path=snapshot.path,
     )
 
     assert result["validatorRevision"] == "1-contract"
     assert client.write_order == ["_design/fortudo-document-contract"]
     assert ops.verify_validator(client, client.database)["state"] == "compatible"
+
+
+@pytest.mark.parametrize("drift", ["account", "security", "body", "winner"])
+def test_install_rejects_any_state_outside_the_locked_target_binding(tmp_path, drift):
+    client = FakeCloudant()
+    snapshot = ops.create_snapshot(
+        client,
+        database=client.database,
+        backup_root=tmp_path,
+        label="S0",
+        encrypted_volume_confirmed=True,
+        timestamp="20260721T120000Z",
+    )
+    manifest = ops.verify_snapshot(snapshot.path)
+
+    if drift == "account":
+        client.account_checksum = "b" * 64
+    elif drift == "security":
+        client.security["members"]["names"] = ["changed"]
+    elif drift == "body":
+        client.leaves[0]["private"] = "changed under the same revision"
+    else:
+        client.winners["activity-conflict"] = "3-loser"
+
+    with pytest.raises(ops.ContractOpsSafetyError, match="locked snapshot"):
+        ops.install_validator(
+            client,
+            database=client.database,
+            confirmation=client.database,
+            expected_target_binding_checksum=manifest["targetBinding"]["checksum"],
+            snapshot_path=snapshot.path,
+        )
+
+    assert client.write_order == []
 
 
 def test_provision_is_empty_database_and_validator_first():
@@ -226,11 +314,26 @@ def test_provision_is_empty_database_and_validator_first():
         client,
         database="fortudo-new-room",
         confirmation="fortudo-new-room",
+        expected_account_checksum="a" * 64,
     )
 
     assert client.created == ["fortudo-new-room"]
     assert client.write_order == ["_design/fortudo-document-contract"]
-    assert result["databaseUuid"] == "new-database-uuid"
+    assert result["targetAccountChecksum"] == "a" * 64
+
+
+def test_provision_rejects_the_wrong_account_before_database_creation():
+    client = FakeCloudant()
+
+    with pytest.raises(ops.ContractOpsSafetyError, match="approved Cloudant account"):
+        ops.provision_database(
+            client,
+            database="fortudo-new-room",
+            confirmation="fortudo-new-room",
+            expected_account_checksum="b" * 64,
+        )
+
+    assert client.created == []
 
 
 def test_quarantine_restore_loads_legacy_leaves_before_validator(tmp_path):
@@ -250,6 +353,7 @@ def test_quarantine_restore_loads_legacy_leaves_before_validator(tmp_path):
         target,
         database="fortudo-quarantine-20260721",
         confirmation="fortudo-quarantine-20260721",
+        expected_account_checksum="a" * 64,
         snapshot_path=snapshot.path,
     )
 
@@ -282,10 +386,63 @@ def test_quarantine_restore_halts_before_validator_when_leaf_reconstruction_diff
             target,
             database="fortudo-quarantine-20260721",
             confirmation="fortudo-quarantine-20260721",
+            expected_account_checksum="a" * 64,
             snapshot_path=snapshot.path,
         )
 
     assert "_design/fortudo-document-contract" not in target.write_order
+
+
+def test_quarantine_restore_rejects_snapshot_from_an_unapproved_account_before_creation(
+    tmp_path,
+):
+    source = FakeCloudant()
+    snapshot = ops.create_snapshot(
+        source,
+        database=source.database,
+        backup_root=tmp_path,
+        label="S0",
+        encrypted_volume_confirmed=True,
+        timestamp="20260721T120000Z",
+    )
+    target = FakeCloudant()
+    target.account_checksum = "b" * 64
+
+    with pytest.raises(ops.ContractOpsSafetyError, match="snapshot Cloudant account"):
+        ops.restore_quarantine(
+            target,
+            database="fortudo-quarantine-20260721",
+            confirmation="fortudo-quarantine-20260721",
+            expected_account_checksum="b" * 64,
+            snapshot_path=snapshot.path,
+        )
+
+    assert target.created == []
+
+
+def test_quarantine_restore_rejects_wrong_active_account_before_database_creation(tmp_path):
+    source = FakeCloudant()
+    snapshot = ops.create_snapshot(
+        source,
+        database=source.database,
+        backup_root=tmp_path,
+        label="S0",
+        encrypted_volume_confirmed=True,
+        timestamp="20260721T120000Z",
+    )
+    target = FakeCloudant()
+    target.account_checksum = "b" * 64
+
+    with pytest.raises(ops.ContractOpsSafetyError, match="approved Cloudant account"):
+        ops.restore_quarantine(
+            target,
+            database="fortudo-quarantine-20260721",
+            confirmation="fortudo-quarantine-20260721",
+            expected_account_checksum="a" * 64,
+            snapshot_path=snapshot.path,
+        )
+
+    assert target.created == []
 
 
 def test_inventory_writes_private_manifest_but_returns_only_aggregates(tmp_path):
@@ -300,11 +457,29 @@ def test_inventory_writes_private_manifest_but_returns_only_aggregates(tmp_path)
 
     assert result.counts == {"fortudoDatabases": 2, "compatible": 0, "missingValidator": 2}
     assert len(result.checksum) == 64
+    assert result.account_checksum == "a" * 64
     private = json.loads(result.path.read_text(encoding="utf-8"))
+    assert private["accountChecksum"] == "a" * 64
     assert [row["databaseName"] for row in private["databases"]] == [
         "fortudo-dat-411",
         "fortudo-family",
     ]
+    assert all("databaseUuid" not in row for row in private["databases"])
+    assert all(row["accountChecksum"] == "a" * 64 for row in private["databases"])
+
+
+def test_install_cli_uses_target_binding_and_has_no_uuid_override():
+    parser = ops._parser()
+    commands = parser._subparsers._group_actions[0].choices
+    install_parser = commands["install"]
+    provision_parser = commands["provision"]
+    quarantine_parser = commands["restore-quarantine"]
+    help_text = parser.format_help() + install_parser.format_help()
+
+    assert "--expected-target-binding-checksum" in help_text
+    assert "--expected-account-checksum" in provision_parser.format_help()
+    assert "--expected-account-checksum" in quarantine_parser.format_help()
+    assert "--expected-uuid" not in help_text
 
 
 def test_normal_operational_output_omits_private_targets_revisions_and_paths():
@@ -314,7 +489,7 @@ def test_normal_operational_output_omits_private_targets_revisions_and_paths():
             "counts": {"fortudoDatabases": 2},
             "manifestChecksum": "a" * 64,
             "manifestPath": "X:/private/manifest.json",
-            "databaseUuid": "private-uuid",
+            "targetBindingChecksum": "b" * 64,
             "validatorRevision": "1-private",
         }
     )
@@ -323,6 +498,7 @@ def test_normal_operational_output_omits_private_targets_revisions_and_paths():
         "mode": "inventory",
         "counts": {"fortudoDatabases": 2},
         "manifestChecksum": "a" * 64,
+        "targetBindingChecksum": "b" * 64,
     }
 
 
@@ -337,7 +513,12 @@ def test_encrypted_volume_confirmation_and_exact_target_are_mandatory(tmp_path):
             encrypted_volume_confirmed=False,
         )
     with pytest.raises(ops.ContractOpsSafetyError, match="confirmation"):
-        ops.provision_database(client, database="fortudo-new-room", confirmation="wrong")
+        ops.provision_database(
+            client,
+            database="fortudo-new-room",
+            confirmation="wrong",
+            expected_account_checksum="a" * 64,
+        )
     with pytest.raises(ops.ContractOpsSafetyError, match="unsafe characters"):
         ops.create_snapshot(
             client,
@@ -413,6 +594,25 @@ def test_snapshot_verification_rejects_rechecksummed_invalid_backup_protection(
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(ops.ContractOpsSafetyError, match="backup protection"):
+        ops.verify_snapshot(snapshot.path)
+
+
+def test_snapshot_verification_rejects_rechecksummed_target_binding_tamper(tmp_path):
+    snapshot = ops.create_snapshot(
+        FakeCloudant(),
+        database="fortudo-dat-411",
+        backup_root=tmp_path,
+        label="S0",
+        encrypted_volume_confirmed=True,
+        timestamp="20260722T170000Z",
+    )
+    manifest_path = snapshot.path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["targetBinding"]["scheme"] = "unreviewed-binding"
+    manifest["manifestChecksum"] = ops._manifest_checksum(manifest)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ops.ContractOpsSafetyError, match="target binding"):
         ops.verify_snapshot(snapshot.path)
 
 

--- a/tests/test_migrate_taxonomy_identity.py
+++ b/tests/test_migrate_taxonomy_identity.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 from pathlib import Path
 
 import pytest
 
 from scripts import migrate_taxonomy_identity as migration
 from scripts import document_contract_ops as contract_ops
+
+
+def test_cloudant_account_checksum_excludes_credentials_and_normalizes_host():
+    client = migration.CloudantClient(
+        "https://operator:private@ACCOUNT.example:443/cloudant/"
+    )
+
+    assert client.get_account_checksum() == hashlib.sha256(
+        b"https://account.example:443/cloudant"
+    ).hexdigest()
 
 
 def taxonomy_doc() -> dict:
@@ -85,7 +96,7 @@ def losing_leaf() -> dict:
 class FakeCloudant:
     def __init__(self, *, update_seq: str = "42-seq") -> None:
         self.update_seq = update_seq
-        self.uuid = "database-uuid-1"
+        self.account_checksum = "a" * 64
         self.winners = production_winners()
         self.leaves = {("activity-legacy", "3-activity-loser"): losing_leaf()}
         self.bulk_calls: list[list[dict]] = []
@@ -103,12 +114,14 @@ class FakeCloudant:
     def get_database_info(self, database: str) -> dict:
         return {
             "db_name": database,
-            "uuid": self.uuid,
             "update_seq": self.update_seq,
             "doc_count": len(self.winners),
             "doc_del_count": 0,
             "props": {"partitioned": False},
         }
+
+    def get_account_checksum(self) -> str:
+        return self.account_checksum
 
     def get_all_documents(self, database: str, *, include_conflicts: bool) -> list[dict]:
         assert include_conflicts is True
@@ -473,7 +486,7 @@ def test_apply_backs_up_before_writes_and_tombstones_only_losing_activity_leaf(t
     assert completion["writerContract"] == {"version": 1, "categoryReference": None}
 
 
-@pytest.mark.parametrize("drift", ["uuid", "security", "leaf", "winner"])
+@pytest.mark.parametrize("drift", ["account", "security", "leaf", "winner"])
 def test_apply_binds_every_live_precondition_to_the_complete_s1_snapshot(tmp_path, drift):
     client = FakeCloudant()
     client.winners = [
@@ -481,8 +494,8 @@ def test_apply_binds_every_live_precondition_to_the_complete_s1_snapshot(tmp_pat
     ]
     snapshot = create_s1_snapshot(client, tmp_path)
 
-    if drift == "uuid":
-        client.uuid = "replacement-database-uuid"
+    if drift == "account":
+        client.account_checksum = "b" * 64
     elif drift == "security":
         client.security["members"]["names"] = ["changed"]
     elif drift == "leaf":


### PR DESCRIPTION
## What changed

- replace the unavailable CouchDB database UUID gate with an IBM Cloudant-compatible target binding
- bind snapshots and installs to the credential-free account hash, exact database, partition state, update sequence, security state, complete leaf graph, and winner map
- require an externally approved account checksum before future room provisioning or quarantine database creation
- preserve validator-last quarantine reconstruction while verifying snapshot/account agreement before any remote mutation
- update tests and the migration runbook for the new safety contract

## Why

IBM Cloudant database metadata does not expose the Apache CouchDB UUID assumed by the original operational tooling. That made the S0 production-snapshot gate impossible to satisfy. The replacement preserves the intended wrong-target and state-drift protections using values Cloudant actually exposes.

## Verification

- independent Kleppmann-style review approved exact commit `58cfa40fef0bdde355e09aa42c905502ae2f873d`
- `npm run verify`: 76 Jest suites / 1,592 tests, 181 Python tests, 18 Playwright tests
- coverage: 91.07% statements, 79.40% branches, 93.53% functions, 91.97% lines
- `npm run build:sw-precache`: 83 URLs, version `33b27266708b`
- PouchDB, Font Awesome, and generated CSS checks pass

No production mutation was performed by this change.
