### PR TITLE
Remove premature Cloudant backup tooling

### DIFF
--- a/docs/COUCHDB-SETUP.md
+++ b/docs/COUCHDB-SETUP.md
@@ -22,6 +22,7 @@ Cloudant is a managed CouchDB-compatible database from IBM. The Lite plan is per
    - `username` and `password` — legacy credentials for PouchDB
 
 The URL with embedded credentials looks like:
+
 ```
 https://<username>:<password>@<host>.cloudantnosqldb.appdomain.cloud
 ```
@@ -37,6 +38,7 @@ The browser needs permission to make cross-origin requests to Cloudant.
 3. Enable CORS and add your Firebase Hosting domains.
 
 For this repo (`fortudo`), allowlist:
+
 - Production: `https://fortudo.web.app` and `https://fortudo.firebaseapp.com`
 - Preview channels: `https://fortudo--*.web.app` and `https://fortudo--*.firebaseapp.com` (if wildcards are allowed)
 
@@ -44,24 +46,36 @@ If Cloudant does not accept wildcard domains, add each preview URL explicitly. Y
 
 Do **not** use "All domains" in production — restrict to your exact origin.
 
-## 4. Database creation
+## 4. Manual database provisioning
 
-Fortudo creates a database per room code (e.g., `fortudo-fox-742`). Databases need to exist on Cloudant before PouchDB can replicate to them. Two approaches:
+Fortudo uses one database per room code (for example, `fortudo-fox-742`), but the browser does not
+create Cloudant databases. Replication uses PouchDB's `skip_setup: true`; entering a room whose remote
+database does not exist leaves that room local-only and reports that sync is not provisioned.
 
-### Option A: Admin credentials in the URL (simplest)
+The database must be created by an operator before the room can sync. At present this repository
+intentionally provides no supported production provisioning command. Do not infer that entering a
+room code, possessing the shared credential, or creating local data has provisioned its remote.
 
-Include your service credentials in `COUCHDB_URL`. When PouchDB connects as an admin, Cloudant auto-creates databases on first write.
+Two credential arrangements remain possible after manual provisioning:
+
+### Option A: Shared service credentials in the URL (simplest)
+
+Create the database through the Cloudant Dashboard or an explicitly approved administrative
+request, then include the existing service credentials in `COUCHDB_URL`.
 
 In `public/js/config.js`:
 
 ```js
-export const COUCHDB_URL = 'https://<username>:<password>@<host>.cloudantnosqldb.appdomain.cloud';
+export const COUCHDB_URL =
+  'https://<username>:<password>@<host>.cloudantnosqldb.appdomain.cloud';
 ```
 
-**Pros:** Zero setup per room. New room codes just work.
-**Cons:** Credentials are visible in the browser (network tab, JS source). Acceptable for personal/household use; not suitable for a public-facing app.
+**Pros:** No separate API key per room.
+**Cons:** Every room still needs manual provisioning, and the credentials are visible in the browser
+(network tab and JavaScript source). This is an accepted risk for the current personal/household
+deployment, not a suitable public-facing design.
 
-### Option B: Pre-create databases with scoped API keys
+### Option B: Manually provision with scoped API keys
 
 Keep admin credentials out of the browser. Create each room's database ahead of time and grant access via a scoped API key.
 
@@ -88,17 +102,21 @@ curl -X PUT "$HOST/fortudo-fox-742/_security" \
 Then in `public/js/config.js`, use the API key credentials:
 
 ```js
-export const COUCHDB_URL = 'https://<api_key>:<api_password>@<host>.cloudantnosqldb.appdomain.cloud';
+export const COUCHDB_URL =
+  'https://<api_key>:<api_password>@<host>.cloudantnosqldb.appdomain.cloud';
 ```
 
 You can reuse the same API key across multiple databases by adding it to each database's `_security` document.
 
 **Pros:** Scoped access — the API key can only read/write databases you've explicitly granted.
-**Cons:** Manual step to create each database and grant permissions.
+**Cons:** Manual database creation and permission grants are required.
 
 ### Recommendation
 
-For personal/household use, **Option A** is the pragmatic choice. If you add more rooms rarely, **Option B** is worth the extra step for better security.
+The current personal deployment accepts Option A's shared-credential risk. Prefer Option B for any
+new security design. In either case, database creation is an operator action, not browser behavior.
+After document-contract enforcement becomes fail-closed, a new production database must also receive
+and verify the required validator before any client is allowed to replicate.
 
 ## 5. Connect Fortudo
 
@@ -107,7 +125,8 @@ The repo tracks `public/js/config.js` with `COUCHDB_URL = null`, which means loc
 To enable sync locally, edit `public/js/config.js`:
 
 ```js
-export const COUCHDB_URL = 'https://<credentials>@<host>.cloudantnosqldb.appdomain.cloud';
+export const COUCHDB_URL =
+  'https://<credentials>@<host>.cloudantnosqldb.appdomain.cloud';
 ```
 
 The app constructs the full database URL automatically (e.g., appending `/fortudo-fox-742`).
@@ -171,12 +190,14 @@ firebase deploy
 Credentials (admin or API key) are embedded in `config.js`, which is served as a static file. Anyone who can load the site can view source and extract them. This means they could read, modify, or delete your Cloudant data, or consume your free-tier quota.
 
 **Why this is acceptable for Fortudo:**
+
 - The site URL is not publicly shared — only known to household members
 - The data is non-sensitive (daily to-do items)
 - Room codes add a layer of obscurity (someone would need to know or guess a code to find your data)
 - The app works fully offline without sync, so a compromised Cloudant instance is an inconvenience, not a data loss event (your local PouchDB is the source of truth)
 
 **If your threat model changes** (e.g., you share the URL more broadly), consider:
+
 1. **Firebase Cloud Function as a proxy** — holds Cloudant credentials server-side, the browser never sees them. Firebase Functions has a free tier.
 2. **Firebase Authentication** — gate the app behind Google sign-in. Only authenticated users get the sync URL (served dynamically, not as a static file).
 3. **HTTP gateway** — put Cloudflare Access or similar in front of the site to require a password before the app loads at all.
@@ -196,6 +217,7 @@ db.replicate.to(remoteUrl, { batch_size: 5, batches_limit: 1 });
 ### Cloudant vs CouchDB differences
 
 Cloudant is CouchDB-compatible but has some limits:
+
 - Max request size: 11 MB (vs CouchDB's 4 GB default)
 - Max attachment size: 10 MB
 - No `_users` database (auth is via IAM or Cloudant API keys, not CouchDB users)

--- a/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
+++ b/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
@@ -31,15 +31,20 @@ Inspect whether a named Fortudo database contains the exact reviewed validator:
 python scripts/document_contract_ops.py verify --database fortudo-dat-411
 ```
 
-Generate aggregate dry-run counts for the locked `fortudo-dat-411` taxonomy migration:
+Generate aggregate dry-run counts—for example, for the currently authorized target:
 
 ```powershell
 python scripts/migrate_taxonomy_identity.py --database fortudo-dat-411
 ```
 
-The migration planner accepts no other database and has no apply mode. Both commands print only a
-state or aggregate counts. They do not print the database name, credentials, document bodies,
-descriptions, revision identifiers, or opaque database metadata.
+The read-only planner accepts any explicit, valid `fortudo-*` database name and has no apply mode.
+Its transformation rules are application-wide: it reads and preserves the selected database's
+current taxonomy rather than hardcoding the `dat-411` labels. This permits comparison and auditing;
+it does not authorize taxonomy migration in another room. The future production executor remains
+locked to `fortudo-dat-411`.
+
+Both commands print only a state or aggregate counts. They do not print the database name,
+credentials, document bodies, descriptions, revision identifiers, or opaque database metadata.
 
 ## Compatibility-release verification
 

--- a/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
+++ b/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
@@ -1,28 +1,50 @@
 # Document-contract migration runbook
 
-This runbook is the operational companion to the entity and taxonomy identity hardening. It does not authorize a production write by itself. Stop whenever a target-binding checksum, database name, opaque update sequence, `_security` hash, validator revision, leaf set, or required approval differs from the locked private manifest.
+## Current status
 
-Never paste the Cloudant credential URL, document bodies, descriptions, or private manifests into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only in the local process environment. Store inventories, snapshots, and journals on an encrypted user-only volume outside the repository by default.
+The production entity and taxonomy migration is paused. The compatibility release exists, but
+this repository intentionally has no command that can install a production validator, create a
+backup, restore a database, provision a room, apply the taxonomy migration, resolve production
+conflicts, or write a completion marker.
 
-An operator may explicitly accept temporary unencrypted storage with `--confirm-temporary-unencrypted` only when the directory is user-only, outside the repository and cloud-synced folders, and retained no later than completion of S3 and the known-client exercise. The private manifest records this protection mode and deletion condition. Never pass `--confirm-encrypted-volume` for an unencrypted destination.
+This is deliberate. The retired tooling attempted to implement a complete revision-graph snapshot
+and restore format locally and treated Cloudant's opaque `update_seq` as a stable content lock.
+Production observation showed that `update_seq` can change while the application leaf set does not,
+so it is not a valid equality gate for this deployment. Maintaining a second replication and restore
+implementation in Python was also unnecessary when Cloudant already implements CouchDB replication.
 
-## Compatibility release
+The replacement design is [Cloudant Quarantine Migration Design](plans/design/2026-07-22-cloudant-quarantine-migration-design.md).
+It must be implemented and proven on disposable Cloudant databases in a later pull request before
+any production mutation resumes.
 
-The compatibility release:
+Never paste the Cloudant credential URL, document bodies, descriptions, or private database
+metadata into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only
+in the local process environment.
 
-- writes document contract version 1 and the redundant category witness;
-- audits exact local leaf revisions before every push;
-- permits existing databases whose validator is not installed yet;
-- never creates a remote database from the browser;
-- blocks mismatched/newer fences and recovery-required replicas;
-- keeps an unprovisioned room local-only;
-- exports stranded local leaves before an explicitly confirmed reset.
+## Supported commands
 
-Do not switch `COMPATIBILITY_RELEASE_ALLOWS_MISSING_VALIDATOR` to fail-closed until every known nonempty production room is either fenced or explicitly retired.
+Only two read-only operations remain.
 
-## Required local and preview gates
+Inspect whether a named Fortudo database contains the exact reviewed validator:
 
-Run the repository checks and regenerate the service-worker artifact:
+```powershell
+python scripts/document_contract_ops.py verify --database fortudo-dat-411
+```
+
+Generate aggregate dry-run counts for the locked `fortudo-dat-411` taxonomy migration:
+
+```powershell
+python scripts/migrate_taxonomy_identity.py --database fortudo-dat-411
+```
+
+The migration planner accepts no other database and has no apply mode. Both commands print only a
+state or aggregate counts. They do not print the database name, credentials, document bodies,
+descriptions, revision identifiers, or opaque database metadata.
+
+## Compatibility-release verification
+
+Changes to the compatibility release still require the complete repository gates and regenerated
+service-worker artifact:
 
 ```powershell
 npm run build:sw-precache
@@ -32,112 +54,26 @@ npm run check:css
 npm run verify
 ```
 
-After deploying an isolated compatible preview, run its acceptance suite. Then run the disposable real-Cloudant gate through PouchDB 9:
+An isolated Firebase preview and `node scripts/cloudant-contract-gate.mjs` verify the browser-side
+contract behavior. They do not prove the future quarantine/migration machinery because that
+machinery is not present yet.
 
-```powershell
-node scripts/cloudant-contract-gate.mjs
-```
+## Gates before production work can resume
 
-The gate creates and destroys only two randomly named `fortudo-preview-contract-gate-*` databases. Its aggregate output must show compatible writes, denied legacy writes and tombstones, partial mixed-batch behavior, a detected checkpointed denial, and validator-last reconstruction.
+Production writes remain blocked until all of the following are true:
 
-Require green GitHub CI, record the exact commit SHA and generated service-worker version, deploy the compatibility release, and verify live asset hashes before any production fence installation.
+1. The minimal quarantine design is implemented without reintroducing a local snapshot transport,
+   custom restore engine, portable dump, or `update_seq` equality gate.
+2. The exact implementation passes its mandatory end-to-end disposable Cloudant preview exercise,
+   including conflict leaves, tombstones, attachments, source-drift detection, partial migration
+   recovery, and exact cleanup.
+3. The implementation pull request passes the complete repository suite and GitHub CI and is merged.
+4. The compatible release containing that exact commit is deployed and its live assets are verified.
+5. A fresh read-only production dry-run matches the approved target, mappings, winner/conflict
+   expectations, and reports no running timer.
+6. The operational preflight rechecks that the live timer configuration is absent and fails before
+   any remote write otherwise; known clients remain quiescent.
+7. The operator explicitly approves the production quarantine creation, fence installation, and
+   migration after reviewing those results.
 
-## Private inventory
-
-Create a fresh read-only inventory:
-
-```powershell
-python scripts/document_contract_ops.py inventory `
-  --manifest-root X:\fortudo-private `
-  --confirm-encrypted-volume
-```
-
-For the approved temporary-unencrypted exception, replace the final flag with `--confirm-temporary-unencrypted`.
-
-The normal output contains aggregate counts, the credential-free account checksum, and the manifest checksum only. Locate the private manifest inside the operator-supplied root; its path and exact database list stay off normal command output. Obtain explicit approval for the fresh database list and account checksum. Do not reuse an older count.
-
-IBM Cloudant does not expose the per-database UUID returned by Apache CouchDB. Snapshot format 2 therefore uses a versioned target binding over the credential-free account-endpoint hash, exact database name, partitioning state, opaque update sequence, `_security` checksum, canonical complete leaf-graph checksum, and winner-revision-map checksum. The binding checksum is the operator-visible lock; credentials and the account endpoint remain private.
-
-## Fence and migrate `fortudo-dat-411`
-
-1. Stop the timer and close known active clients.
-2. Lock the target-binding checksum, opaque update sequence, taxonomy mapping, current winners, and every conflict leaf from the private inventory/dry-run.
-3. Create `S0` before installing the fence:
-
-   ```powershell
-   python scripts/document_contract_ops.py snapshot `
-     --database fortudo-dat-411 `
-     --backup-root X:\fortudo-private `
-     --label S0 `
-     --confirm-encrypted-volume
-   ```
-
-   For the approved temporary-unencrypted exception, replace the final flag with `--confirm-temporary-unencrypted`. The resulting manifest binds the exception and mandatory post-S3 deletion into its checksum.
-
-4. Install the validator using only values copied from the locked `S0` manifest:
-
-   ```powershell
-   python scripts/document_contract_ops.py install `
-     --database fortudo-dat-411 `
-     --confirm-database fortudo-dat-411 `
-     --expected-target-binding-checksum <private-S0-binding-checksum> `
-     --snapshot <S0-path>
-   ```
-
-5. Verify the validator and prove that only its design leaf changed. Create `S1` with the same snapshot command and `--label S1`.
-6. Run a new default dry-run of `migrate_taxonomy_identity.py`. Its sequence must exactly equal the `S1` sequence.
-7. Apply with the exact `S1` path:
-
-   ```powershell
-   python scripts/migrate_taxonomy_identity.py `
-     --database fortudo-dat-411 `
-     --apply `
-     --expected-update-seq <S1-opaque-sequence> `
-     --confirm-database fortudo-dat-411 `
-     --s1-snapshot <S1-path>
-   ```
-
-The migration journal is created beside `S1`. On interruption, rerun with `--journal <journal-path>` only after the dry-run still describes the same intended bodies. Locked pre-states resume, exact intended results are accepted, and any divergence halts.
-
-The tool applies identity revisions and conflict tombstones first, verifies all invariants, fingerprints the complete current leaf state, then writes and rereads the completion marker separately. A pre-existing marker blocks automatic execution and requires manual verified-state review.
-
-8. Create `S2` only after marker, fingerprint, counts, winners, conflict resolution, locked labels, and nonidentity invariants all verify.
-
-Direct production restore is disabled. Reconstruct a new `fortudo-quarantine-*` database only in the approved Cloudant account; legacy leaf trees load before the validator:
-
-```powershell
-python scripts/document_contract_ops.py restore-quarantine `
-  --database fortudo-quarantine-<id> `
-  --confirm-database fortudo-quarantine-<id> `
-  --expected-account-checksum <approved-private-inventory-account-checksum> `
-  --snapshot <snapshot-path>
-```
-
-The external account checksum must match both the active credential and the snapshot binding before the quarantine database is created. Direct cross-account reconstruction is not authorized by this runbook. Reconciliation back into production remains manual and selective.
-
-## Other existing rooms
-
-After approval of the fresh inventory, process one room at a time:
-
-1. Re-lock its identity and state.
-2. Create `R0`.
-3. Install the fence with the snapshot lock.
-4. Verify that only the design leaf changed.
-5. Create `R1`.
-
-Do not run the `fortudo-dat-411` taxonomy migration against another room. A failure in one room does not authorize or invalidate another room's operation.
-
-## Future rooms and closure
-
-Provision future remote rooms manually and fence-first:
-
-```powershell
-python scripts/document_contract_ops.py provision `
-  --database fortudo-<room> `
-  --confirm-database fortudo-<room> `
-  --expected-account-checksum <approved-private-inventory-account-checksum>
-```
-
-Exercise each known client. It must either pass a stable divergence audit and sync, or export/reset, pull, and then pass. Create `S3` after that exercise; it is an aggregate observation, not proof that no dormant replica exists.
-
-The final record must include exact test and coverage results, CI and deployment status, commit and service-worker SHAs, live asset hashes, inventory/snapshot/journal paths and checksums, target-binding checksums, migration and fence counts, validator revision, completion fingerprint, and every post-migration invariant.
+No existing script or this document authorizes skipping those gates.

--- a/docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md
+++ b/docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md
@@ -10,7 +10,12 @@ Fortudo's offline-first foundation is reasonable: every browser keeps a local Po
 
 Deploying a new Fortudo release does not atomically update every browser. Each device has its own cached application, service worker, local revision tree, and update lifecycle. An old client can therefore reconnect after a migration and upload documents that predate or omit newly required identity fields.
 
-The current identity migration compensates with an operational gate: update all clients that may reconnect to the target room, stop active writes, back up every revision leaf, lock the database update sequence, migrate, and verify. This can be safe, but it is more fragile and labor-intensive than a fail-closed compatibility architecture.
+The original identity-migration plan compensated with an operational gate around client updates,
+local revision-graph snapshots, and opaque update-sequence equality. Production observation showed
+that the Cloudant update sequence can change without an application leaf change, and the custom
+snapshot/restore layer was larger than this one migration justified. That tooling has been retired.
+The replacement design uses a server-enforced document contract plus a temporary Cloudant-native
+replication quarantine.
 
 ## Current production scope
 
@@ -23,7 +28,10 @@ A metadata-only inventory on 2026-07-21 found:
 
 The current migration tool deliberately accepts only `fortudo-dat-411`. This is a safety fence derived from the rollout's explicit authorization for the guarded `dat-411` migration, not a Cloudant limitation. The other six non-preview databases have not been classified as active rooms, abandoned rooms, or tests, and they are not authorized migration targets.
 
-If more rooms require migration, each should receive an independent dry-run, client-quiescence window, update-sequence lock, backup, checksum, apply, and verification cycle. The tool must not silently generalize to every database whose name starts with `fortudo-`.
+If more rooms require fencing, each needs an independently approved client-quiescence, native
+quarantine capture, content-state fingerprint, fence installation, and verification cycle. The
+taxonomy migration remains locked to `fortudo-dat-411`; tooling must not silently generalize it to
+every database whose name starts with `fortudo-`.
 
 ## What is not inherently wrong
 
@@ -121,18 +129,20 @@ A device whose Fortudo site data has been cleared no longer holds a local revisi
 
 ## Current operational mitigation
 
-Until writer-version enforcement exists, the safe migration sequence is:
+Production is paused while the minimum replacement machinery is implemented. The intended sequence
+is:
 
 1. Deploy the forward-compatible release.
-2. Reload every device that retains the target room and may reconnect.
-3. Let each device complete synchronization on the compatible release.
-4. Stop the running timer and close all other Fortudo sessions.
-5. Run a fresh read-only dry-run and capture the exact update sequence.
-6. Back up every winning document and every conflict leaf outside the repository.
-7. Verify the backup manifest and checksum.
-8. Apply only while the update sequence and document revisions remain unchanged.
-9. Verify counts, durations, labels, existing IDs, identity fields, and absence of conflict leaves.
-10. Reopen a compatible client, complete a normal sync, and repeat read-only verification.
+2. Prove the exact native-quarantine and migration implementation on disposable Cloudant databases.
+3. Stop the running timer, close known active Fortudo sessions, and require the live timer
+   configuration to be absent before any quarantine or source write.
+4. Run a fresh read-only dry-run.
+5. Create and verify a Cloudant-native one-shot quarantine containing every current leaf.
+6. Recheck the exact source leaf set and `_security` hash immediately before fencing.
+7. Install and verify the server-side document contract as the only application-state change.
+8. Apply deterministic compare-and-set successors and conflict tombstones.
+9. Verify counts, durations, labels, existing IDs, identity fields, and absence of live conflict leaves.
+10. Reopen compatible clients, complete normal sync, and repeat read-only verification.
 
 This gate is scoped per room. Updating one device is sufficient only when it is the sole remaining device with a local copy of that room.
 
@@ -170,7 +180,7 @@ Future migrations should use explicit phases:
 1. Deploy readers and writers that tolerate both old and new fields and preserve unknown data.
 2. Establish or enforce the minimum compatible writer version.
 3. Observe that active clients are compatible where useful, without treating absence as proof that no dormant clients exist.
-4. Migrate data under revision and backup gates.
+4. Migrate data under revision and verified native-quarantine gates.
 5. Retain compatibility until the rollback window closes.
 
 ### Reduce singleton blast radius
@@ -197,7 +207,9 @@ A privacy-conscious client-capability record could report a random device instal
 - `public/js/sync-manager.js`: push-before-pull replication order.
 - `public/js/sw-register.js`: per-browser service-worker activation.
 - `public/js/taxonomy/taxonomy-store.js`: taxonomy normalization and singleton persistence.
-- `scripts/migrate_taxonomy_identity.py`: exact database fence, backup, revision, conflict, and invariant gates.
+- `scripts/migrate_taxonomy_identity.py`: exact database fence and read-only transformation planner.
+- `docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md`: proposed minimal
+  production recovery and migration gates.
 
 ## Appendix A: DDIA learning guide
 
@@ -216,7 +228,7 @@ The central lesson is:
 | Every browser owns a writable local replica                     | Sync engines and local-first software                                | Chapter 6, “Replication”                                                       |
 | Offline devices create divergent revision branches              | Multi-leader behavior, conflicting writes, and concurrency detection | Chapter 6, “Dealing with Conflicting Writes” and “Detecting Concurrent Writes” |
 | Cloudant selects one revision leaf as winner                    | Storage convergence versus application-level correctness             | Chapter 6                                                                      |
-| Revision and update-sequence gates prevent overwrites           | Compare-and-set, lost-update prevention, and transaction boundaries  | Chapter 8, “Transactions”                                                      |
+| Revision compare-and-set gates prevent overwrites               | Compare-and-set, lost-update prevention, and transaction boundaries  | Chapter 8, “Transactions”                                                      |
 | A dormant device cannot be distinguished from a retired device  | Partial failure and the limits of distributed knowledge              | Chapter 9, “The Trouble with Distributed Systems”                              |
 | Reload, quiesce, migrate, and verify is an operational protocol | Reliability, evolvability, and operability                           | Chapter 2, “Defining Nonfunctional Requirements”                               |
 
@@ -351,7 +363,9 @@ The exercise leads to a stronger migration protocol:
 4. Check that contract before a client pushes.
 5. Enforce it at a trusted write boundary so pre-protocol clients fail closed.
 6. Preserve rejected local work for controlled recovery.
-7. Migrate under revision, backup, and quiescence gates.
+7. Migrate under revision, verified native-quarantine, and quiescence gates.
 8. Verify application invariants, not only replication success.
 
-DDIA supplies the conceptual tools for deriving this protocol, but it is not a PWA migration runbook. Service-worker activation, Cloudant permissions, backup construction, and the exact recovery UX remain application-specific engineering work.
+DDIA supplies the conceptual tools for deriving this protocol, but it is not a PWA migration
+runbook. Service-worker activation, Cloudant permissions, quarantine verification, and the exact
+recovery UX remain application-specific engineering work.

--- a/docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md
+++ b/docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md
@@ -26,7 +26,16 @@ A metadata-only inventory on 2026-07-21 found:
 - 7 non-preview, nonempty databases with schema 3.5 legacy taxonomy.
 - 0 non-preview databases already carrying taxonomy `identityVersion: 1`.
 
-The current migration tool deliberately accepts only `fortudo-dat-411`. This is a safety fence derived from the rollout's explicit authorization for the guarded `dat-411` migration, not a Cloudant limitation. The other six non-preview databases have not been classified as active rooms, abandoned rooms, or tests, and they are not authorized migration targets.
+The current tooling has no write mode. Its read-only planner accepts an explicitly named valid
+`fortudo-*` database so operators can compare legacy schema-3.5 rooms without changing them. The
+planner reads and preserves each room's own taxonomy; it does not contain a hardcoded `dat-411`
+taxonomy.
+
+The future mutation executor remains deliberately locked to `fortudo-dat-411`. That is a safety
+fence derived from the rollout's explicit authorization for the guarded `dat-411` migration, not a
+Cloudant limitation. The other six non-preview databases have not been classified as active rooms,
+abandoned rooms, or tests, and they are not authorized migration targets merely because a read-only
+plan succeeds.
 
 If more rooms require fencing, each needs an independently approved client-quiescence, native
 quarantine capture, content-state fingerprint, fence installation, and verification cycle. The
@@ -207,7 +216,7 @@ A privacy-conscious client-capability record could report a random device instal
 - `public/js/sync-manager.js`: push-before-pull replication order.
 - `public/js/sw-register.js`: per-browser service-worker activation.
 - `public/js/taxonomy/taxonomy-store.js`: taxonomy normalization and singleton persistence.
-- `scripts/migrate_taxonomy_identity.py`: exact database fence and read-only transformation planner.
+- `scripts/migrate_taxonomy_identity.py`: namespace-scoped, read-only transformation planner.
 - `docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md`: proposed minimal
   production recovery and migration gates.
 

--- a/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
+++ b/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
@@ -129,6 +129,17 @@ Afterward, require:
 
 Any difference stops the operation before taxonomy writes.
 
+## Read-only planning scope
+
+The existing planner may inspect any explicitly named database in the `fortudo-*` namespace. Its
+rules are not room-specific: it reads the selected schema-3.5 taxonomy, preserves its labels and
+nonidentity fields, derives identities from its current rows, and reports aggregate intended
+changes. It performs GET requests only and emits no document bodies or database name.
+
+A successful plan is evidence that the database fits the transformation's structural assumptions,
+not authorization to mutate it. The executor described below remains separately and exactly locked
+to `fortudo-dat-411`; supporting another room would require its own approval and production gates.
+
 ## Minimal migration executor
 
 The executor remains locked to `fortudo-dat-411` and the approved taxonomy mapping. It recomputes a

--- a/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
+++ b/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
@@ -1,0 +1,219 @@
+# Cloudant quarantine migration design
+
+**Status:** Design for a later implementation pull request. It is not an operational authorization.
+
+## Decision
+
+Use a new Cloudant database populated by Cloudant's own one-shot replication as the temporary
+pre-migration recovery point for `fortudo-dat-411`. Verify the replicated current revision graph,
+then install the document validator and run a narrowly scoped, resumable taxonomy migration.
+
+Do not build or retain a local snapshot format, portable dump, general restore engine, database
+inventory system, or opaque-`update_seq` lock.
+
+IBM recommends managed `_replicator` jobs over the transient `/_replicate` endpoint because jobs are
+restartable and observable. Normal CouchDB replication transfers all current leaf revisions;
+`winning_revs_only` must not be enabled because it intentionally discards conflicting leaves.
+
+References:
+
+- [IBM Cloudant replication guide](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-replication-guide)
+- [IBM Cloudant advanced replication](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-advanced-replication)
+- [Apache CouchDB replication protocol](https://docs.couchdb.org/en/stable/replication/protocol.html)
+
+## Goals
+
+- Preserve every current live, deleted, and conflicting leaf before fencing production.
+- Preserve Cloudant's current winners and all task and activity IDs.
+- Detect source drift using application revision state rather than `update_seq` equality.
+- Make an interrupted migration safe to inspect and resume from current Cloudant state.
+- Provide a recovery source without automating a dangerous reverse restore into production.
+- Keep normal output limited to aggregate counts and hashes.
+
+## Non-goals
+
+- A general Cloudant backup product or disaster-recovery system.
+- A byte-for-byte archive of compacted non-leaf bodies, database UUID, or update sequence.
+- A portable export outside Cloudant.
+- Automatic full-database rollback or conflict merging.
+- Migration of any room other than `fortudo-dat-411`.
+- Taxonomy redesign, room identity, credentials, device telemetry, or browser provisioning.
+
+## Why native replication is the recovery primitive
+
+Cloudant already implements revision-tree transfer, attachment transfer, conflict preservation,
+checkpointing, and retry. Reimplementing those responsibilities in a local Python archive adds a
+second data transport and restore protocol that must be proven under compaction, conflicts,
+tombstones, attachments, rate limiting, interruption, and partial files.
+
+The quarantine database is intentionally narrower than a conventional backup. It is a temporary,
+same-account copy of the current replicable leaf graph for this one migration. It does not claim to
+preserve compacted historical bodies. That is sufficient for inspecting or selectively recovering
+the state that could otherwise be affected by the migration.
+
+## State model
+
+For this operation, content state is represented by:
+
+- the set of `(document ID, leaf revision, deletion state)` for every current non-`_local` leaf;
+- the winning revision for every document;
+- aggregate live, deleted, and conflicted-leaf counts; and
+- a canonical SHA-256 fingerprint of those values.
+
+The set includes application and design documents. `_local/*` documents are excluded because
+replication checkpoints are local implementation metadata and replication itself can change them.
+Derived `_conflicts` arrays are not hashed separately because the leaf set already represents them.
+
+Matching revision identities across source and quarantine are the verification boundary for the
+native replication protocol. Attachments travel as part of those replicated revisions. The design
+does not duplicate every body and attachment into a second local archive merely to reimplement that
+integrity check.
+
+Cloudant's `update_seq` may be recorded diagnostically but must never be compared for equality or
+used as a content-stability gate.
+
+## `_security`
+
+Read and canonically hash the source `_security` document before quarantine capture, immediately
+before validator installation, and after the migration. Equality proves that this operation did not
+change the database's legacy names/roles configuration.
+
+Do not copy `_security` into a local backup, copy it automatically to quarantine, or offer a restore
+command for it. It is authorization metadata, not application data, and Cloudant IAM configuration
+is outside this document. Any intentional security change is a separate approved operation.
+
+## Quarantine capture protocol
+
+1. Require the compatible release to be live and close known active clients. Read the source and
+   require `config-running-activity` to be absent. A live timer blocks before any remote mutation,
+   including quarantine database creation. Stopping the timer through a compatible client deletes
+   that live configuration; merely closing its UI is insufficient.
+2. Lock the exact Cloudant account endpoint and source database name in process memory. Normal
+   output exposes neither.
+3. Create one empty, nonpartitioned database with a random high-entropy
+   `fortudo-quarantine-<random>` name. Abort if it already exists or is not empty.
+4. Create a one-shot `_replicator` job from `fortudo-dat-411` to that exact database. Use no selector,
+   filter, `doc_ids`, `winning_revs_only`, or continuous mode. Any replication credential must be
+   temporary and narrowly scoped, must never be logged or committed, and must be revoked after the
+   job is removed.
+5. Wait for the scheduler to report completion. A terminal error or timeout blocks the operation.
+6. Read the source and quarantine state models. Require exact leaf-set, winner-map, count, and
+   fingerprint equality.
+7. Re-read and compare the source `_security` hash.
+8. Remove the completed replication job and revoke its temporary credential. Retain the quarantine
+   database through the known-client exercise.
+
+The replication may write `_local` checkpoints to the source. Those writes are expected and do not
+invalidate the application-state comparison.
+
+If source state changes before the validator is installed, do not proceed. Repeat the one-shot
+replication into the same quarantine database, reverify exact equality, and establish a new locked
+fingerprint. Unexpected quarantine-only leaves or any ambiguous result require a new empty
+quarantine database rather than destructive cleanup.
+
+## Fence installation
+
+Immediately before installation, require the source state fingerprint and `_security` hash to match
+the locked capture. On first installation the validator design document must be absent; create the
+exact reviewed `_design/fortudo-document-contract` revision with a create-only compare-and-set
+request. On resume, accept an existing validator only when its revision is the exact revision
+recorded from this operation's successful create and its source, version, checksum, and surrounding
+locked source state all match. Any other existing design document blocks the operation.
+
+Afterward, require:
+
+- the previous source leaf set plus exactly the expected validator leaf;
+- no other new, removed, or changed leaf;
+- the expected validator version, checksum, source, and revision; and
+- the unchanged `_security` hash.
+
+Any difference stops the operation before taxonomy writes.
+
+## Minimal migration executor
+
+The executor remains locked to `fortudo-dat-411` and the approved taxonomy mapping. It recomputes a
+fresh plan from remote winners and conflicts and writes one intended successor at a time using the
+exact current `_rev` as a compare-and-set precondition.
+
+The order is:
+
+1. taxonomy identity document;
+2. task and activity successors;
+3. losing activity-branch tombstones carrying writer contract version 1;
+4. complete invariant verification; and
+5. a separate completion marker followed by another complete verification.
+
+Each transformation is deterministic and idempotent. After interruption, rerun from a fresh remote
+read: already-correct successors are skipped, unresolved documents and conflict leaves remain in the
+new plan, and any state that cannot be classified safely blocks progress. There is no automatic
+rewind and no general local journal/restore subsystem.
+
+The executor must preserve:
+
+- all task and activity IDs;
+- the current Cloudant winner as the parent of each migrated successor;
+- every nonidentity field;
+- `work/meetings -> Comms` and `work/comms -> Meetings`; and
+- meaning derived from current taxonomy rows and immutable IDs, never from legacy key wording.
+
+Post-migration verification derives the exact expected leaf transitions from the locked pre-state
+and successful Cloudant responses. An unrelated leaf or revision blocks the completion marker even
+if every migrated document is individually valid.
+
+## Recovery boundary
+
+The quarantine database is read-only after capture. No tool may reverse-replicate it over production.
+If recovery is needed, inspect the production and quarantine revisions and copy selected documents
+through a separately reviewed procedure. For broader analysis, quarantine may be replicated into a
+new disposable database; production remains untouched.
+
+Retain quarantine until the compatible-client exercise and final production verification are
+complete, then delete exactly that approved database. Cloudant database deletion is irreversible,
+so require the exact name, the recorded quarantine fingerprint, and explicit confirmation.
+
+## Mandatory preview proof before implementation merge
+
+The later implementation pull request may not merge based on mocked tests alone. Before merge, run
+the exact operational code against randomly named disposable Cloudant source and quarantine
+databases through the same authenticated path intended for production.
+
+The fixture must initially include:
+
+- ordinary live documents;
+- a deleted leaf;
+- a document with multiple live conflict leaves and a known winner;
+- an attachment;
+- the locked taxonomy labels and representative task/activity references; and
+- a running-timer configuration document used only to prove the zero-write preflight.
+
+First run the production preflight with that live timer. It must fail before creating a quarantine
+database, replication job, validator revision, or migration revision. The preview harness then stops
+the timer through the same compatible persistence behavior used by the application and proves the
+configuration is absent before starting the successful capture path.
+
+The exercise must prove:
+
+1. default one-shot replication preserves the exact leaf set, winners, deletions, conflicts, and
+   attachment-bearing revisions;
+2. `winning_revs_only`, filters, selectors, `doc_ids`, and continuous mode are absent;
+3. source leaf drift after capture blocks validator installation without a validator or migration
+   write;
+4. a deliberate `_security` change after capture blocks validator installation, and the successful
+   path finishes with the original source `_security` hash unchanged;
+5. validator installation changes exactly one expected design leaf;
+6. a forced interruption leaves a state that a fresh run safely classifies and completes;
+7. invalid legacy writes are denied after fencing while compatible writes succeed;
+8. the final invariant and completion checks detect any unexpected revision; and
+9. cleanup deletes only the two exact disposable databases and the exact replication job, and
+   verifies revocation of the exact temporary replication credential.
+
+Record only aggregate counts, state fingerprints, validator checksum/revision, test result, and
+cleanup confirmation in the pull request. Credentials, URLs, descriptions, bodies, attachment
+contents, and replication documents remain private.
+
+## Production authorization boundary
+
+Passing the preview proof establishes that the machinery works; it does not authorize production.
+Production still requires the exact merged/deployed commit, fresh read-only state, stopped timer,
+known-client quiescence, validator and database-name checks, explicit operator approval, and all
+post-migration invariants.

--- a/scripts/document_contract_ops.py
+++ b/scripts/document_contract_ops.py
@@ -1,9 +1,4 @@
-"""Guarded Cloudant document-contract inventory, snapshots, and provisioning.
-
-Normal output contains aggregate counts and hashes only. Snapshot and inventory
-manifests are private artifacts and may contain database identities and leaf
-metadata; document bodies are never printed.
-"""
+"""Read-only inspection of the Fortudo Cloudant document contract."""
 
 from __future__ import annotations
 
@@ -14,26 +9,18 @@ import os
 import re
 import sys
 import urllib.parse
-from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-# The operational runbook invokes this file directly. In that mode Python adds
-# ``scripts/`` rather than the repository root to ``sys.path``, so make the
-# package import below resolve identically to ``python -m`` execution.
+# The runbook invokes this file directly. In that mode Python adds ``scripts/``
+# rather than the repository root to ``sys.path``.
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.migrate_taxonomy_identity import (
     CREDENTIAL_ENV_VAR,
     CloudantClient,
-    _canonical_json,
-    _exact_artifact_path,
-    _remove_exact_artifact,
-    _secure_backup_directory,
-    _write_secure,
-    validate_backup_root,
+    MigrationSafetyError,
 )
 
 
@@ -41,65 +28,11 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_MODULE = REPOSITORY_ROOT / "public" / "js" / "document-contract.js"
 CONTRACT_DESIGN_ID = "_design/fortudo-document-contract"
 CONTRACT_VERSION = 1
-SNAPSHOT_FORMAT_VERSION = 2
-TARGET_BINDING_FORMAT_VERSION = 1
-TARGET_BINDING_SCHEME = "ibm-cloudant-account-database-state-v1"
-TEMPORARY_UNENCRYPTED_RETENTION = "delete-after-s3-and-known-client-exercise"
+CONTRACT_CHECKSUM = "c0bf4717ff74c9daa32b850b059df95a45f2156b3491c91f5c658990c0e26a75"
 
 
 class ContractOpsSafetyError(RuntimeError):
-    """Raised before or during a guarded operation when a gate does not hold."""
-
-
-@dataclass(frozen=True)
-class SnapshotResult:
-    path: Path
-    checksum: str
-
-
-@dataclass(frozen=True)
-class InventoryResult:
-    path: Path
-    checksum: str
-    counts: dict[str, int]
-    account_checksum: str
-
-
-def _sha256_bytes(value: bytes) -> str:
-    return hashlib.sha256(value).hexdigest()
-
-
-def security_checksum(security: Mapping[str, Any]) -> str:
-    return _sha256_bytes(_canonical_json(security).encode("utf-8"))
-
-
-def _require_backup_protection(
-    *, encrypted_volume_confirmed: bool, temporary_unencrypted_confirmed: bool
-) -> dict[str, str]:
-    if encrypted_volume_confirmed == temporary_unencrypted_confirmed:
-        raise ContractOpsSafetyError(
-            "confirm exactly one backup protection mode: an encrypted user-only volume "
-            "or the explicit temporary-unencrypted retention override"
-        )
-    if encrypted_volume_confirmed:
-        return {"mode": "encrypted-user-only-volume"}
-    return {
-        "mode": "temporary-unencrypted-user-only-directory",
-        "retention": TEMPORARY_UNENCRYPTED_RETENTION,
-    }
-
-
-def _validate_backup_protection(value: Any) -> None:
-    valid = (
-        value == {"mode": "encrypted-user-only-volume"}
-        or value
-        == {
-            "mode": "temporary-unencrypted-user-only-directory",
-            "retention": TEMPORARY_UNENCRYPTED_RETENTION,
-        }
-    )
-    if not valid:
-        raise ContractOpsSafetyError("snapshot backup protection evidence is invalid")
+    """Raised when a read-only contract-inspection precondition does not hold."""
 
 
 def _require_database_name(database: str) -> None:
@@ -107,23 +40,11 @@ def _require_database_name(database: str) -> None:
         raise ContractOpsSafetyError("database name is outside the Fortudo namespace")
 
 
-def _require_confirmation(database: str, confirmation: str) -> None:
-    if confirmation != database:
-        raise ContractOpsSafetyError("typed database confirmation did not match")
-
-
-def _require_artifact_label(label: str) -> None:
-    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", label):
-        raise ContractOpsSafetyError("snapshot label contains unsafe characters")
-
-
 def _extract_validator_source(module_source: str) -> str:
     start = module_source.index("function cloudantValidateDocUpdate")
     marker = "\n}\n\n/**\n * Add persistence metadata"
     end = module_source.index(marker, start) + 2
-    return module_source[start:end].replace(
-        "function cloudantValidateDocUpdate", "function", 1
-    )
+    return module_source[start:end].replace("function cloudantValidateDocUpdate", "function", 1)
 
 
 def load_design_document() -> dict[str, Any]:
@@ -133,11 +54,15 @@ def load_design_document() -> dict[str, Any]:
     except (OSError, ValueError) as error:
         raise ContractOpsSafetyError("contract source is unreadable") from error
 
-    checksum = _sha256_bytes(validator_source.encode("utf-8"))
+    checksum = hashlib.sha256(validator_source.encode("utf-8")).hexdigest()
     declared_match = re.search(
         r"DOCUMENT_CONTRACT_CHECKSUM\s*=\s*\n?\s*'([a-f0-9]{64})'", module_source
     )
-    if not declared_match or declared_match.group(1) != checksum:
+    if (
+        not declared_match
+        or declared_match.group(1) != checksum
+        or checksum != CONTRACT_CHECKSUM
+    ):
         raise ContractOpsSafetyError("contract source checksum does not match its declaration")
     return {
         "_id": CONTRACT_DESIGN_ID,
@@ -145,364 +70,6 @@ def load_design_document() -> dict[str, Any]:
         "fortudoDocumentContract": {"version": CONTRACT_VERSION, "checksum": checksum},
         "validate_doc_update": validator_source,
     }
-
-
-def _leaf_identity(leaf: Mapping[str, Any]) -> tuple[str, str, bool]:
-    document_id = leaf.get("_id")
-    revision = leaf.get("_rev")
-    if not isinstance(document_id, str) or not isinstance(revision, str):
-        raise ContractOpsSafetyError("leaf graph contains an invalid identity")
-    return document_id, revision, bool(leaf.get("_deleted"))
-
-
-def _leaf_set(leaves: Sequence[Mapping[str, Any]]) -> list[tuple[str, str, bool]]:
-    identities = [_leaf_identity(leaf) for leaf in leaves]
-    if len(identities) != len(set(identities)):
-        raise ContractOpsSafetyError("leaf graph contains duplicate identities")
-    return sorted(identities)
-
-
-def _leaf_body_map(leaves: Sequence[Mapping[str, Any]]) -> dict[tuple[str, str, bool], str]:
-    identities = _leaf_set(leaves)
-    by_identity = {
-        _leaf_identity(leaf): _canonical_json(leaf)
-        for leaf in leaves
-    }
-    if len(by_identity) != len(identities):
-        raise ContractOpsSafetyError("leaf graph contains duplicate identities")
-    return by_identity
-
-
-def _ndjson_bytes(rows: Sequence[Mapping[str, Any]]) -> bytes:
-    if not rows:
-        return b""
-    _leaf_set(rows)
-    return ("\n".join(_canonical_json(row) for row in rows) + "\n").encode("utf-8")
-
-
-def _canonical_leaf_graph_checksum(rows: Sequence[Mapping[str, Any]]) -> str:
-    _leaf_set(rows)
-    ordered = sorted(rows, key=_leaf_identity)
-    content = ("\n".join(_canonical_json(row) for row in ordered) + "\n").encode("utf-8")
-    return _sha256_bytes(content)
-
-
-def _read_json(path: Path) -> Any:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise ContractOpsSafetyError("private artifact is unreadable") from error
-
-
-def _read_ndjson(path: Path) -> list[dict[str, Any]]:
-    try:
-        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
-    except (OSError, json.JSONDecodeError) as error:
-        raise ContractOpsSafetyError("snapshot leaf graph is unreadable") from error
-
-
-def _manifest_checksum(manifest: Mapping[str, Any]) -> str:
-    unsigned = dict(manifest)
-    unsigned.pop("manifestChecksum", None)
-    return _sha256_bytes(_canonical_json(unsigned).encode("utf-8"))
-
-
-def _partitioned(info: Mapping[str, Any]) -> bool:
-    return bool(
-        info.get("partitioned") is True
-        or info.get("props", {}).get("partitioned", False)
-    )
-
-
-def _account_checksum(client: Any) -> str:
-    try:
-        checksum = client.get_account_checksum()
-    except (AttributeError, TypeError) as error:
-        raise ContractOpsSafetyError("Cloudant account identity is unavailable") from error
-    return _require_sha256(checksum, field="Cloudant account identity")
-
-
-def _require_sha256(value: Any, *, field: str) -> str:
-    if (
-        not isinstance(value, str)
-        or len(value) != 64
-        or any(character not in "0123456789abcdef" for character in value)
-    ):
-        raise ContractOpsSafetyError(f"{field} is invalid")
-    return value
-
-
-def _target_binding_from_parts(
-    *,
-    account_checksum: str,
-    database: str,
-    partitioned: bool,
-    update_seq: Any,
-    security_checksum_value: str,
-    leaf_graph_checksum: str,
-    winner_revisions: Mapping[str, str],
-) -> dict[str, Any]:
-    if not isinstance(database, str):
-        raise ContractOpsSafetyError("database identity is invalid")
-    _require_database_name(database)
-    if not isinstance(partitioned, bool):
-        raise ContractOpsSafetyError("database partitioning metadata is invalid")
-    if not isinstance(winner_revisions, Mapping):
-        raise ContractOpsSafetyError("winner metadata is invalid")
-    account_checksum = _require_sha256(
-        account_checksum, field="Cloudant account identity"
-    )
-    security_checksum_value = _require_sha256(
-        security_checksum_value, field="security checksum"
-    )
-    leaf_graph_checksum = _require_sha256(
-        leaf_graph_checksum, field="leaf graph checksum"
-    )
-    if not isinstance(update_seq, str) or not update_seq:
-        raise ContractOpsSafetyError("database update sequence is incomplete")
-    if any(
-        not isinstance(document_id, str) or not isinstance(revision, str)
-        for document_id, revision in winner_revisions.items()
-    ):
-        raise ContractOpsSafetyError("winner metadata is invalid")
-    body = {
-        "formatVersion": TARGET_BINDING_FORMAT_VERSION,
-        "scheme": TARGET_BINDING_SCHEME,
-        "accountChecksum": account_checksum,
-        "databaseName": database,
-        "partitioned": partitioned,
-        "databaseUpdateSeq": update_seq,
-        "securityChecksum": security_checksum_value,
-        "leafGraphChecksum": leaf_graph_checksum,
-        "winnerRevisionsChecksum": _sha256_bytes(
-            _canonical_json(dict(sorted(winner_revisions.items()))).encode("utf-8")
-        ),
-    }
-    return {**body, "checksum": _sha256_bytes(_canonical_json(body).encode("utf-8"))}
-
-
-def capture_target_binding(
-    client: Any,
-    *,
-    database: str,
-    info: Mapping[str, Any],
-    security: Mapping[str, Any],
-    leaves: Sequence[Mapping[str, Any]],
-    winners: Mapping[str, str],
-) -> dict[str, Any]:
-    """Bind one exact Cloudant account/database state without a database UUID."""
-    if info.get("db_name") != database:
-        raise ContractOpsSafetyError("Cloudant reported a different database name")
-    return _target_binding_from_parts(
-        account_checksum=_account_checksum(client),
-        database=database,
-        partitioned=_partitioned(info),
-        update_seq=info.get("update_seq"),
-        security_checksum_value=security_checksum(security),
-        leaf_graph_checksum=_canonical_leaf_graph_checksum(leaves),
-        winner_revisions=winners,
-    )
-
-
-def _database_observation(
-    client: Any, database: str, info: Mapping[str, Any]
-) -> dict[str, Any]:
-    if info.get("db_name") != database:
-        raise ContractOpsSafetyError("Cloudant reported a different database name")
-    update_seq = info.get("update_seq")
-    if not isinstance(update_seq, str) or not update_seq:
-        raise ContractOpsSafetyError("database update sequence is incomplete")
-    return {
-        "accountChecksum": _account_checksum(client),
-        "databaseName": database,
-        "partitioned": _partitioned(info),
-        "databaseUpdateSeq": update_seq,
-    }
-
-
-def _validate_snapshot_target_binding(
-    manifest: Mapping[str, Any], *, leaf_graph_checksum: str
-) -> None:
-    if manifest.get("formatVersion") != SNAPSHOT_FORMAT_VERSION:
-        raise ContractOpsSafetyError("snapshot format version is unsupported")
-    binding = manifest.get("targetBinding")
-    if not isinstance(binding, Mapping):
-        raise ContractOpsSafetyError("snapshot target binding is missing")
-    if not isinstance(manifest.get("partitioned"), bool):
-        raise ContractOpsSafetyError("snapshot partitioning metadata is invalid")
-    expected = _target_binding_from_parts(
-        account_checksum=binding.get("accountChecksum"),
-        database=manifest.get("databaseName"),
-        partitioned=manifest["partitioned"],
-        update_seq=manifest.get("databaseUpdateSeq"),
-        security_checksum_value=manifest.get("securityChecksum"),
-        leaf_graph_checksum=leaf_graph_checksum,
-        winner_revisions=manifest.get("winnerRevisions", {}),
-    )
-    if dict(binding) != expected:
-        raise ContractOpsSafetyError("snapshot target binding is invalid")
-
-
-def create_snapshot(
-    client: Any,
-    *,
-    database: str,
-    backup_root: str | Path,
-    label: str,
-    encrypted_volume_confirmed: bool,
-    temporary_unencrypted_confirmed: bool = False,
-    timestamp: str | None = None,
-) -> SnapshotResult:
-    _require_database_name(database)
-    backup_protection = _require_backup_protection(
-        encrypted_volume_confirmed=encrypted_volume_confirmed,
-        temporary_unencrypted_confirmed=temporary_unencrypted_confirmed,
-    )
-    _require_artifact_label(label)
-    root = validate_backup_root(backup_root)
-    timestamp = timestamp or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    path = _exact_artifact_path(root, f"fortudo-contract-{label}-{timestamp}")
-
-    info_before = client.get_database_info(database)
-    security_before = client.get_security(database)
-    leaves, winners = client.get_current_leaf_graph(database)
-    leaf_identities = _leaf_set(leaves)
-    if not isinstance(winners, Mapping):
-        raise ContractOpsSafetyError("winner metadata is invalid")
-    target_binding = capture_target_binding(
-        client,
-        database=database,
-        info=info_before,
-        security=security_before,
-        leaves=leaves,
-        winners=winners,
-    )
-
-    try:
-        path.mkdir(parents=True, mode=0o700)
-        _secure_backup_directory(path)
-    except FileExistsError as error:
-        raise ContractOpsSafetyError("snapshot directory already exists") from error
-    except Exception:
-        _remove_exact_artifact(path, root)
-        raise
-
-    try:
-        leaf_bytes = _ndjson_bytes(leaves)
-        security_bytes = (json.dumps(security_before, indent=2, sort_keys=True) + "\n").encode()
-        metadata = {
-            "databaseName": database,
-            "databaseUpdateSeq": info_before.get("update_seq"),
-            "docCount": info_before.get("doc_count"),
-            "deletedDocCount": info_before.get("doc_del_count"),
-            "partitioned": _partitioned(info_before),
-        }
-        metadata_bytes = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode()
-        design_leaf = next(
-            (leaf for leaf in leaves if leaf.get("_id") == CONTRACT_DESIGN_ID), None
-        )
-        manifest_base = {
-            "formatVersion": SNAPSHOT_FORMAT_VERSION,
-            "label": label,
-            "createdAt": timestamp,
-            "backupProtection": backup_protection,
-            **metadata,
-            "targetBinding": target_binding,
-            "leafCount": len(leaves),
-            "winnerCount": len(winners),
-            "winnerRevisions": dict(sorted(winners.items())),
-            "leafIdentities": [list(identity) for identity in leaf_identities],
-            "securityChecksum": security_checksum(security_before),
-            "validatorRevision": design_leaf.get("_rev") if design_leaf else None,
-            "validatorChecksum": design_leaf.get("fortudoDocumentContract", {}).get("checksum")
-            if design_leaf
-            else None,
-            "files": {
-                "leaf-graph.ndjson": _sha256_bytes(leaf_bytes),
-                "security.json": _sha256_bytes(security_bytes),
-                "database-metadata.json": _sha256_bytes(metadata_bytes),
-            },
-        }
-        manifest = {**manifest_base, "manifestChecksum": _manifest_checksum(manifest_base)}
-        _write_secure(path / "leaf-graph.ndjson", leaf_bytes)
-        _write_secure(path / "security.json", security_bytes)
-        _write_secure(path / "database-metadata.json", metadata_bytes)
-        _write_secure(
-            path / "manifest.json",
-            (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(),
-        )
-
-        info_after = client.get_database_info(database)
-        security_after = client.get_security(database)
-        leaves_after, winners_after = client.get_current_leaf_graph(database)
-        target_binding_after = capture_target_binding(
-            client,
-            database=database,
-            info=info_after,
-            security=security_after,
-            leaves=leaves_after,
-            winners=winners_after,
-        )
-        if target_binding_after != target_binding:
-            raise ContractOpsSafetyError("database changed during snapshot")
-        verify_snapshot(path)
-        return SnapshotResult(path=path, checksum=manifest["manifestChecksum"])
-    except Exception:
-        _remove_exact_artifact(path, root)
-        raise
-
-
-def verify_snapshot(snapshot_path: str | Path) -> dict[str, Any]:
-    path = Path(snapshot_path).resolve()
-    manifest = _read_json(path / "manifest.json")
-    if not isinstance(manifest, Mapping):
-        raise ContractOpsSafetyError("snapshot manifest is invalid")
-    _validate_backup_protection(manifest.get("backupProtection"))
-    files = manifest.get("files")
-    expected_files = {"leaf-graph.ndjson", "security.json", "database-metadata.json"}
-    if not isinstance(files, Mapping) or set(files) != expected_files:
-        raise ContractOpsSafetyError("snapshot file manifest is invalid")
-    for filename, checksum in files.items():
-        _require_sha256(checksum, field="snapshot file checksum")
-        try:
-            content = (path / filename).read_bytes()
-        except OSError as error:
-            raise ContractOpsSafetyError("snapshot file is unreadable") from error
-        if _sha256_bytes(content) != checksum:
-            raise ContractOpsSafetyError("snapshot checksum mismatch")
-    if _manifest_checksum(manifest) != manifest.get("manifestChecksum"):
-        raise ContractOpsSafetyError("snapshot manifest checksum mismatch")
-    leaves = _read_ndjson(path / "leaf-graph.ndjson")
-    _validate_snapshot_target_binding(
-        manifest, leaf_graph_checksum=_canonical_leaf_graph_checksum(leaves)
-    )
-    if len(leaves) != manifest.get("leafCount"):
-        raise ContractOpsSafetyError("snapshot leaf count mismatch")
-    if [list(identity) for identity in _leaf_set(leaves)] != manifest.get("leafIdentities"):
-        raise ContractOpsSafetyError("snapshot leaf identity mismatch")
-    winners = manifest.get("winnerRevisions")
-    if not isinstance(winners, Mapping) or len(winners) != manifest.get("winnerCount"):
-        raise ContractOpsSafetyError("snapshot winner metadata is invalid")
-    live_identities = {(identity[0], identity[1]) for identity in _leaf_set(leaves)}
-    if any((document_id, revision) not in live_identities for document_id, revision in winners.items()):
-        raise ContractOpsSafetyError("snapshot winner identity is missing")
-    security = _read_json(path / "security.json")
-    if security_checksum(security) != manifest.get("securityChecksum"):
-        raise ContractOpsSafetyError("snapshot security checksum mismatch")
-    metadata = _read_json(path / "database-metadata.json")
-    expected_metadata = {
-        key: manifest.get(key)
-        for key in (
-            "databaseName",
-            "databaseUpdateSeq",
-            "docCount",
-            "deletedDocCount",
-            "partitioned",
-        )
-    }
-    if metadata != expected_metadata:
-        raise ContractOpsSafetyError("snapshot database metadata mismatch")
-    return manifest
 
 
 def verify_validator(client: Any, database: str) -> dict[str, Any]:
@@ -520,419 +87,31 @@ def verify_validator(client: Any, database: str) -> dict[str, Any]:
     return {"state": "compatible", "validatorRevision": document.get("_rev")}
 
 
-def install_validator(
-    client: Any,
-    *,
-    database: str,
-    confirmation: str,
-    expected_target_binding_checksum: str,
-    snapshot_path: str | Path,
-) -> dict[str, Any]:
-    _require_database_name(database)
-    _require_confirmation(database, confirmation)
-    manifest = verify_snapshot(snapshot_path)
-    expected_target_binding_checksum = _require_sha256(
-        expected_target_binding_checksum, field="expected target binding checksum"
-    )
-    if manifest.get("targetBinding", {}).get("checksum") != expected_target_binding_checksum:
-        raise ContractOpsSafetyError("snapshot does not match the locked installation target")
-
-    info = client.get_database_info(database)
-    security_before = client.get_security(database)
-    leaves_before, winners_before = client.get_current_leaf_graph(database)
-    live_target_binding = capture_target_binding(
-        client,
-        database=database,
-        info=info,
-        security=security_before,
-        leaves=leaves_before,
-        winners=winners_before,
-    )
-    if live_target_binding != manifest.get("targetBinding"):
-        raise ContractOpsSafetyError("database state differs from the locked snapshot")
-    if any(leaf.get("_id") == CONTRACT_DESIGN_ID for leaf in leaves_before):
-        raise ContractOpsSafetyError("validator already exists; use verify instead")
-
-    result = client.put_document(database, load_design_document())
-    if not result.get("ok") or not isinstance(result.get("rev"), str):
-        raise ContractOpsSafetyError("validator installation did not commit")
-    verified = verify_validator(client, database)
-    if verified.get("state") != "compatible":
-        raise ContractOpsSafetyError("installed validator verification failed")
-
-    info_after = client.get_database_info(database)
-    security_after = client.get_security(database)
-    leaves_after, winners_after = client.get_current_leaf_graph(database)
-    after_target_binding = capture_target_binding(
-        client,
-        database=database,
-        info=info_after,
-        security=security_after,
-        leaves=leaves_after,
-        winners=winners_after,
-    )
-    before_without_design = _leaf_set(
-        [leaf for leaf in leaves_before if leaf.get("_id") != CONTRACT_DESIGN_ID]
-    )
-    after_without_design = _leaf_set(
-        [leaf for leaf in leaves_after if leaf.get("_id") != CONTRACT_DESIGN_ID]
-    )
-    design_after = [leaf for leaf in leaves_after if leaf.get("_id") == CONTRACT_DESIGN_ID]
-    bodies_before = _leaf_body_map(
-        [leaf for leaf in leaves_before if leaf.get("_id") != CONTRACT_DESIGN_ID]
-    )
-    bodies_after = _leaf_body_map(
-        [leaf for leaf in leaves_after if leaf.get("_id") != CONTRACT_DESIGN_ID]
-    )
-    if (
-        before_without_design != after_without_design
-        or bodies_before != bodies_after
-        or len(design_after) != 1
-        or {
-            key: value
-            for key, value in winners_after.items()
-            if key != CONTRACT_DESIGN_ID
-        }
-        != dict(winners_before)
-        or any(
-            after_target_binding.get(key) != manifest["targetBinding"].get(key)
-            for key in ("accountChecksum", "databaseName", "partitioned", "securityChecksum")
-        )
-    ):
-        raise ContractOpsSafetyError("installation changed state beyond the design document")
-    return {
-        "state": "compatible",
-        "validatorRevision": verified["validatorRevision"],
-        "validatorChecksum": load_design_document()["fortudoDocumentContract"]["checksum"],
-    }
-
-
-def provision_database(
-    client: Any,
-    *,
-    database: str,
-    confirmation: str,
-    expected_account_checksum: str,
-) -> dict[str, Any]:
-    _require_database_name(database)
-    _require_confirmation(database, confirmation)
-    expected_account_checksum = _require_sha256(
-        expected_account_checksum, field="expected Cloudant account checksum"
-    )
-    if _account_checksum(client) != expected_account_checksum:
-        raise ContractOpsSafetyError("credential does not match the approved Cloudant account")
-    client.create_database(database)
-    info = client.get_database_info(database)
-    if info.get("db_name") != database or info.get("doc_count") != 0:
-        raise ContractOpsSafetyError("new database was not empty")
-    leaves, _ = client.get_current_leaf_graph(database)
-    if leaves:
-        raise ContractOpsSafetyError("new database already contains revisions")
-    result = client.put_document(database, load_design_document())
-    if not result.get("ok") or verify_validator(client, database).get("state") != "compatible":
-        raise ContractOpsSafetyError("fence-first provisioning failed")
-    final_leaves, _ = client.get_current_leaf_graph(database)
-    if len(final_leaves) != 1 or final_leaves[0].get("_id") != CONTRACT_DESIGN_ID:
-        raise ContractOpsSafetyError("validator was not the first database document")
-    return {
-        "targetAccountChecksum": _account_checksum(client),
-        "validatorRevision": result.get("rev"),
-        "validatorChecksum": load_design_document()["fortudoDocumentContract"]["checksum"],
-    }
-
-
-def _read_stable_leaf_graph(
-    client: Any, database: str
-) -> tuple[list[dict[str, Any]], dict[str, str]]:
-    before = client.get_database_info(database)
-    leaves, winners = client.get_current_leaf_graph(database)
-    after = client.get_database_info(database)
-    if _database_observation(client, database, before) != _database_observation(
-        client, database, after
-    ):
-        raise ContractOpsSafetyError("quarantine state changed during verification")
-    return leaves, winners
-
-
-def restore_quarantine(
-    client: Any,
-    *,
-    database: str,
-    confirmation: str,
-    expected_account_checksum: str,
-    snapshot_path: str | Path,
-) -> dict[str, Any]:
-    if not database.startswith("fortudo-quarantine-"):
-        raise ContractOpsSafetyError("restore target must be a new quarantine database")
-    _require_database_name(database)
-    _require_confirmation(database, confirmation)
-    expected_account_checksum = _require_sha256(
-        expected_account_checksum, field="expected Cloudant account checksum"
-    )
-    if _account_checksum(client) != expected_account_checksum:
-        raise ContractOpsSafetyError("credential does not match the approved Cloudant account")
-    manifest = verify_snapshot(snapshot_path)
-    if manifest["targetBinding"]["accountChecksum"] != expected_account_checksum:
-        raise ContractOpsSafetyError("snapshot Cloudant account is not the approved account")
-    leaves = _read_ndjson(Path(snapshot_path) / "leaf-graph.ndjson")
-    legacy_leaves = [leaf for leaf in leaves if leaf.get("_id") != CONTRACT_DESIGN_ID]
-    expected_leaf_bodies = {
-        (leaf["_id"], leaf["_rev"]): _canonical_json(leaf) for leaf in legacy_leaves
-    }
-    if len(expected_leaf_bodies) != len(legacy_leaves):
-        raise ContractOpsSafetyError("source snapshot contains duplicate legacy leaves")
-    expected_winners = {
-        document_id: revision
-        for document_id, revision in manifest.get("winnerRevisions", {}).items()
-        if document_id != CONTRACT_DESIGN_ID
-    }
-    source_security = _read_json(Path(snapshot_path) / "security.json")
-
-    client.create_database(database)
-    info = client.get_database_info(database)
-    if info.get("doc_count") != 0:
-        raise ContractOpsSafetyError("quarantine database was not empty")
-    if legacy_leaves:
-        client.bulk_docs_new_edits_false(database, legacy_leaves)
-
-    restored_before_validator, winners_before_validator = _read_stable_leaf_graph(
-        client, database
-    )
-    restored_bodies = {
-        (leaf.get("_id"), leaf.get("_rev")): _canonical_json(leaf)
-        for leaf in restored_before_validator
-    }
-    if (
-        restored_bodies != expected_leaf_bodies
-        or dict(winners_before_validator) != expected_winners
-    ):
-        raise ContractOpsSafetyError("quarantine leaf reconstruction verification failed")
-
-    result = client.put_document(database, load_design_document())
-    if not result.get("ok") or verify_validator(client, database).get("state") != "compatible":
-        raise ContractOpsSafetyError("validator-last quarantine reconstruction failed")
-    # Restore source authorization only after every document write. This avoids
-    # self-locking the recovery operator before the validator can be installed.
-    client.put_security(database, source_security)
-    restored_after_validator, winners_after_validator = _read_stable_leaf_graph(client, database)
-    non_design_after = [
-        leaf for leaf in restored_after_validator if leaf.get("_id") != CONTRACT_DESIGN_ID
-    ]
-    final_bodies = {
-        (leaf.get("_id"), leaf.get("_rev")): _canonical_json(leaf)
-        for leaf in non_design_after
-    }
-    final_winners = {
-        document_id: revision
-        for document_id, revision in winners_after_validator.items()
-        if document_id != CONTRACT_DESIGN_ID
-    }
-    design_leaves = [
-        leaf for leaf in restored_after_validator if leaf.get("_id") == CONTRACT_DESIGN_ID
-    ]
-    if (
-        final_bodies != expected_leaf_bodies
-        or final_winners != expected_winners
-        or len(design_leaves) != 1
-        or design_leaves[0].get("_rev") != result.get("rev")
-        or security_checksum(client.get_security(database)) != manifest["securityChecksum"]
-    ):
-        raise ContractOpsSafetyError("verified quarantine state differs from the snapshot")
-    return {
-        "sourceSnapshotChecksum": manifest["manifestChecksum"],
-        "leafCount": len(legacy_leaves),
-        "validatorRevision": result.get("rev"),
-    }
-
-
-def create_inventory(
-    client: Any,
-    *,
-    manifest_root: str | Path,
-    encrypted_volume_confirmed: bool,
-    temporary_unencrypted_confirmed: bool = False,
-    timestamp: str | None = None,
-) -> InventoryResult:
-    backup_protection = _require_backup_protection(
-        encrypted_volume_confirmed=encrypted_volume_confirmed,
-        temporary_unencrypted_confirmed=temporary_unencrypted_confirmed,
-    )
-    root = validate_backup_root(manifest_root)
-    account_checksum = _account_checksum(client)
-    timestamp = timestamp or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    path = _exact_artifact_path(root, f"fortudo-inventory-{timestamp}")
-    try:
-        path.mkdir(parents=True, mode=0o700)
-        _secure_backup_directory(path)
-    except FileExistsError as error:
-        raise ContractOpsSafetyError("inventory directory already exists") from error
-
-    rows = []
-    counts = {"fortudoDatabases": 0, "compatible": 0, "missingValidator": 0}
-    try:
-        for database in sorted(
-            name for name in client.list_databases() if name.startswith("fortudo-")
-        ):
-            info = client.get_database_info(database)
-            verification = verify_validator(client, database)
-            counts["fortudoDatabases"] += 1
-            if verification["state"] == "compatible":
-                counts["compatible"] += 1
-            elif verification["state"] == "missing-validator":
-                counts["missingValidator"] += 1
-            rows.append(
-                {
-                    "databaseName": database,
-                    "accountChecksum": account_checksum,
-                    "updateSequence": info.get("update_seq"),
-                    "documentCount": info.get("doc_count"),
-                    "deletedDocumentCount": info.get("doc_del_count"),
-                    "partitioned": bool(info.get("props", {}).get("partitioned", False)),
-                    "securityChecksum": security_checksum(client.get_security(database)),
-                    **verification,
-                }
-            )
-        manifest_base = {
-            "formatVersion": 2,
-            "createdAt": timestamp,
-            "backupProtection": backup_protection,
-            "accountChecksum": account_checksum,
-            "counts": counts,
-            "databases": rows,
-        }
-        manifest = {**manifest_base, "manifestChecksum": _manifest_checksum(manifest_base)}
-        manifest_path = path / "manifest.json"
-        _write_secure(
-            manifest_path,
-            (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(),
-        )
-        return InventoryResult(
-            path=manifest_path,
-            checksum=manifest["manifestChecksum"],
-            counts=counts,
-            account_checksum=account_checksum,
-        )
-    except Exception:
-        _remove_exact_artifact(path, root)
-        raise
-
-
 class ContractOpsCloudantClient(CloudantClient):
-    def list_databases(self) -> list[str]:
-        return self._request("database inventory", "_all_dbs")
+    """Cloudant client extension for one exact read-only document lookup."""
 
-    def get_security(self, database: str) -> dict[str, Any]:
-        return self._request(
-            "security metadata read", f"{urllib.parse.quote(database, safe='')}/_security"
+    def get_document(self, database: str, document_id: str) -> dict[str, Any] | None:
+        path = (
+            f"{urllib.parse.quote(database, safe='')}/"
+            f"{urllib.parse.quote(document_id, safe='')}"
         )
-
-    def put_security(self, database: str, security: Mapping[str, Any]) -> None:
-        self._request(
-            "security metadata write",
-            f"{urllib.parse.quote(database, safe='')}/_security",
-            method="PUT",
-            body=security,
-        )
-
-    def get_current_leaf_graph(
-        self, database: str
-    ) -> tuple[list[dict[str, Any]], dict[str, str]]:
-        encoded = urllib.parse.quote(database, safe="")
-        changes = self._request(
-            "current leaf inventory", f"{encoded}/_changes?since=0&style=all_docs"
-        )
-        leaves: list[dict[str, Any]] = []
-        for row in changes.get("results", []):
-            document_id = row.get("id")
-            if not isinstance(document_id, str) or document_id.startswith("_local/"):
-                continue
-            for item in row.get("changes", []):
-                revision = item.get("rev")
-                path = (
-                    f"{encoded}/{urllib.parse.quote(document_id, safe='')}?"
-                    f"rev={urllib.parse.quote(revision, safe='')}&revs=true&attachments=true"
-                )
-                leaves.append(self._request("leaf revision read", path))
-        winners_payload = self._request("winner identity read", f"{encoded}/_all_docs")
-        winners = {
-            row["id"]: row["value"]["rev"]
-            for row in winners_payload.get("rows", [])
-            if isinstance(row.get("value", {}).get("rev"), str)
-        }
-        return leaves, winners
-
-    def put_document(self, database: str, document: dict[str, Any]) -> dict[str, Any]:
-        return self._request(
-            "guarded document write",
-            f"{urllib.parse.quote(database, safe='')}/{urllib.parse.quote(document['_id'], safe='')}",
-            method="PUT",
-            body=document,
-        )
-
-    def create_database(self, database: str) -> None:
-        self._request(
-            "guarded database creation",
-            urllib.parse.quote(database, safe=""),
-            method="PUT",
-        )
-
-    def bulk_docs_new_edits_false(self, database: str, documents: list[dict[str, Any]]) -> None:
-        result = self._request(
-            "quarantine leaf reconstruction",
-            f"{urllib.parse.quote(database, safe='')}/_bulk_docs",
-            method="POST",
-            body={"docs": documents, "new_edits": False},
-        )
-        if len(result) != len(documents) or any(row.get("error") for row in result):
-            raise ContractOpsSafetyError("quarantine leaf reconstruction was incomplete")
+        try:
+            payload = self._request("document read", path)
+        except MigrationSafetyError as error:
+            if "HTTP 404" in str(error):
+                return None
+            raise
+        if not isinstance(payload, Mapping):
+            raise MigrationSafetyError("Cloudant returned an invalid document response")
+        return dict(payload)
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="mode", required=True)
-
-    inventory = subparsers.add_parser("inventory")
-    inventory.add_argument("--manifest-root", required=True)
-    inventory_protection = inventory.add_mutually_exclusive_group()
-    inventory_protection.add_argument("--confirm-encrypted-volume", action="store_true")
-    inventory_protection.add_argument("--confirm-temporary-unencrypted", action="store_true")
-
-    snapshot = subparsers.add_parser("snapshot")
-    snapshot.add_argument("--database", required=True)
-    snapshot.add_argument("--backup-root", required=True)
-    snapshot.add_argument("--label", required=True)
-    snapshot_protection = snapshot.add_mutually_exclusive_group()
-    snapshot_protection.add_argument("--confirm-encrypted-volume", action="store_true")
-    snapshot_protection.add_argument("--confirm-temporary-unencrypted", action="store_true")
-
     verify = subparsers.add_parser("verify")
     verify.add_argument("--database", required=True)
-
-    install = subparsers.add_parser("install")
-    install.add_argument("--database", required=True)
-    install.add_argument("--confirm-database", required=True)
-    install.add_argument("--expected-target-binding-checksum", required=True)
-    install.add_argument("--snapshot", required=True)
-
-    provision = subparsers.add_parser("provision")
-    provision.add_argument("--database", required=True)
-    provision.add_argument("--confirm-database", required=True)
-    provision.add_argument("--expected-account-checksum", required=True)
-
-    quarantine = subparsers.add_parser("restore-quarantine")
-    quarantine.add_argument("--database", required=True)
-    quarantine.add_argument("--confirm-database", required=True)
-    quarantine.add_argument("--expected-account-checksum", required=True)
-    quarantine.add_argument("--snapshot", required=True)
     return parser
-
-
-def _public_operational_report(report: Mapping[str, Any]) -> dict[str, Any]:
-    public = {"mode": report["mode"]}
-    for key, value in report.items():
-        if key == "counts" or key == "state" or key == "leafCount" or key.endswith("Checksum"):
-            public[key] = value
-    return public
 
 
 def execute(
@@ -947,79 +126,15 @@ def execute(
     if not credential_url:
         raise ContractOpsSafetyError(f"required environment variable {CREDENTIAL_ENV_VAR} is unset")
     client = client_factory(credential_url)
-
-    if args.mode == "inventory":
-        result = create_inventory(
-            client,
-            manifest_root=args.manifest_root,
-            encrypted_volume_confirmed=args.confirm_encrypted_volume,
-            temporary_unencrypted_confirmed=args.confirm_temporary_unencrypted,
-        )
-        report = {
-            "mode": args.mode,
-            "counts": result.counts,
-            "accountChecksum": result.account_checksum,
-            "manifestPath": str(result.path),
-            "manifestChecksum": result.checksum,
-        }
-    elif args.mode == "snapshot":
-        result = create_snapshot(
-            client,
-            database=args.database,
-            backup_root=args.backup_root,
-            label=args.label,
-            encrypted_volume_confirmed=args.confirm_encrypted_volume,
-            temporary_unencrypted_confirmed=args.confirm_temporary_unencrypted,
-        )
-        snapshot_manifest = verify_snapshot(result.path)
-        report = {
-            "mode": args.mode,
-            "snapshotPath": str(result.path),
-            "snapshotChecksum": result.checksum,
-            "targetBindingChecksum": snapshot_manifest["targetBinding"]["checksum"],
-        }
-    elif args.mode == "verify":
-        report = {"mode": args.mode, **verify_validator(client, args.database)}
-    elif args.mode == "install":
-        report = {
-            "mode": args.mode,
-            **install_validator(
-                client,
-                database=args.database,
-                confirmation=args.confirm_database,
-                expected_target_binding_checksum=args.expected_target_binding_checksum,
-                snapshot_path=args.snapshot,
-            ),
-        }
-    elif args.mode == "provision":
-        report = {
-            "mode": args.mode,
-            **provision_database(
-                client,
-                database=args.database,
-                confirmation=args.confirm_database,
-                expected_account_checksum=args.expected_account_checksum,
-            ),
-        }
-    else:
-        report = {
-            "mode": args.mode,
-            **restore_quarantine(
-                client,
-                database=args.database,
-                confirmation=args.confirm_database,
-                expected_account_checksum=args.expected_account_checksum,
-                snapshot_path=args.snapshot,
-            ),
-        }
-    print(json.dumps(_public_operational_report(report), indent=2, sort_keys=True))
+    report = {"mode": "verify", **verify_validator(client, args.database)}
+    print(json.dumps({"mode": report["mode"], "state": report["state"]}, indent=2, sort_keys=True))
     return report
 
 
 def main() -> int:
     try:
         execute()
-    except ContractOpsSafetyError as error:
+    except (ContractOpsSafetyError, MigrationSafetyError) as error:
         print(f"Contract operation blocked: {error}", file=sys.stderr)
         return 2
     return 0

--- a/scripts/migrate_taxonomy_identity.py
+++ b/scripts/migrate_taxonomy_identity.py
@@ -1,9 +1,8 @@
-"""Guarded Cloudant migration for Fortudo taxonomy identity version 1.
+"""Read-only planner for Fortudo taxonomy identity version 1.
 
-Dry-run is the default. Apply and restore modes require an exact database name,
-an update-sequence lock, typed confirmation, and a backup outside this repository.
-The command deliberately prints metadata only; document bodies and credentials
-must never appear in its output or exception messages.
+This command validates the exact production database and reports aggregate dry-run
+counts. It has no backup, restore, or write capability. Document bodies, database
+names, opaque database metadata, and credentials are never printed.
 """
 
 from __future__ import annotations
@@ -11,36 +10,28 @@ from __future__ import annotations
 import argparse
 import base64
 import copy
-import csv
-import hashlib
 import json
 import os
-import shutil
-import subprocess
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from dataclasses import dataclass, field
-from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
 
 
 EXPECTED_DATABASE_NAME = "fortudo-dat-411"
 CREDENTIAL_ENV_VAR = "FORTUDO_CLOUDANT_URL"
-MIGRATION_COMPLETION_ID = "config-taxonomy-identity-migration-v1"
 TAXONOMY_DOCUMENT_ID = "config-categories"
 RUNNING_ACTIVITY_ID = "config-running-activity"
 TAXONOMY_IDENTITY_VERSION = 1
 DOCUMENT_CONTRACT_VERSION = 1
 TAXONOMY_NAMESPACE = uuid.UUID("8e2e8b7a-5c3f-4f3e-9c5d-7a1b2e4f6c80")
-REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class MigrationSafetyError(RuntimeError):
-    """Raised when a production-safety precondition is not satisfied."""
+    """Raised when a read-only migration-planning precondition is not satisfied."""
 
 
 @dataclass(frozen=True)
@@ -52,27 +43,9 @@ class MigrationPlan:
 
 
 @dataclass(frozen=True)
-class BackupResult:
-    path: Path
-    checksum: str
-
-
-@dataclass(frozen=True)
 class MigrationResult:
     mode: str
-    update_seq: str
-    counts: dict[str, int] = field(default_factory=dict)
-    backup_path: Path | None = None
-    backup_checksum: str | None = None
-    journal_path: Path | None = None
-
-
-def _canonical_json(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-def _sha256_bytes(value: bytes) -> str:
-    return hashlib.sha256(value).hexdigest()
+    counts: dict[str, int]
 
 
 def _deterministic_id(kind: str, legacy_key: str) -> str:
@@ -381,988 +354,8 @@ def build_migration_plan(documents: Sequence[Mapping[str, Any]]) -> MigrationPla
     )
 
 
-def validate_backup_root(backup_root: str | Path) -> Path:
-    resolved = Path(backup_root).expanduser().resolve()
-    try:
-        resolved.relative_to(REPOSITORY_ROOT)
-    except ValueError:
-        return resolved
-    raise MigrationSafetyError("backup root must be outside the repository")
-
-
-def _exact_artifact_path(root: Path, name: str) -> Path:
-    """Resolve one private artifact immediately below its validated root."""
-
-    path = (root / name).resolve()
-    if path.parent != root or path == root:
-        raise MigrationSafetyError("private artifact path escaped its approved root")
-    return path
-
-
-def _remove_exact_artifact(path: Path, root: Path) -> None:
-    """Remove only a previously resolved direct child of the approved root."""
-
-    resolved_path = path.resolve()
-    if resolved_path.parent != root or resolved_path == root:
-        raise MigrationSafetyError("refusing to remove an unverified private artifact path")
-    shutil.rmtree(resolved_path, ignore_errors=True)
-
-
-def _write_secure(path: Path, content: bytes) -> None:
-    with path.open("xb") as stream:
-        stream.write(content)
-        stream.flush()
-        os.fsync(stream.fileno())
-    path.chmod(0o600)
-
-
-def _secure_backup_directory(path: Path) -> None:
-    """Restrict a backup directory to the current user on the host platform."""
-
-    path.chmod(0o700)
-    if os.name != "nt":
-        return
-
-    try:
-        identity = subprocess.run(
-            ["whoami", "/user", "/fo", "csv", "/nh"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        row = next(csv.reader([identity.stdout.strip()]))
-        sid = row[1].strip()
-        if not sid.startswith("S-1-"):
-            raise ValueError
-        subprocess.run(
-            [
-                "icacls",
-                str(path),
-                "/inheritance:r",
-                "/grant:r",
-                f"*{sid}:(OI)(CI)F",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, ValueError, IndexError, StopIteration, subprocess.SubprocessError) as error:
-        raise MigrationSafetyError("could not enforce user-only backup permissions") from error
-
-
-def _ndjson_bytes(documents: Iterable[Mapping[str, Any]]) -> bytes:
-    rows = [_canonical_json(document) for document in documents]
-    return (("\n".join(rows) + "\n") if rows else "").encode("utf-8")
-
-
-def _backup_checksum(manifest_without_checksum: Mapping[str, Any]) -> str:
-    return _sha256_bytes(_canonical_json(manifest_without_checksum).encode("utf-8"))
-
-
-def create_backup(
-    client: Any,
-    database: str,
-    database_info: Mapping[str, Any],
-    winners: Sequence[Mapping[str, Any]],
-    backup_root: str | Path,
-    *,
-    timestamp: str | None = None,
-) -> BackupResult:
-    """Write winners and every losing conflict leaf, then verify all checksums."""
-
-    _ensure_exact_database(database)
-    root = validate_backup_root(backup_root)
-    timestamp = timestamp or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-
-    conflict_leaves: list[dict[str, Any]] = []
-    conflict_revisions: list[dict[str, str]] = []
-    for winner in winners:
-        document_id = winner.get("_id")
-        for revision in winner.get("_conflicts", []) or []:
-            leaf = client.get_revision(database, document_id, revision)
-            if leaf.get("_id") != document_id or leaf.get("_rev") != revision:
-                raise MigrationSafetyError("conflict leaf revision did not match its request")
-            conflict_leaves.append(leaf)
-            conflict_revisions.append({"id": document_id, "revision": revision})
-
-    root.mkdir(parents=True, exist_ok=True)
-    backup_path = _exact_artifact_path(root, f"fortudo-taxonomy-identity-{timestamp}")
-    try:
-        backup_path.mkdir(mode=0o700)
-    except FileExistsError as error:
-        raise MigrationSafetyError("backup directory already exists") from error
-    try:
-        _secure_backup_directory(backup_path)
-    except Exception:
-        _remove_exact_artifact(backup_path, root)
-        raise
-
-    winners_bytes = _ndjson_bytes(winners)
-    conflicts_bytes = _ndjson_bytes(conflict_leaves)
-    manifest_base = {
-        "formatVersion": 1,
-        "databaseName": database,
-        "databaseUpdateSeq": database_info.get("update_seq"),
-        "databaseDocCount": database_info.get("doc_count"),
-        "databaseDeletedDocCount": database_info.get("doc_del_count"),
-        "createdAt": timestamp,
-        "winnerCount": len(winners),
-        "conflictLeafCount": len(conflict_leaves),
-        "winningRevisions": [
-            {"id": winner.get("_id"), "revision": winner.get("_rev")} for winner in winners
-        ],
-        "conflictRevisions": conflict_revisions,
-        "files": {
-            "winning-documents.ndjson": _sha256_bytes(winners_bytes),
-            "conflict-leaves.ndjson": _sha256_bytes(conflicts_bytes),
-        },
-    }
-    checksum = _backup_checksum(manifest_base)
-    manifest = {**manifest_base, "backupChecksum": checksum}
-
-    try:
-        _write_secure(backup_path / "winning-documents.ndjson", winners_bytes)
-        _write_secure(backup_path / "conflict-leaves.ndjson", conflicts_bytes)
-        _write_secure(
-            backup_path / "manifest.json",
-            (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
-        )
-        verify_backup(backup_path)
-    except Exception:
-        _remove_exact_artifact(backup_path, root)
-        raise
-    return BackupResult(path=backup_path, checksum=checksum)
-
-
-def _load_ndjson(path: Path) -> list[dict[str, Any]]:
-    try:
-        with path.open("r", encoding="utf-8") as stream:
-            return [json.loads(line) for line in stream if line.strip()]
-    except (OSError, json.JSONDecodeError) as error:
-        raise MigrationSafetyError("backup data is unreadable") from error
-
-
-def verify_backup(backup_path: str | Path) -> dict[str, Any]:
-    path = Path(backup_path).resolve()
-    try:
-        with (path / "manifest.json").open("r", encoding="utf-8") as stream:
-            manifest = json.load(stream)
-    except (OSError, json.JSONDecodeError) as error:
-        raise MigrationSafetyError("backup manifest is unreadable") from error
-
-    if manifest.get("databaseName") != EXPECTED_DATABASE_NAME:
-        raise MigrationSafetyError("backup database name does not match production")
-    for filename in ("winning-documents.ndjson", "conflict-leaves.ndjson"):
-        try:
-            content = (path / filename).read_bytes()
-        except OSError as error:
-            raise MigrationSafetyError("backup data file is unreadable") from error
-        if _sha256_bytes(content) != manifest.get("files", {}).get(filename):
-            raise MigrationSafetyError("backup file checksum mismatch")
-
-    winners = _load_ndjson(path / "winning-documents.ndjson")
-    conflicts = _load_ndjson(path / "conflict-leaves.ndjson")
-    if len(winners) != manifest.get("winnerCount") or len(conflicts) != manifest.get(
-        "conflictLeafCount"
-    ):
-        raise MigrationSafetyError("backup row count mismatch")
-    expected_revisions = {
-        (row.get("id"), row.get("revision")) for row in manifest.get("conflictRevisions", [])
-    }
-    actual_revisions = {(row.get("_id"), row.get("_rev")) for row in conflicts}
-    if expected_revisions != actual_revisions:
-        raise MigrationSafetyError("backup conflict leaf set mismatch")
-    expected_winners = {
-        (row.get("id"), row.get("revision")) for row in manifest.get("winningRevisions", [])
-    }
-    actual_winners = {(row.get("_id"), row.get("_rev")) for row in winners}
-    if expected_winners != actual_winners:
-        raise MigrationSafetyError("backup winning revision set mismatch")
-
-    checksum = manifest.get("backupChecksum")
-    manifest_base = dict(manifest)
-    manifest_base.pop("backupChecksum", None)
-    if checksum != _backup_checksum(manifest_base):
-        raise MigrationSafetyError("backup manifest checksum mismatch")
-    return manifest
-
-
-def _validate_database_info(database: str, database_info: Mapping[str, Any]) -> None:
-    _ensure_exact_database(database)
-    if database_info.get("db_name") != database:
-        raise MigrationSafetyError("Cloudant reported a different database name")
-    if not isinstance(database_info.get("update_seq"), str):
-        raise MigrationSafetyError("Cloudant did not report an opaque update_seq string")
-
-
-def _validate_locked_state(
-    *,
-    expected_update_seq: str,
-    database_info: Mapping[str, Any],
-    original_winners: Sequence[Mapping[str, Any]],
-    current_winners: Sequence[Mapping[str, Any]],
-) -> None:
-    if database_info.get("update_seq") != expected_update_seq:
-        raise MigrationSafetyError("update_seq changed after the dry-run")
-    original_revisions = {row.get("_id"): row.get("_rev") for row in original_winners}
-    current_revisions = {row.get("_id"): row.get("_rev") for row in current_winners}
-    if original_revisions != current_revisions:
-        raise MigrationSafetyError("winning document revisions changed after backup")
-
-
-def _bulk_write_checked(client: Any, database: str, documents: list[dict[str, Any]]) -> None:
-    if not documents:
-        return
-    results = client.bulk_docs(database, documents)
-    if len(results) != len(documents) or any(not result.get("ok") for result in results):
-        raise MigrationSafetyError("Cloudant bulk write did not commit every requested revision")
-
-
-def create_migration_journal(
-    documents: Sequence[Mapping[str, Any]],
-    journal_root: str | Path,
-    *,
-    timestamp: str | None = None,
-) -> Path:
-    root = validate_backup_root(journal_root)
-    timestamp = timestamp or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    path = _exact_artifact_path(root, f"fortudo-taxonomy-migration-journal-{timestamp}")
-    entries = []
-    seen: set[tuple[str, str]] = set()
-    ordered_documents = sorted(
-        documents,
-        key=lambda document: (
-            str(document.get("_id")),
-            bool(document.get("_deleted")),
-            str(document.get("_rev")),
-        ),
-    )
-    for document in ordered_documents:
-        document_id = document.get("_id")
-        pre_revision = document.get("_rev")
-        if not isinstance(document_id, str) or not isinstance(pre_revision, str):
-            raise MigrationSafetyError("journal entry is missing its locked pre-revision")
-        identity = (document_id, pre_revision)
-        if identity in seen:
-            raise MigrationSafetyError("journal contains a duplicate pre-revision")
-        seen.add(identity)
-        intended = copy.deepcopy(dict(document))
-        entries.append(
-            {
-                "documentId": document_id,
-                "preRevision": pre_revision,
-                "intendedBody": intended,
-                "intendedBodyChecksum": _sha256_bytes(
-                    _canonical_json(intended).encode("utf-8")
-                ),
-            }
-        )
-    manifest_base = {
-        "formatVersion": 1,
-        "databaseName": EXPECTED_DATABASE_NAME,
-        "createdAt": timestamp,
-        "entryCount": len(entries),
-        "entries": entries,
-    }
-    manifest = {**manifest_base, "manifestChecksum": _backup_checksum(manifest_base)}
-    try:
-        path.mkdir(parents=True, mode=0o700)
-        _secure_backup_directory(path)
-        _write_secure(
-            path / "journal.json",
-            (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
-        )
-    except FileExistsError as error:
-        raise MigrationSafetyError("migration journal already exists") from error
-    except Exception:
-        _remove_exact_artifact(path, root)
-        raise
-    return path
-
-
-def _load_migration_journal(journal_path: str | Path) -> dict[str, Any]:
-    path = Path(journal_path).resolve()
-    try:
-        manifest = json.loads((path / "journal.json").read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise MigrationSafetyError("migration journal is unreadable") from error
-    unsigned = dict(manifest)
-    checksum = unsigned.pop("manifestChecksum", None)
-    if checksum != _backup_checksum(unsigned):
-        raise MigrationSafetyError("migration journal checksum mismatch")
-    if manifest.get("databaseName") != EXPECTED_DATABASE_NAME or manifest.get(
-        "entryCount"
-    ) != len(manifest.get("entries", [])):
-        raise MigrationSafetyError("migration journal metadata is invalid")
-    for entry in manifest["entries"]:
-        if entry.get("intendedBodyChecksum") != _sha256_bytes(
-            _canonical_json(entry.get("intendedBody")).encode("utf-8")
-        ):
-            raise MigrationSafetyError("migration journal body checksum mismatch")
-    return manifest
-
-
-def _without_revision(document: Mapping[str, Any]) -> dict[str, Any]:
-    body = copy.deepcopy(dict(document))
-    body.pop("_rev", None)
-    body.pop("_revisions", None)
-    body.pop("_conflicts", None)
-    return body
-
-
-def _revision_ancestry(leaf: Mapping[str, Any]) -> list[str]:
-    revisions = leaf.get("_revisions")
-    if not isinstance(revisions, Mapping):
-        return []
-    start = revisions.get("start")
-    identifiers = revisions.get("ids")
-    if not isinstance(start, int) or start < 1 or not isinstance(identifiers, list):
-        return []
-    if not all(isinstance(identifier, str) and identifier for identifier in identifiers):
-        return []
-    ancestry = [f"{start - index}-{identifier}" for index, identifier in enumerate(identifiers)]
-    return ancestry if ancestry and ancestry[0] == leaf.get("_rev") else []
-
-
-def _is_direct_successor(leaf: Mapping[str, Any], pre_revision: str) -> bool:
-    ancestry = _revision_ancestry(leaf)
-    return len(ancestry) >= 2 and ancestry[1] == pre_revision
-
-
-def _classify_journal_entry(
-    leaves: Sequence[Mapping[str, Any]],
-    winners: Mapping[str, str],
-    entry: Mapping[str, Any],
-) -> str:
-    document_id = entry["documentId"]
-    pre_revision = entry["preRevision"]
-    intended = entry["intendedBody"]
-    matching = [leaf for leaf in leaves if leaf.get("_id") == document_id]
-    if any(leaf.get("_rev") == pre_revision for leaf in matching):
-        return "locked-pre-state"
-    intended_body = _without_revision(intended)
-    if intended.get("_deleted"):
-        # CouchDB may retain only special fields in a stored deletion stub. The
-        # exact journal result is the current deleted leaf directly descending
-        # from this entry's locked conflict revision.
-        if any(
-            leaf.get("_deleted") and _is_direct_successor(leaf, pre_revision)
-            for leaf in matching
-        ):
-            return "exact-intended-result"
-    else:
-        winner_revision = winners.get(document_id)
-        winner = next((leaf for leaf in matching if leaf.get("_rev") == winner_revision), None)
-        if (
-            winner is not None
-            and _is_direct_successor(winner, pre_revision)
-            and _without_revision(winner) == intended_body
-        ):
-            return "exact-intended-result"
-    return "divergent"
-
-
-def _read_stable_leaf_graph(
-    client: Any, database: str
-) -> tuple[list[dict[str, Any]], dict[str, str]]:
-    before = client.get_database_info(database)
-    leaves, winners = client.get_current_leaf_graph(database)
-    after = client.get_database_info(database)
-    if _database_observation(client, database, before) != _database_observation(
-        client, database, after
-    ):
-        raise MigrationSafetyError("database changed during journal classification")
-    return leaves, winners
-
-
-def _database_observation(
-    client: Any, database: str, info: Mapping[str, Any]
-) -> dict[str, Any]:
-    try:
-        account_checksum = client.get_account_checksum()
-    except (AttributeError, TypeError) as error:
-        raise MigrationSafetyError("Cloudant account identity is unavailable") from error
-    if (
-        not isinstance(account_checksum, str)
-        or len(account_checksum) != 64
-        or any(character not in "0123456789abcdef" for character in account_checksum)
-        or info.get("db_name") != database
-        or not isinstance(info.get("update_seq"), str)
-    ):
-        raise MigrationSafetyError("database identity metadata is incomplete")
-    return {
-        "accountChecksum": account_checksum,
-        "databaseName": database,
-        "partitioned": bool(
-            info.get("partitioned") is True
-            or info.get("props", {}).get("partitioned", False)
-        ),
-        "databaseUpdateSeq": info["update_seq"],
-    }
-
-
-def _classify_journal_entries(
-    client: Any, database: str, entries: Sequence[Mapping[str, Any]]
-) -> list[str]:
-    leaves, winners = _read_stable_leaf_graph(client, database)
-    return [_classify_journal_entry(leaves, winners, entry) for entry in entries]
-
-
-def apply_or_resume_journal(
-    client: Any, *, database: str, journal_path: str | Path
-) -> dict[str, int]:
-    _ensure_exact_database(database)
-    journal = _load_migration_journal(journal_path)
-    classifications = _classify_journal_entries(client, database, journal["entries"])
-    if "divergent" in classifications:
-        raise MigrationSafetyError("journaled operation encountered divergent state")
-
-    pending = [
-        copy.deepcopy(entry["intendedBody"])
-        for entry, state in zip(journal["entries"], classifications, strict=True)
-        if state == "locked-pre-state"
-    ]
-    if pending:
-        # Bulk responses are advisory. Exact rereads below establish what actually committed.
-        client.bulk_docs(database, pending)
-
-    final = _classify_journal_entries(client, database, journal["entries"])
-    if "divergent" in final:
-        raise MigrationSafetyError("journaled operation diverged after a partial write")
-    if "locked-pre-state" in final:
-        raise MigrationSafetyError("journaled operation remains incomplete and is safe to resume")
-    return {
-        "exactIntendedResults": final.count("exact-intended-result"),
-        "resumedPreStates": classifications.count("locked-pre-state"),
-    }
-
-
-def _without_identity(document: Mapping[str, Any]) -> dict[str, Any]:
-    result = copy.deepcopy(dict(document))
-    result.pop("_rev", None)
-    result.pop("_conflicts", None)
-    result.pop("writerContract", None)
-    if result.get("category") is None:
-        result.pop("category", None)
-    result.pop("categoryId", None)
-    result.pop("categoryIdentityVersion", None)
-    if result.get("_id") == TAXONOMY_DOCUMENT_ID:
-        result.pop("identityVersion", None)
-        for row in [*result.get("groups", []), *result.get("categories", [])]:
-            for field_name in ("id", "groupId", "legacyKeys", "status", "archivedAt"):
-                row.pop(field_name, None)
-    return result
-
-
-def _verify_post_migration(
-    before: Sequence[Mapping[str, Any]], after: Sequence[Mapping[str, Any]]
-) -> None:
-    after_by_id = {row.get("_id"): row for row in after}
-    for original in before:
-        if original.get("_id") == MIGRATION_COMPLETION_ID:
-            continue
-        current = after_by_id.get(original.get("_id"))
-        if current is None or _without_identity(current) != _without_identity(original):
-            raise MigrationSafetyError("post-migration nonidentity invariant failed")
-
-    remaining = build_migration_plan(after)
-    if remaining.updates or remaining.conflict_tombstones:
-        raise MigrationSafetyError("post-migration identity or conflict invariant failed")
-    if MIGRATION_COMPLETION_ID in after_by_id:
-        raise MigrationSafetyError("completion marker was written before data verification")
-
-
-def _attachment_digests(document: Mapping[str, Any]) -> dict[str, str]:
-    result: dict[str, str] = {}
-    for name, attachment in sorted((document.get("_attachments") or {}).items()):
-        digest = attachment.get("digest") if isinstance(attachment, Mapping) else None
-        if isinstance(digest, str):
-            result[name] = digest
-        elif isinstance(attachment, Mapping) and isinstance(attachment.get("data"), str):
-            result[name] = _sha256_bytes(attachment["data"].encode("utf-8"))
-        else:
-            raise MigrationSafetyError("attachment digest metadata is incomplete")
-    return result
-
-
-def compute_verified_state_fingerprint(
-    client: Any, database: str, validator_revision: str
-) -> tuple[str, dict[str, int]]:
-    leaves, _winners = _read_stable_leaf_graph(client, database)
-    filtered = [leaf for leaf in leaves if leaf.get("_id") != MIGRATION_COMPLETION_ID]
-    identities = [(leaf.get("_id"), leaf.get("_rev")) for leaf in filtered]
-    if len(identities) != len(set(identities)):
-        raise MigrationSafetyError("verified leaf graph contains duplicate identities")
-    id_counts: dict[str, int] = {}
-    canonical_leaves = []
-    for leaf in sorted(filtered, key=lambda row: (str(row.get("_id")), str(row.get("_rev")))):
-        document_id = leaf.get("_id")
-        revision = leaf.get("_rev")
-        if not isinstance(document_id, str) or not isinstance(revision, str):
-            raise MigrationSafetyError("verified leaf graph contains an invalid identity")
-        id_counts[document_id] = id_counts.get(document_id, 0) + 1
-        body = copy.deepcopy(dict(leaf))
-        body.pop("_conflicts", None)
-        canonical_leaves.append(
-            {
-                "documentId": document_id,
-                "leafRevision": revision,
-                "deleted": bool(leaf.get("_deleted")),
-                "body": body,
-                "attachmentDigests": _attachment_digests(leaf),
-            }
-        )
-    counts = {
-        "leafCount": len(filtered),
-        "liveLeafCount": sum(not bool(leaf.get("_deleted")) for leaf in filtered),
-        "deletedLeafCount": sum(bool(leaf.get("_deleted")) for leaf in filtered),
-        "conflictedDocumentCount": sum(count > 1 for count in id_counts.values()),
-    }
-    fingerprint_body = {
-        "validatorRevision": validator_revision,
-        "counts": counts,
-        "leaves": canonical_leaves,
-    }
-    return _sha256_bytes(_canonical_json(fingerprint_body).encode("utf-8")), counts
-
-
-def _completion_intent(completion: Mapping[str, Any]) -> dict[str, Any]:
-    intent = {
-        "formatVersion": 1,
-        "documentId": MIGRATION_COMPLETION_ID,
-        "preRevision": None,
-        "intendedBody": dict(completion),
-        "intendedBodyChecksum": _sha256_bytes(
-            _canonical_json(completion).encode("utf-8")
-        ),
-    }
-    intent["intentChecksum"] = _backup_checksum(intent)
-    return intent
-
-
-def _load_completion_intent(path: Path) -> dict[str, Any]:
-    try:
-        intent = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise MigrationSafetyError("completion intent journal is unreadable") from error
-    if not isinstance(intent, dict):
-        raise MigrationSafetyError("completion intent journal is invalid")
-    unsigned = dict(intent)
-    intent_checksum = unsigned.pop("intentChecksum", None)
-    body = intent.get("intendedBody")
-    if (
-        intent.get("formatVersion") != 1
-        or intent.get("documentId") != MIGRATION_COMPLETION_ID
-        or intent.get("preRevision") is not None
-        or not isinstance(body, dict)
-        or intent.get("intendedBodyChecksum")
-        != _sha256_bytes(_canonical_json(body).encode("utf-8"))
-        or intent_checksum != _backup_checksum(unsigned)
-    ):
-        raise MigrationSafetyError("completion intent journal is invalid")
-    return intent
-
-
-def _validate_snapshot_and_fence(
-    client: Any,
-    *,
-    database: str,
-    expected_update_seq: str,
-    snapshot_path: str | Path,
-    require_exact_state: bool = True,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    # Lazy import avoids a module cycle: the operations module reuses this file's HTTP client.
-    from scripts.document_contract_ops import (
-        ContractOpsSafetyError,
-        capture_target_binding,
-        security_checksum,
-        verify_snapshot,
-        verify_validator,
-    )
-
-    try:
-        snapshot = verify_snapshot(snapshot_path)
-    except ContractOpsSafetyError as error:
-        raise MigrationSafetyError("S1 snapshot verification failed") from error
-    if (
-        snapshot.get("databaseName") != database
-        or snapshot.get("databaseUpdateSeq") != expected_update_seq
-        or snapshot.get("label") != "S1"
-    ):
-        raise MigrationSafetyError("S1 snapshot does not match the locked migration state")
-    try:
-        validator = verify_validator(client, database)
-    except ContractOpsSafetyError as error:
-        raise MigrationSafetyError("document validator verification failed") from error
-    if validator.get("state") != "compatible":
-        raise MigrationSafetyError("compatible document validator is not installed")
-    if snapshot.get("validatorRevision") != validator.get("validatorRevision"):
-        raise MigrationSafetyError("validator revision differs from S1")
-
-    info_before = client.get_database_info(database)
-    security_before = client.get_security(database)
-    leaves, winners = client.get_current_leaf_graph(database)
-    info_after = client.get_database_info(database)
-    security_after = client.get_security(database)
-    before_observation = _database_observation(client, database, info_before)
-    after_observation = _database_observation(client, database, info_after)
-    try:
-        live_target_binding = capture_target_binding(
-            client,
-            database=database,
-            info=info_before,
-            security=security_before,
-            leaves=leaves,
-            winners=winners,
-        )
-    except ContractOpsSafetyError as error:
-        raise MigrationSafetyError("live target binding is invalid") from error
-    snapshot_target_binding = snapshot.get("targetBinding", {})
-    if (
-        before_observation != after_observation
-        or security_checksum(security_before) != snapshot.get("securityChecksum")
-        or security_checksum(security_after) != snapshot.get("securityChecksum")
-        or any(
-            live_target_binding.get(key) != snapshot_target_binding.get(key)
-            for key in ("accountChecksum", "databaseName", "partitioned")
-        )
-    ):
-        raise MigrationSafetyError("live database state differs from the complete S1 snapshot")
-    if require_exact_state and live_target_binding != snapshot_target_binding:
-        raise MigrationSafetyError("live database state differs from the complete S1 snapshot")
-    return snapshot, validator
-
-
-def _load_snapshot_leaves(snapshot_path: str | Path) -> list[dict[str, Any]]:
-    leaf_path = Path(snapshot_path).resolve() / "leaf-graph.ndjson"
-    try:
-        return [
-            json.loads(line)
-            for line in leaf_path.read_text(encoding="utf-8").splitlines()
-            if line
-        ]
-    except (OSError, json.JSONDecodeError) as error:
-        raise MigrationSafetyError("S1 leaf graph is unreadable") from error
-
-
-def _snapshot_winners(
-    snapshot: Mapping[str, Any], leaves: Sequence[Mapping[str, Any]]
-) -> list[dict[str, Any]]:
-    by_identity = {
-        (leaf.get("_id"), leaf.get("_rev")): leaf
-        for leaf in leaves
-    }
-    if len(by_identity) != len(leaves):
-        raise MigrationSafetyError("S1 leaf graph contains duplicate identities")
-    winners = []
-    for document_id, revision in snapshot.get("winnerRevisions", {}).items():
-        if document_id == "_design/fortudo-document-contract":
-            continue
-        winner = by_identity.get((document_id, revision))
-        if winner is None:
-            raise MigrationSafetyError("S1 winner body is missing from the leaf graph")
-        body = copy.deepcopy(dict(winner))
-        body.pop("_revisions", None)
-        conflicts = sorted(
-            str(leaf.get("_rev"))
-            for leaf in leaves
-            if leaf.get("_id") == document_id
-            and leaf.get("_rev") != revision
-            and not leaf.get("_deleted")
-        )
-        if conflicts:
-            body["_conflicts"] = conflicts
-        winners.append(body)
-    return winners
-
-
-def _validate_resume_state_against_s1(
-    client: Any,
-    *,
-    database: str,
-    snapshot: Mapping[str, Any],
-    snapshot_leaves: Sequence[Mapping[str, Any]],
-    journal: Mapping[str, Any],
-) -> None:
-    live_leaves, live_winners = _read_stable_leaf_graph(client, database)
-    classifications = [
-        _classify_journal_entry(live_leaves, live_winners, entry)
-        for entry in journal["entries"]
-    ]
-    if "divergent" in classifications:
-        raise MigrationSafetyError("journaled resume state diverges from S1")
-
-    source_by_identity = {
-        (leaf.get("_id"), leaf.get("_rev")): leaf for leaf in snapshot_leaves
-    }
-    live_by_identity = {
-        (leaf.get("_id"), leaf.get("_rev")): leaf for leaf in live_leaves
-    }
-    if len(source_by_identity) != len(snapshot_leaves) or len(live_by_identity) != len(live_leaves):
-        raise MigrationSafetyError("resume leaf graph contains duplicate identities")
-
-    journal_pre_identities = {
-        (entry["documentId"], entry["preRevision"]) for entry in journal["entries"]
-    }
-    expected_identities = set(source_by_identity) - journal_pre_identities
-    expected_winners = dict(snapshot.get("winnerRevisions", {}))
-
-    for entry, state in zip(journal["entries"], classifications, strict=True):
-        pre_identity = (entry["documentId"], entry["preRevision"])
-        if pre_identity not in source_by_identity:
-            raise MigrationSafetyError("journal pre-revision is absent from S1")
-        if state == "locked-pre-state":
-            expected_identities.add(pre_identity)
-            continue
-
-        intended = entry["intendedBody"]
-        matching = [leaf for leaf in live_leaves if leaf.get("_id") == entry["documentId"]]
-        if intended.get("_deleted"):
-            candidates = [
-                leaf
-                for leaf in matching
-                if leaf.get("_deleted")
-                and _is_direct_successor(leaf, entry["preRevision"])
-            ]
-        else:
-            winner_revision = live_winners.get(entry["documentId"])
-            candidates = [
-                leaf
-                for leaf in matching
-                if leaf.get("_rev") == winner_revision
-                and _is_direct_successor(leaf, entry["preRevision"])
-                and _without_revision(leaf) == _without_revision(intended)
-            ]
-        if len(candidates) != 1:
-            raise MigrationSafetyError("journal intended successor is not unique")
-        successor = candidates[0]
-        expected_identities.add((successor["_id"], successor["_rev"]))
-        if not intended.get("_deleted"):
-            expected_winners[entry["documentId"]] = successor["_rev"]
-
-    if set(live_by_identity) != expected_identities or dict(live_winners) != expected_winners:
-        raise MigrationSafetyError("journaled resume state contains unrelated changes")
-    unchanged_identities = set(source_by_identity) - journal_pre_identities
-    if any(
-        _canonical_json(live_by_identity[identity])
-        != _canonical_json(source_by_identity[identity])
-        for identity in unchanged_identities
-    ):
-        raise MigrationSafetyError("unchanged S1 leaf body differs during resume")
-
-
-def apply_migration(
-    client: Any,
-    *,
-    database: str,
-    expected_update_seq: str,
-    confirmation: str,
-    snapshot_path: str | Path,
-    journal_path: str | Path | None = None,
-    timestamp: str | None = None,
-) -> MigrationResult:
-    _ensure_exact_database(database)
-    if confirmation != database:
-        raise MigrationSafetyError("typed database confirmation did not match")
-    is_resume = journal_path is not None
-    info = client.get_database_info(database)
-    _validate_database_info(database, info)
-    if not is_resume and info["update_seq"] != expected_update_seq:
-        raise MigrationSafetyError("update_seq changed after the dry-run")
-
-    snapshot, validator = _validate_snapshot_and_fence(
-        client,
-        database=database,
-        expected_update_seq=expected_update_seq,
-        snapshot_path=snapshot_path,
-        require_exact_state=not is_resume,
-    )
-    snapshot_leaves = _load_snapshot_leaves(snapshot_path)
-    winners = _snapshot_winners(snapshot, snapshot_leaves)
-
-    plan = build_migration_plan(winners)
-    if plan.running_timer_present:
-        raise MigrationSafetyError("running timer must be stopped before production migration")
-
-    live_winners = client.get_all_documents(database, include_conflicts=True)
-    existing_completion = next(
-        (row for row in live_winners if row.get("_id") == MIGRATION_COMPLETION_ID), None
-    )
-    if existing_completion is not None:
-        raise MigrationSafetyError("completion marker already exists; manual verification is required")
-
-    writes = sorted(
-        [*plan.updates, *plan.conflict_tombstones],
-        key=lambda document: (
-            str(document.get("_id")),
-            bool(document.get("_deleted")),
-            str(document.get("_rev")),
-        ),
-    )
-    if journal_path is None:
-        journal_path = create_migration_journal(
-            writes,
-            Path(snapshot_path).resolve().parent,
-            timestamp=timestamp,
-        )
-    journal = _load_migration_journal(journal_path)
-    if [entry["intendedBody"] for entry in journal["entries"]] != writes:
-        raise MigrationSafetyError("migration journal does not match the current dry-run")
-    if is_resume:
-        _validate_resume_state_against_s1(
-            client,
-            database=database,
-            snapshot=snapshot,
-            snapshot_leaves=snapshot_leaves,
-            journal=journal,
-        )
-    else:
-        # Recheck immediately before the first production mutation. Creating the
-        # local journal cannot change Cloudant state.
-        _validate_snapshot_and_fence(
-            client,
-            database=database,
-            expected_update_seq=expected_update_seq,
-            snapshot_path=snapshot_path,
-            require_exact_state=True,
-        )
-    apply_or_resume_journal(client, database=database, journal_path=journal_path)
-    _validate_resume_state_against_s1(
-        client,
-        database=database,
-        snapshot=snapshot,
-        snapshot_leaves=snapshot_leaves,
-        journal=journal,
-    )
-    snapshot, validator = _validate_snapshot_and_fence(
-        client,
-        database=database,
-        expected_update_seq=expected_update_seq,
-        snapshot_path=snapshot_path,
-        require_exact_state=False,
-    )
-    post_winners = client.get_all_documents(database, include_conflicts=True)
-    _verify_post_migration(winners, post_winners)
-
-    fingerprint, verified_counts = compute_verified_state_fingerprint(
-        client, database, validator["validatorRevision"]
-    )
-    repeated_fingerprint, repeated_counts = compute_verified_state_fingerprint(
-        client, database, validator["validatorRevision"]
-    )
-    if fingerprint != repeated_fingerprint or verified_counts != repeated_counts:
-        raise MigrationSafetyError("verified state changed before completion")
-
-    # Re-establish the exact S1-derived graph and metadata fence immediately before
-    # fixing the completion intent. A later race is detected by the post-marker checks.
-    _validate_resume_state_against_s1(
-        client,
-        database=database,
-        snapshot=snapshot,
-        snapshot_leaves=snapshot_leaves,
-        journal=journal,
-    )
-    snapshot, validator = _validate_snapshot_and_fence(
-        client,
-        database=database,
-        expected_update_seq=expected_update_seq,
-        snapshot_path=snapshot_path,
-        require_exact_state=False,
-    )
-    locked_fingerprint, locked_counts = compute_verified_state_fingerprint(
-        client, database, validator["validatorRevision"]
-    )
-    if locked_fingerprint != fingerprint or locked_counts != verified_counts:
-        raise MigrationSafetyError("verified state changed before completion")
-
-    completion_fields = {
-        "_id": MIGRATION_COMPLETION_ID,
-        "id": MIGRATION_COMPLETION_ID,
-        "docType": "config",
-        "migration": "taxonomy-identity-v1",
-        "s1SnapshotChecksum": snapshot["manifestChecksum"],
-        "verifiedStateFingerprint": fingerprint,
-        "validatorRevision": validator["validatorRevision"],
-        "counts": plan.counts,
-        "verifiedCounts": verified_counts,
-    }
-    completion_intent_path = Path(journal_path) / "completion-intent.json"
-    if completion_intent_path.exists():
-        existing_intent = _load_completion_intent(completion_intent_path)
-        completed_at = existing_intent["intendedBody"].get("completedAt")
-        if not isinstance(completed_at, str) or not completed_at:
-            raise MigrationSafetyError("completion intent journal is invalid")
-        completion = _apply_writer_contract(
-            {**completion_fields, "completedAt": completed_at}
-        )
-        completion_intent = _completion_intent(completion)
-        if existing_intent != completion_intent:
-            raise MigrationSafetyError("completion intent journal diverges from verified state")
-    else:
-        completion = _apply_writer_contract(
-            {
-                **completion_fields,
-                "completedAt": timestamp or datetime.now(UTC).isoformat(),
-            }
-        )
-        completion_intent = _completion_intent(completion)
-        _write_secure(
-            completion_intent_path,
-            (json.dumps(completion_intent, indent=2, sort_keys=True) + "\n").encode("utf-8"),
-        )
-    marker_result = client.put_document(database, completion)
-    if not marker_result.get("ok") or not isinstance(marker_result.get("rev"), str):
-        raise MigrationSafetyError("completion marker write conflicted or failed")
-    stored_marker = client.get_document(database, MIGRATION_COMPLETION_ID)
-    expected_stored_marker = {**completion, "_rev": marker_result["rev"]}
-    if stored_marker != expected_stored_marker:
-        raise MigrationSafetyError("completion marker reread failed")
-    _validate_snapshot_and_fence(
-        client,
-        database=database,
-        expected_update_seq=expected_update_seq,
-        snapshot_path=snapshot_path,
-        require_exact_state=False,
-    )
-    final_fingerprint, final_counts = compute_verified_state_fingerprint(
-        client, database, validator["validatorRevision"]
-    )
-    if final_fingerprint != fingerprint or final_counts != verified_counts:
-        raise MigrationSafetyError("verified state changed after completion")
-    final_winners = client.get_all_documents(database, include_conflicts=True)
-    final_without_marker = [
-        document for document in final_winners if document.get("_id") != MIGRATION_COMPLETION_ID
-    ]
-    remaining = build_migration_plan(final_without_marker)
-    if remaining.updates or remaining.conflict_tombstones:
-        raise MigrationSafetyError("post-completion invariants are incomplete")
-    return MigrationResult(
-        mode="apply",
-        update_seq=expected_update_seq,
-        counts=plan.counts,
-        backup_path=Path(snapshot_path).resolve(),
-        backup_checksum=snapshot["manifestChecksum"],
-        journal_path=Path(journal_path).resolve(),
-    )
-
-
-def restore_backup(
-    client: Any,
-    *,
-    database: str,
-    expected_update_seq: str,
-    confirmation: str,
-    backup_path: str | Path,
-) -> MigrationResult:
-    raise MigrationSafetyError(
-        "direct production restore is disabled; reconstruct a validator-last quarantine database"
-    )
-
-
 class CloudantClient:
-    """Small standard-library Cloudant client with credential-redacted errors."""
+    """Small read-only Cloudant client with credential-redacted errors."""
 
     def __init__(self, credential_url: str) -> None:
         parsed = urllib.parse.urlsplit(credential_url)
@@ -1379,28 +372,11 @@ class CloudantClient:
         ).decode("ascii")
         self._authorization = f"Basic {token}"
 
-    def get_account_checksum(self) -> str:
-        """Return a credential-free binding for the exact Cloudant account endpoint."""
-        return _sha256_bytes(self._base_url.encode("utf-8"))
-
-    def _request(
-        self,
-        operation: str,
-        path: str,
-        *,
-        method: str = "GET",
-        body: Mapping[str, Any] | None = None,
-    ) -> Any:
-        data = _canonical_json(body).encode("utf-8") if body is not None else None
+    def _request(self, operation: str, path: str) -> Any:
         request = urllib.request.Request(
             f"{self._base_url}/{path.lstrip('/')}",
-            data=data,
-            method=method,
-            headers={
-                "Authorization": self._authorization,
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            method="GET",
+            headers={"Authorization": self._authorization, "Accept": "application/json"},
         )
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
@@ -1413,7 +389,10 @@ class CloudantClient:
             raise MigrationSafetyError(f"Cloudant request failed during {operation}") from None
 
     def get_database_info(self, database: str) -> dict[str, Any]:
-        return self._request("database metadata read", urllib.parse.quote(database, safe=""))
+        payload = self._request("database metadata read", urllib.parse.quote(database, safe=""))
+        if not isinstance(payload, Mapping):
+            raise MigrationSafetyError("Cloudant returned an invalid database metadata response")
+        return dict(payload)
 
     def get_all_documents(self, database: str, *, include_conflicts: bool) -> list[dict[str, Any]]:
         query = "include_docs=true"
@@ -1423,91 +402,49 @@ class CloudantClient:
             "winning document read",
             f"{urllib.parse.quote(database, safe='')}/_all_docs?{query}",
         )
-        return [row["doc"] for row in payload.get("rows", []) if row.get("doc")]
-
-    def get_revision(self, database: str, document_id: str, revision: str) -> dict[str, Any]:
-        path = (
-            f"{urllib.parse.quote(database, safe='')}/"
-            f"{urllib.parse.quote(document_id, safe='')}?rev={urllib.parse.quote(revision, safe='')}"
-        )
-        return self._request("conflict leaf read", path)
-
-    def get_document(self, database: str, document_id: str) -> dict[str, Any] | None:
-        path = f"{urllib.parse.quote(database, safe='')}/{urllib.parse.quote(document_id, safe='')}"
-        try:
-            return self._request("document revision read", path)
-        except MigrationSafetyError as error:
-            if "HTTP 404" in str(error):
-                return None
-            raise
-
-    def get_current_leaf_graph(
-        self, database: str
-    ) -> tuple[list[dict[str, Any]], dict[str, str]]:
-        encoded = urllib.parse.quote(database, safe="")
-        changes = self._request(
-            "verified leaf inventory", f"{encoded}/_changes?since=0&style=all_docs"
-        )
-        leaves: list[dict[str, Any]] = []
-        for row in changes.get("results", []):
-            document_id = row.get("id")
-            if not isinstance(document_id, str) or document_id.startswith("_local/"):
-                continue
-            for item in row.get("changes", []):
-                revision = item.get("rev")
-                path = (
-                    f"{encoded}/{urllib.parse.quote(document_id, safe='')}?"
-                    f"rev={urllib.parse.quote(revision, safe='')}&revs=true&attachments=true"
+        if not isinstance(payload, Mapping) or not isinstance(payload.get("rows"), list):
+            raise MigrationSafetyError("Cloudant returned an invalid winning document response")
+        documents: list[dict[str, Any]] = []
+        for row in payload["rows"]:
+            if not isinstance(row, Mapping):
+                raise MigrationSafetyError(
+                    "Cloudant returned an invalid winning document response"
                 )
-                leaves.append(self._request("verified leaf read", path))
-        winner_payload = self._request("verified winner read", f"{encoded}/_all_docs")
-        winners = {
-            row["id"]: row["value"]["rev"]
-            for row in winner_payload.get("rows", [])
-            if isinstance(row.get("value", {}).get("rev"), str)
-        }
-        return leaves, winners
+            document = row.get("doc")
+            if document is None:
+                continue
+            if not isinstance(document, Mapping):
+                raise MigrationSafetyError(
+                    "Cloudant returned an invalid winning document response"
+                )
+            documents.append(dict(document))
+        return documents
 
-    def put_document(self, database: str, document: Mapping[str, Any]) -> dict[str, Any]:
-        return self._request(
-            "guarded single document write",
-            f"{urllib.parse.quote(database, safe='')}/"
-            f"{urllib.parse.quote(str(document['_id']), safe='')}",
-            method="PUT",
-            body=document,
-        )
 
-    def bulk_docs(self, database: str, documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return self._request(
-            "guarded bulk write",
-            f"{urllib.parse.quote(database, safe='')}/_bulk_docs",
-            method="POST",
-            body={"docs": documents},
-        )
+def _validate_database_info(database: str, database_info: Mapping[str, Any]) -> None:
+    _ensure_exact_database(database)
+    if database_info.get("db_name") != database:
+        raise MigrationSafetyError("Cloudant reported a different database name")
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--database", required=True)
-    parser.add_argument("--backup-root")
-    parser.add_argument("--s1-snapshot")
-    parser.add_argument("--journal")
-    parser.add_argument("--expected-update-seq")
-    parser.add_argument("--confirm-database")
-    modes = parser.add_mutually_exclusive_group()
-    modes.add_argument("--apply", action="store_true")
     return parser
 
 
-def _safe_report(result: MigrationResult, *, running_timer_present: bool = False) -> None:
-    report = {
-        "mode": result.mode,
-        "counts": result.counts,
-        "runningTimerPresent": running_timer_present,
-    }
-    if result.backup_path is not None:
-        report["s1SnapshotChecksum"] = result.backup_checksum
-    print(json.dumps(report, indent=2, sort_keys=True))
+def _safe_report(result: MigrationResult, *, running_timer_present: bool) -> None:
+    print(
+        json.dumps(
+            {
+                "mode": result.mode,
+                "counts": result.counts,
+                "runningTimerPresent": running_timer_present,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 def execute(
@@ -1525,28 +462,11 @@ def execute(
             f"required credential environment variable {CREDENTIAL_ENV_VAR} is unset"
         )
     client = client_factory(credential_url)
-
-    if args.apply:
-        if not args.expected_update_seq or not args.confirm_database or not args.s1_snapshot:
-            raise MigrationSafetyError(
-                "apply requires --expected-update-seq, --confirm-database, and --s1-snapshot"
-            )
-        result = apply_migration(
-            client,
-            database=args.database,
-            expected_update_seq=args.expected_update_seq,
-            confirmation=args.confirm_database,
-            snapshot_path=args.s1_snapshot,
-            journal_path=args.journal,
-        )
-        _safe_report(result)
-        return result
-
     info = client.get_database_info(args.database)
     _validate_database_info(args.database, info)
     winners = client.get_all_documents(args.database, include_conflicts=True)
     plan = build_migration_plan(winners)
-    result = MigrationResult(mode="dry-run", update_seq=info["update_seq"], counts=plan.counts)
+    result = MigrationResult(mode="dry-run", counts=plan.counts)
     _safe_report(result, running_timer_present=plan.running_timer_present)
     return result
 

--- a/scripts/migrate_taxonomy_identity.py
+++ b/scripts/migrate_taxonomy_identity.py
@@ -12,6 +12,7 @@ import base64
 import copy
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -21,7 +22,6 @@ from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Sequence
 
 
-EXPECTED_DATABASE_NAME = "fortudo-dat-411"
 CREDENTIAL_ENV_VAR = "FORTUDO_CLOUDANT_URL"
 TAXONOMY_DOCUMENT_ID = "config-categories"
 RUNNING_ACTIVITY_ID = "config-running-activity"
@@ -66,11 +66,9 @@ def _document_kind(document: Mapping[str, Any]) -> str:
     return "unknown"
 
 
-def _ensure_exact_database(database: str) -> None:
-    if database != EXPECTED_DATABASE_NAME:
-        raise MigrationSafetyError(
-            f'unexpected database name; expected exactly "{EXPECTED_DATABASE_NAME}"'
-        )
+def _ensure_fortudo_database(database: str) -> None:
+    if not re.fullmatch(r"fortudo-[a-z0-9][a-z0-9-]*", database):
+        raise MigrationSafetyError("database name is outside the Fortudo namespace")
 
 
 def _find_taxonomy_document(documents: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
@@ -422,7 +420,7 @@ class CloudantClient:
 
 
 def _validate_database_info(database: str, database_info: Mapping[str, Any]) -> None:
-    _ensure_exact_database(database)
+    _ensure_fortudo_database(database)
     if database_info.get("db_name") != database:
         raise MigrationSafetyError("Cloudant reported a different database name")
 
@@ -454,7 +452,7 @@ def execute(
     client_factory: Callable[[str], Any] = CloudantClient,
 ) -> MigrationResult:
     args = _parser().parse_args(argv)
-    _ensure_exact_database(args.database)
+    _ensure_fortudo_database(args.database)
     environment = os.environ if environ is None else environ
     credential_url = environment.get(CREDENTIAL_ENV_VAR)
     if not credential_url:

--- a/tests/test_document_contract_ops.py
+++ b/tests/test_document_contract_ops.py
@@ -1,9 +1,8 @@
-"""Safety gates for document-contract provisioning and complete-leaf snapshots."""
+"""Tests for the intentionally read-only document-contract inspector."""
 
 from __future__ import annotations
 
 import copy
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -13,7 +12,17 @@ import pytest
 from scripts import document_contract_ops as ops
 
 
-def test_runbook_direct_cli_entry_point_loads_from_any_working_directory(tmp_path) -> None:
+class ReadOnlyCloudant:
+    def __init__(self, document: dict | None = None) -> None:
+        self.document = copy.deepcopy(document)
+        self.reads: list[tuple[str, str]] = []
+
+    def get_document(self, database: str, document_id: str) -> dict | None:
+        self.reads.append((database, document_id))
+        return copy.deepcopy(self.document)
+
+
+def test_direct_cli_exposes_only_validator_verification(tmp_path: Path) -> None:
     script = Path(ops.__file__).resolve()
 
     result = subprocess.run(
@@ -25,608 +34,171 @@ def test_runbook_direct_cli_entry_point_loads_from_any_working_directory(tmp_pat
     )
 
     assert result.returncode == 0, result.stderr
-    assert "inventory" in result.stdout
-    assert "restore-quarantine" in result.stdout
+    assert "verify" in result.stdout
+    for retired_mode in ("inventory", "snapshot", "install", "provision", "restore-quarantine"):
+        assert retired_mode not in result.stdout
 
 
-class FakeCloudant:
-    def __init__(self) -> None:
-        self.database = "fortudo-dat-411"
-        self.info = {
-            "db_name": self.database,
-            "update_seq": "10-seq",
-            "doc_count": 2,
-            "doc_del_count": 1,
-            "props": {"partitioned": False},
-        }
-        self.security = {"admins": {"names": []}, "members": {"names": []}}
-        self.leaves = [
-            {
-                "_id": "task-live",
-                "_rev": "2-live",
-                "_revisions": {"start": 2, "ids": ["live", "parent"]},
-                "docType": "task",
-                "private": "never print",
-            },
-            {
-                "_id": "activity-conflict",
-                "_rev": "3-winner",
-                "_revisions": {"start": 3, "ids": ["winner", "p2", "p1"]},
-                "docType": "activity",
-            },
-            {
-                "_id": "activity-conflict",
-                "_rev": "3-loser",
-                "_revisions": {"start": 3, "ids": ["loser", "p2", "p1"]},
-                "docType": "activity",
-            },
-            {
-                "_id": "task-deleted",
-                "_rev": "2-deleted",
-                "_deleted": True,
-                "_revisions": {"start": 2, "ids": ["deleted", "parent"]},
-                "writerContract": {"version": 1},
-            },
-        ]
-        self.winners = {
-            "task-live": "2-live",
-            "activity-conflict": "3-winner",
-            "task-deleted": "2-deleted",
-        }
-        self.created: list[str] = []
-        self.write_order: list[str] = []
-        self.account_checksum = "a" * 64
+def test_retired_backup_and_mutation_entry_points_are_absent() -> None:
+    for retired_name in (
+        "create_inventory",
+        "create_snapshot",
+        "verify_snapshot",
+        "install_validator",
+        "provision_database",
+        "restore_quarantine",
+    ):
+        assert not hasattr(ops, retired_name)
 
-    def get_account_checksum(self) -> str:
-        return self.account_checksum
-
-    def list_databases(self) -> list[str]:
-        return [self.database, "fortudo-family", "system-database"]
-
-    def get_database_info(self, database: str) -> dict:
-        result = copy.deepcopy(self.info)
-        result["db_name"] = database
-        return result
-
-    def get_security(self, database: str) -> dict:
-        return copy.deepcopy(self.security)
-
-    def put_security(self, database: str, security: dict) -> None:
-        self.write_order.append("_security")
-        self.security = copy.deepcopy(security)
-
-    def get_current_leaf_graph(self, database: str) -> tuple[list[dict], dict[str, str]]:
-        return copy.deepcopy(self.leaves), copy.deepcopy(self.winners)
-
-    def get_document(self, database: str, document_id: str) -> dict | None:
-        return next(
-            (copy.deepcopy(leaf) for leaf in self.leaves if leaf["_id"] == document_id),
-            None,
-        )
-
-    def put_document(self, database: str, document: dict) -> dict:
-        self.write_order.append(document["_id"])
-        stored = copy.deepcopy(document)
-        stored["_rev"] = "1-contract"
-        self.leaves = [leaf for leaf in self.leaves if leaf["_id"] != document["_id"]]
-        self.leaves.append(stored)
-        self.winners[document["_id"]] = stored["_rev"]
-        self.info["update_seq"] = "11-seq"
-        self.info["doc_count"] += 1
-        return {"ok": True, "id": document["_id"], "rev": stored["_rev"]}
-
-    def create_database(self, database: str) -> None:
-        self.created.append(database)
-        self.database = database
-        self.info = {
-            "db_name": database,
-            "update_seq": "0-seq",
-            "doc_count": 0,
-            "doc_del_count": 0,
-            "props": {"partitioned": False},
-        }
-        self.leaves = []
-        self.winners = {}
-
-    def bulk_docs_new_edits_false(self, database: str, documents: list[dict]) -> None:
-        self.write_order.extend(document["_id"] for document in documents)
-        self.leaves.extend(copy.deepcopy(documents))
-        for document in documents:
-            self.winners.setdefault(document["_id"], document["_rev"])
-        self.info["doc_count"] = len(self.winners)
-        self.info["update_seq"] = "restored-seq"
+    for retired_method in (
+        "create_database",
+        "delete_database",
+        "put_document",
+        "put_security",
+        "bulk_docs_new_edits_false",
+    ):
+        assert not hasattr(ops.ContractOpsCloudantClient, retired_method)
 
 
-def test_design_document_source_and_checksum_match_the_browser_contract():
-    design = ops.load_design_document()
+def test_design_document_source_and_declared_checksum_match_browser_contract() -> None:
+    document = ops.load_design_document()
+    metadata = document["fortudoDocumentContract"]
 
-    assert design["_id"] == "_design/fortudo-document-contract"
-    assert design["fortudoDocumentContract"] == {
-        "version": 1,
-        "checksum": "c0bf4717ff74c9daa32b850b059df95a45f2156b3491c91f5c658990c0e26a75",
+    assert document["_id"] == ops.CONTRACT_DESIGN_ID
+    assert document["language"] == "javascript"
+    assert metadata == {
+        "version": ops.CONTRACT_VERSION,
+        "checksum": ops.CONTRACT_CHECKSUM,
     }
-    assert "FDC_CONTRACT_VERSION" in design["validate_doc_update"]
-
-
-def test_snapshot_captures_complete_leaf_graph_security_and_stable_winners(tmp_path):
-    client = FakeCloudant()
-
-    result = ops.create_snapshot(
-        client,
-        database=client.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-
-    manifest = ops.verify_snapshot(result.path)
-    assert manifest["label"] == "S0"
-    assert manifest["formatVersion"] == 2
-    assert manifest["leafCount"] == 4
-    assert manifest["winnerCount"] == 3
-    assert "databaseUuid" not in manifest
-    assert manifest["targetBinding"]["accountChecksum"] == "a" * 64
-    assert manifest["targetBinding"]["databaseName"] == "fortudo-dat-411"
-    assert len(manifest["targetBinding"]["checksum"]) == 64
-    assert manifest["securityChecksum"] == ops.security_checksum(client.security)
-    assert manifest["manifestChecksum"] == result.checksum
-    leaf_text = (result.path / "leaf-graph.ndjson").read_text(encoding="utf-8")
-    assert "never print" in leaf_text
-    metadata = json.loads((result.path / "database-metadata.json").read_text(encoding="utf-8"))
-    assert "databaseUuid" not in metadata
-
-
-def test_target_binding_is_semantic_and_independent_of_leaf_enumeration_order():
-    client = FakeCloudant()
-    leaves, winners = client.get_current_leaf_graph(client.database)
-    info = client.get_database_info(client.database)
-
-    first = ops.capture_target_binding(
-        client,
-        database=client.database,
-        info=info,
-        security=client.security,
-        leaves=leaves,
-        winners=winners,
-    )
-    second = ops.capture_target_binding(
-        client,
-        database=client.database,
-        info=info,
-        security=client.security,
-        leaves=list(reversed(leaves)),
-        winners=dict(reversed(list(winners.items()))),
-    )
-
-    assert first == second
-
-
-def test_snapshot_deletes_incomplete_output_and_halts_on_leaf_drift(tmp_path):
-    class DriftingCloudant(FakeCloudant):
-        reads = 0
-
-        def get_current_leaf_graph(self, database: str):
-            leaves, winners = super().get_current_leaf_graph(database)
-            self.reads += 1
-            if self.reads == 2:
-                leaves[0]["_rev"] = "3-concurrent"
-            return leaves, winners
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="changed during snapshot"):
-        ops.create_snapshot(
-            DriftingCloudant(),
-            database="fortudo-dat-411",
-            backup_root=tmp_path,
-            label="S0",
-            encrypted_volume_confirmed=True,
-            timestamp="20260721T120000Z",
-        )
-
-    assert list(tmp_path.iterdir()) == []
-
-
-def test_snapshot_halts_if_the_cloudant_account_binding_changes_during_capture(tmp_path):
-    class AccountDriftCloudant(FakeCloudant):
-        account_reads = 0
-
-        def get_account_checksum(self) -> str:
-            self.account_reads += 1
-            return ("a" if self.account_reads == 1 else "b") * 64
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="changed during snapshot"):
-        ops.create_snapshot(
-            AccountDriftCloudant(),
-            database="fortudo-dat-411",
-            backup_root=tmp_path,
-            label="S0",
-            encrypted_volume_confirmed=True,
-            timestamp="20260721T120000Z",
-        )
-
-    assert list(tmp_path.iterdir()) == []
-
-
-def test_install_requires_locked_snapshot_and_changes_only_the_design_leaf(tmp_path):
-    client = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        client,
-        database=client.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-
-    result = ops.install_validator(
-        client,
-        database=client.database,
-        confirmation=client.database,
-        expected_target_binding_checksum=ops.verify_snapshot(snapshot.path)[
-            "targetBinding"
-        ]["checksum"],
-        snapshot_path=snapshot.path,
-    )
-
-    assert result["validatorRevision"] == "1-contract"
-    assert client.write_order == ["_design/fortudo-document-contract"]
-    assert ops.verify_validator(client, client.database)["state"] == "compatible"
-
-
-@pytest.mark.parametrize("drift", ["account", "security", "body", "winner"])
-def test_install_rejects_any_state_outside_the_locked_target_binding(tmp_path, drift):
-    client = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        client,
-        database=client.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-    manifest = ops.verify_snapshot(snapshot.path)
-
-    if drift == "account":
-        client.account_checksum = "b" * 64
-    elif drift == "security":
-        client.security["members"]["names"] = ["changed"]
-    elif drift == "body":
-        client.leaves[0]["private"] = "changed under the same revision"
-    else:
-        client.winners["activity-conflict"] = "3-loser"
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="locked snapshot"):
-        ops.install_validator(
-            client,
-            database=client.database,
-            confirmation=client.database,
-            expected_target_binding_checksum=manifest["targetBinding"]["checksum"],
-            snapshot_path=snapshot.path,
-        )
-
-    assert client.write_order == []
-
-
-def test_provision_is_empty_database_and_validator_first():
-    client = FakeCloudant()
-
-    result = ops.provision_database(
-        client,
-        database="fortudo-new-room",
-        confirmation="fortudo-new-room",
-        expected_account_checksum="a" * 64,
-    )
-
-    assert client.created == ["fortudo-new-room"]
-    assert client.write_order == ["_design/fortudo-document-contract"]
-    assert result["targetAccountChecksum"] == "a" * 64
-
-
-def test_provision_rejects_the_wrong_account_before_database_creation():
-    client = FakeCloudant()
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="approved Cloudant account"):
-        ops.provision_database(
-            client,
-            database="fortudo-new-room",
-            confirmation="fortudo-new-room",
-            expected_account_checksum="b" * 64,
-        )
-
-    assert client.created == []
-
-
-def test_quarantine_restore_loads_legacy_leaves_before_validator(tmp_path):
-    source = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        source,
-        database=source.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-    target = FakeCloudant()
-    target.write_order.clear()
-
-    ops.restore_quarantine(
-        target,
-        database="fortudo-quarantine-20260721",
-        confirmation="fortudo-quarantine-20260721",
-        expected_account_checksum="a" * 64,
-        snapshot_path=snapshot.path,
-    )
-
-    assert target.created == ["fortudo-quarantine-20260721"]
-    assert target.write_order[-2:] == ["_design/fortudo-document-contract", "_security"]
-    assert "task-live" in target.write_order[:-2]
-    assert target.security == source.security
-
-
-def test_quarantine_restore_halts_before_validator_when_leaf_reconstruction_differs(tmp_path):
-    source = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        source,
-        database=source.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-
-    class CorruptingTarget(FakeCloudant):
-        def bulk_docs_new_edits_false(self, database: str, documents: list[dict]) -> None:
-            super().bulk_docs_new_edits_false(database, documents)
-            self.leaves[0]["private"] = "corrupted"
-
-    target = CorruptingTarget()
-    target.write_order.clear()
-    with pytest.raises(ops.ContractOpsSafetyError, match="reconstruction verification"):
-        ops.restore_quarantine(
-            target,
-            database="fortudo-quarantine-20260721",
-            confirmation="fortudo-quarantine-20260721",
-            expected_account_checksum="a" * 64,
-            snapshot_path=snapshot.path,
-        )
-
-    assert "_design/fortudo-document-contract" not in target.write_order
-
-
-def test_quarantine_restore_rejects_snapshot_from_an_unapproved_account_before_creation(
-    tmp_path,
-):
-    source = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        source,
-        database=source.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-    target = FakeCloudant()
-    target.account_checksum = "b" * 64
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="snapshot Cloudant account"):
-        ops.restore_quarantine(
-            target,
-            database="fortudo-quarantine-20260721",
-            confirmation="fortudo-quarantine-20260721",
-            expected_account_checksum="b" * 64,
-            snapshot_path=snapshot.path,
-        )
-
-    assert target.created == []
-
-
-def test_quarantine_restore_rejects_wrong_active_account_before_database_creation(tmp_path):
-    source = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        source,
-        database=source.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-    target = FakeCloudant()
-    target.account_checksum = "b" * 64
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="approved Cloudant account"):
-        ops.restore_quarantine(
-            target,
-            database="fortudo-quarantine-20260721",
-            confirmation="fortudo-quarantine-20260721",
-            expected_account_checksum="a" * 64,
-            snapshot_path=snapshot.path,
-        )
-
-    assert target.created == []
-
-
-def test_inventory_writes_private_manifest_but_returns_only_aggregates(tmp_path):
-    client = FakeCloudant()
-
-    result = ops.create_inventory(
-        client,
-        manifest_root=tmp_path,
-        encrypted_volume_confirmed=True,
-        timestamp="20260721T120000Z",
-    )
-
-    assert result.counts == {"fortudoDatabases": 2, "compatible": 0, "missingValidator": 2}
-    assert len(result.checksum) == 64
-    assert result.account_checksum == "a" * 64
-    private = json.loads(result.path.read_text(encoding="utf-8"))
-    assert private["accountChecksum"] == "a" * 64
-    assert [row["databaseName"] for row in private["databases"]] == [
-        "fortudo-dat-411",
-        "fortudo-family",
-    ]
-    assert all("databaseUuid" not in row for row in private["databases"])
-    assert all(row["accountChecksum"] == "a" * 64 for row in private["databases"])
-
-
-def test_install_cli_uses_target_binding_and_has_no_uuid_override():
-    parser = ops._parser()
-    commands = parser._subparsers._group_actions[0].choices
-    install_parser = commands["install"]
-    provision_parser = commands["provision"]
-    quarantine_parser = commands["restore-quarantine"]
-    help_text = parser.format_help() + install_parser.format_help()
-
-    assert "--expected-target-binding-checksum" in help_text
-    assert "--expected-account-checksum" in provision_parser.format_help()
-    assert "--expected-account-checksum" in quarantine_parser.format_help()
-    assert "--expected-uuid" not in help_text
-
-
-def test_normal_operational_output_omits_private_targets_revisions_and_paths():
-    report = ops._public_operational_report(
-        {
-            "mode": "inventory",
-            "counts": {"fortudoDatabases": 2},
-            "manifestChecksum": "a" * 64,
-            "manifestPath": "X:/private/manifest.json",
-            "targetBindingChecksum": "b" * 64,
-            "validatorRevision": "1-private",
-        }
-    )
-
-    assert report == {
-        "mode": "inventory",
-        "counts": {"fortudoDatabases": 2},
-        "manifestChecksum": "a" * 64,
-        "targetBindingChecksum": "b" * 64,
-    }
-
-
-def test_encrypted_volume_confirmation_and_exact_target_are_mandatory(tmp_path):
-    client = FakeCloudant()
-    with pytest.raises(ops.ContractOpsSafetyError, match="encrypted user-only volume"):
-        ops.create_snapshot(
-            client,
-            database=client.database,
-            backup_root=tmp_path,
-            label="S0",
-            encrypted_volume_confirmed=False,
-        )
-    with pytest.raises(ops.ContractOpsSafetyError, match="confirmation"):
-        ops.provision_database(
-            client,
-            database="fortudo-new-room",
-            confirmation="wrong",
-            expected_account_checksum="a" * 64,
-        )
-    with pytest.raises(ops.ContractOpsSafetyError, match="unsafe characters"):
-        ops.create_snapshot(
-            client,
-            database=client.database,
-            backup_root=tmp_path,
-            label="../escaped",
-            encrypted_volume_confirmed=True,
-        )
-    assert list(tmp_path.iterdir()) == []
-
-
-def test_temporary_unencrypted_override_is_explicit_and_recorded(tmp_path):
-    client = FakeCloudant()
-
-    snapshot = ops.create_snapshot(
-        client,
-        database=client.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=False,
-        temporary_unencrypted_confirmed=True,
-        timestamp="20260722T170000Z",
-    )
-    manifest = ops.verify_snapshot(snapshot.path)
-
-    assert manifest["backupProtection"] == {
-        "mode": "temporary-unencrypted-user-only-directory",
-        "retention": "delete-after-s3-and-known-client-exercise",
-    }
-
-    inventory = ops.create_inventory(
-        client,
-        manifest_root=tmp_path,
-        encrypted_volume_confirmed=False,
-        temporary_unencrypted_confirmed=True,
-        timestamp="20260722T170001Z",
-    )
-    inventory_manifest = json.loads(inventory.path.read_text(encoding="utf-8"))
-    assert inventory_manifest["backupProtection"] == manifest["backupProtection"]
+    assert document["validate_doc_update"].startswith("function(newDoc, oldDoc)")
 
 
 @pytest.mark.parametrize(
-    "invalid_protection",
+    ("document", "state"),
     [
-        None,
-        {"mode": "unknown"},
-        {
-            "mode": "temporary-unencrypted-user-only-directory",
-            "retention": "keep-indefinitely",
-        },
-        {"mode": "encrypted-user-only-volume", "extra": True},
+        (None, "missing-validator"),
+        ({"_id": ops.CONTRACT_DESIGN_ID, "_rev": "1-wrong"}, "validator-mismatch"),
     ],
 )
-def test_snapshot_verification_rejects_rechecksummed_invalid_backup_protection(
-    tmp_path, invalid_protection
-):
-    client = FakeCloudant()
-    snapshot = ops.create_snapshot(
-        client,
-        database=client.database,
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260722T170000Z",
+def test_verify_validator_classifies_missing_and_mismatched_documents(document, state) -> None:
+    client = ReadOnlyCloudant(document)
+
+    result = ops.verify_validator(client, "fortudo-dat-411")
+
+    assert result["state"] == state
+    assert client.reads == [("fortudo-dat-411", ops.CONTRACT_DESIGN_ID)]
+
+
+def test_verify_validator_accepts_the_exact_design_document() -> None:
+    document = ops.load_design_document()
+    document["_rev"] = "3-compatible"
+
+    result = ops.verify_validator(ReadOnlyCloudant(document), "fortudo-dat-411")
+
+    assert result == {"state": "compatible", "validatorRevision": "3-compatible"}
+
+
+def test_cloudant_document_read_rejects_malformed_payload_without_echoing_it(monkeypatch) -> None:
+    client = ops.ContractOpsCloudantClient("https://user:secret@example.invalid")
+    monkeypatch.setattr(client, "_request", lambda _operation, _path: "private response body")
+
+    with pytest.raises(ops.MigrationSafetyError, match="invalid document response") as error:
+        client.get_document("fortudo-dat-411", ops.CONTRACT_DESIGN_ID)
+
+    assert "private response body" not in str(error.value)
+
+
+def test_execute_requires_credentials_and_performs_only_the_validator_read(capsys) -> None:
+    client = ReadOnlyCloudant()
+
+    result = ops.execute(
+        ["verify", "--database", "fortudo-dat-411"],
+        environ={ops.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+        client_factory=lambda _credential: client,
     )
-    manifest_path = snapshot.path / "manifest.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if invalid_protection is None:
-        manifest.pop("backupProtection")
-    else:
-        manifest["backupProtection"] = invalid_protection
-    manifest["manifestChecksum"] = ops._manifest_checksum(manifest)
-    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    with pytest.raises(ops.ContractOpsSafetyError, match="backup protection"):
-        ops.verify_snapshot(snapshot.path)
+    assert result == {
+        "mode": "verify",
+        "state": "missing-validator",
+        "validatorRevision": None,
+    }
+    assert client.reads == [("fortudo-dat-411", ops.CONTRACT_DESIGN_ID)]
+    output = capsys.readouterr().out
+    assert "secret" not in output
+    assert "fortudo-dat-411" not in output
+    assert "missing-validator" in output
+
+    with pytest.raises(ops.ContractOpsSafetyError, match=ops.CREDENTIAL_ENV_VAR):
+        ops.execute(["verify", "--database", "fortudo-dat-411"], environ={})
 
 
-def test_snapshot_verification_rejects_rechecksummed_target_binding_tamper(tmp_path):
-    snapshot = ops.create_snapshot(
-        FakeCloudant(),
-        database="fortudo-dat-411",
-        backup_root=tmp_path,
-        label="S0",
-        encrypted_volume_confirmed=True,
-        timestamp="20260722T170000Z",
+@pytest.mark.parametrize(
+    "retired_argv",
+    [
+        [
+            "inventory",
+            "--manifest-root",
+            "private",
+            "--confirm-temporary-unencrypted",
+        ],
+        [
+            "snapshot",
+            "--database",
+            "fortudo-dat-411",
+            "--backup-root",
+            "private",
+            "--label",
+            "S0",
+            "--confirm-temporary-unencrypted",
+        ],
+        [
+            "install",
+            "--database",
+            "fortudo-dat-411",
+            "--confirm-database",
+            "fortudo-dat-411",
+            "--expected-target-binding-checksum",
+            "a" * 64,
+            "--snapshot",
+            "private/S0",
+        ],
+        [
+            "provision",
+            "--database",
+            "fortudo-new",
+            "--confirm-database",
+            "fortudo-new",
+            "--expected-account-checksum",
+            "a" * 64,
+        ],
+        [
+            "restore-quarantine",
+            "--database",
+            "fortudo-quarantine",
+            "--confirm-database",
+            "fortudo-quarantine",
+            "--expected-account-checksum",
+            "a" * 64,
+            "--snapshot",
+            "private/S0",
+        ],
+    ],
+)
+def test_parser_rejects_retired_modes(retired_argv) -> None:
+    with pytest.raises(SystemExit):
+        ops._parser().parse_args(retired_argv)
+
+
+def test_main_sanitizes_cloudant_failures(monkeypatch, capsys) -> None:
+    def fail_execute():
+        raise ops.MigrationSafetyError("Cloudant request failed with HTTP 429 during document read")
+
+    monkeypatch.setattr(ops, "execute", fail_execute)
+
+    assert ops.main() == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "Contract operation blocked: Cloudant request failed with HTTP 429 during document read\n"
     )
-    manifest_path = snapshot.path / "manifest.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest["targetBinding"]["scheme"] = "unreviewed-binding"
-    manifest["manifestChecksum"] = ops._manifest_checksum(manifest)
-    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="target binding"):
-        ops.verify_snapshot(snapshot.path)
-
-
-def test_backup_protection_modes_are_mutually_exclusive_for_programmatic_callers(tmp_path):
-    client = FakeCloudant()
-
-    with pytest.raises(ops.ContractOpsSafetyError, match="exactly one"):
-        ops.create_snapshot(
-            client,
-            database=client.database,
-            backup_root=tmp_path,
-            label="S0",
-            encrypted_volume_confirmed=True,
-            temporary_unencrypted_confirmed=True,
-        )
-
-    assert list(tmp_path.iterdir()) == []
+    assert "Traceback" not in captured.err

--- a/tests/test_migrate_taxonomy_identity.py
+++ b/tests/test_migrate_taxonomy_identity.py
@@ -1,25 +1,16 @@
-"""Safety and invariants for the guarded taxonomy identity migration."""
+"""Safety and invariants for the read-only taxonomy identity planner."""
 
 from __future__ import annotations
 
 import copy
-import hashlib
+import io
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from scripts import migrate_taxonomy_identity as migration
-from scripts import document_contract_ops as contract_ops
-
-
-def test_cloudant_account_checksum_excludes_credentials_and_normalizes_host():
-    client = migration.CloudantClient(
-        "https://operator:private@ACCOUNT.example:443/cloudant/"
-    )
-
-    assert client.get_account_checksum() == hashlib.sha256(
-        b"https://account.example:443/cloudant"
-    ).hexdigest()
 
 
 def taxonomy_doc() -> dict:
@@ -29,7 +20,9 @@ def taxonomy_doc() -> dict:
         "id": "config-categories",
         "docType": "config",
         "schemaVersion": "3.5",
-        "groups": [{"key": "work", "label": "Work", "colorFamily": "blue", "color": "#0ea5e9"}],
+        "groups": [
+            {"key": "work", "label": "Work", "colorFamily": "blue", "color": "#0ea5e9"}
+        ],
         "categories": [
             {
                 "key": "work/meetings",
@@ -81,221 +74,216 @@ def production_winners() -> list[dict]:
     ]
 
 
-def losing_leaf() -> dict:
-    return {
-        "_id": "activity-legacy",
-        "_rev": "3-activity-loser",
-        "id": "activity-legacy",
-        "docType": "activity",
-        "description": "private losing text",
-        "category": "work/meetings",
-        "duration": 45,
-    }
-
-
-class FakeCloudant:
-    def __init__(self, *, update_seq: str = "42-seq") -> None:
-        self.update_seq = update_seq
-        self.account_checksum = "a" * 64
-        self.winners = production_winners()
-        self.leaves = {("activity-legacy", "3-activity-loser"): losing_leaf()}
-        self.bulk_calls: list[list[dict]] = []
-        self.put_calls: list[dict] = []
-        self.tombstone_leaves: list[dict] = []
-        self.graph_reads = 0
-        self.security = {"admins": {"names": []}, "members": {"names": []}}
-        self.validator = contract_ops.load_design_document()
-        self.validator["_rev"] = "1-contract"
-        self.revision_ancestries = {
-            (document["_id"], document["_rev"]): [document["_rev"]]
-            for document in [*self.winners, losing_leaf(), self.validator]
-        }
+class ReadOnlyCloudant:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
 
     def get_database_info(self, database: str) -> dict:
-        return {
-            "db_name": database,
-            "update_seq": self.update_seq,
-            "doc_count": len(self.winners),
-            "doc_del_count": 0,
-            "props": {"partitioned": False},
-        }
-
-    def get_account_checksum(self) -> str:
-        return self.account_checksum
+        self.calls.append(("info", database))
+        return {"db_name": database}
 
     def get_all_documents(self, database: str, *, include_conflicts: bool) -> list[dict]:
-        assert include_conflicts is True
-        return copy.deepcopy(self.winners)
-
-    def get_revision(self, database: str, document_id: str, revision: str) -> dict:
-        return copy.deepcopy(self.leaves[(document_id, revision)])
-
-    def get_document(self, database: str, document_id: str) -> dict | None:
-        if document_id == contract_ops.CONTRACT_DESIGN_ID:
-            return copy.deepcopy(self.validator)
-        return copy.deepcopy(next((d for d in self.winners if d["_id"] == document_id), None))
-
-    def get_security(self, database: str) -> dict:
-        return copy.deepcopy(self.security)
-
-    def get_current_leaf_graph(self, database: str) -> tuple[list[dict], dict[str, str]]:
-        self.graph_reads += 1
-        leaves = [
-            {key: copy.deepcopy(value) for key, value in winner.items() if key != "_conflicts"}
-            for winner in self.winners
-        ]
-        leaves.extend(copy.deepcopy(list(self.leaves.values())))
-        leaves.extend(copy.deepcopy(self.tombstone_leaves))
-        leaves.append(copy.deepcopy(self.validator))
-        for leaf in leaves:
-            ancestry = self.revision_ancestries.get(
-                (leaf["_id"], leaf["_rev"]), [leaf["_rev"]]
-            )
-            leaf["_revisions"] = {
-                "start": int(ancestry[0].split("-", 1)[0]),
-                "ids": [revision.split("-", 1)[1] for revision in ancestry],
-            }
-        winners = {document["_id"]: document["_rev"] for document in self.winners}
-        winners[self.validator["_id"]] = self.validator["_rev"]
-        return leaves, winners
-
-    def put_document(self, database: str, document: dict) -> dict:
-        self.put_calls.append(copy.deepcopy(document))
-        stored = copy.deepcopy(document)
-        stored["_rev"] = "1-completion"
-        self.winners.append(stored)
-        self.revision_ancestries[(stored["_id"], stored["_rev"])] = [stored["_rev"]]
-        return {"ok": True, "id": document["_id"], "rev": stored["_rev"]}
-
-    def bulk_docs(self, database: str, documents: list[dict]) -> list[dict]:
-        self.bulk_calls.append(copy.deepcopy(documents))
-        results = []
-        for index, document in enumerate(documents):
-            document_id = document["_id"]
-            pre_revision = document["_rev"]
-            generation = int(pre_revision.split("-", 1)[0]) + 1
-            new_revision = f"{generation}-next{len(self.bulk_calls)}{index}"
-            if document.get("_deleted"):
-                winner = next(d for d in self.winners if d["_id"] == document_id)
-                winner["_conflicts"] = [
-                    revision
-                    for revision in winner.get("_conflicts", [])
-                    if revision != document["_rev"]
-                ]
-                if not winner["_conflicts"]:
-                    winner.pop("_conflicts")
-                self.leaves.pop((document_id, pre_revision), None)
-                tombstone = copy.deepcopy(document)
-                tombstone["_rev"] = new_revision
-                self.tombstone_leaves.append(tombstone)
-            else:
-                stored = copy.deepcopy(document)
-                stored["_rev"] = new_revision
-                stored.pop("_conflicts", None)
-                winner_index = next(
-                    (
-                        row_index
-                        for row_index, winner in enumerate(self.winners)
-                        if winner["_id"] == document_id
-                    ),
-                    None,
-                )
-                if winner_index is None:
-                    self.winners.append(stored)
-                else:
-                    self.winners[winner_index] = stored
-            parent_ancestry = self.revision_ancestries[(document_id, pre_revision)]
-            self.revision_ancestries[(document_id, new_revision)] = [
-                new_revision,
-                *parent_ancestry,
-            ]
-            results.append({"id": document_id, "ok": True, "rev": new_revision})
-        return results
+        self.calls.append(("documents", database, include_conflicts))
+        return copy.deepcopy(production_winners())
 
 
-def create_s1_snapshot(client: FakeCloudant, root: Path, suffix: str = "120000") -> Path:
-    return contract_ops.create_snapshot(
-        client,
-        database=migration.EXPECTED_DATABASE_NAME,
-        backup_root=root,
-        label="S1",
-        encrypted_volume_confirmed=True,
-        timestamp=f"20260721T{suffix}Z",
-    ).path
+def test_cloudant_transport_issues_get_requests_only(monkeypatch) -> None:
+    methods: list[str] = []
+
+    class Response(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+
+    def open_request(request, *, timeout):
+        assert timeout == 60
+        methods.append(request.get_method())
+        payload = (
+            b'{"db_name":"fortudo-dat-411"}'
+            if request.full_url.endswith("fortudo-dat-411")
+            else b'{"rows":[]}'
+        )
+        return Response(payload)
+
+    monkeypatch.setattr(migration.urllib.request, "urlopen", open_request)
+    client = migration.CloudantClient("https://user:secret@example.invalid")
+
+    client.get_database_info(migration.EXPECTED_DATABASE_NAME)
+    client.get_all_documents(migration.EXPECTED_DATABASE_NAME, include_conflicts=True)
+
+    assert methods == ["GET", "GET"]
 
 
-def test_dry_run_is_default_and_never_writes_or_creates_a_backup(tmp_path, capsys):
-    client = FakeCloudant()
+@pytest.mark.parametrize(
+    ("operation", "payload", "message"),
+    [
+        ("info", ["private"], "invalid database metadata response"),
+        ("documents", {"rows": "private"}, "invalid winning document response"),
+        ("documents", {"rows": [{"doc": "private"}]}, "invalid winning document response"),
+    ],
+)
+def test_cloudant_reads_reject_malformed_payloads_without_echoing_them(
+    monkeypatch, operation, payload, message
+) -> None:
+    client = migration.CloudantClient("https://user:secret@example.invalid")
+    monkeypatch.setattr(client, "_request", lambda _operation, _path: payload)
+
+    with pytest.raises(migration.MigrationSafetyError, match=message) as error:
+        if operation == "info":
+            client.get_database_info(migration.EXPECTED_DATABASE_NAME)
+        else:
+            client.get_all_documents(migration.EXPECTED_DATABASE_NAME, include_conflicts=True)
+
+    assert "private" not in str(error.value)
+
+
+def test_direct_cli_is_dry_run_only_from_any_working_directory(tmp_path: Path) -> None:
+    script = Path(migration.__file__).resolve()
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--database" in result.stdout
+    for retired_flag in (
+        "--apply",
+        "--backup-root",
+        "--s1-snapshot",
+        "--journal",
+        "--expected-update-seq",
+        "--confirm-database",
+    ):
+        assert retired_flag not in result.stdout
+
+
+def test_retired_backup_restore_and_write_entry_points_are_absent() -> None:
+    for retired_name in (
+        "create_backup",
+        "verify_backup",
+        "apply_migration",
+        "restore_backup",
+        "write_completion_marker",
+        "compute_verified_state_fingerprint",
+    ):
+        assert not hasattr(migration, retired_name)
+
+    for retired_method in (
+        "get_revision",
+        "get_current_leaf_graph",
+        "get_document",
+        "put_document",
+        "bulk_docs",
+    ):
+        assert not hasattr(migration.CloudantClient, retired_method)
+
+
+def test_dry_run_is_the_only_mode_and_never_writes_or_exposes_private_values(capsys) -> None:
+    client = ReadOnlyCloudant()
 
     result = migration.execute(
-        ["--database", migration.EXPECTED_DATABASE_NAME, "--backup-root", str(tmp_path)],
+        ["--database", migration.EXPECTED_DATABASE_NAME],
         environ={migration.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
         client_factory=lambda _url: client,
     )
 
     assert result.mode == "dry-run"
-    assert result.update_seq == "42-seq"
-    assert client.bulk_calls == []
-    assert list(tmp_path.iterdir()) == []
+    assert result.counts == {
+        "documentsScanned": 4,
+        "taxonomyRecordsMigrated": 3,
+        "categorizedReferences": 3,
+        "referencesMigrated": 3,
+        "conflictLeaves": 1,
+        "documentsUpdated": 4,
+    }
+    assert client.calls == [
+        ("info", migration.EXPECTED_DATABASE_NAME),
+        ("documents", migration.EXPECTED_DATABASE_NAME, True),
+    ]
     output = capsys.readouterr().out
     assert "private task text" not in output
     assert "private activity text" not in output
     assert "secret" not in output
     assert migration.EXPECTED_DATABASE_NAME not in output
-    assert "dry-run-seq" not in output
 
 
-def test_plan_preserves_ids_labels_and_nonidentity_fields():
+@pytest.mark.parametrize(
+    "retired_arguments",
+    [
+        ["--apply"],
+        ["--backup-root", "private"],
+        ["--s1-snapshot", "private/S1"],
+        ["--journal", "private/journal.json"],
+        ["--expected-update-seq", "opaque"],
+        ["--confirm-database", migration.EXPECTED_DATABASE_NAME],
+    ],
+)
+def test_parser_rejects_all_retired_mutation_and_backup_flags(retired_arguments) -> None:
+    with pytest.raises(SystemExit):
+        migration._parser().parse_args(
+            ["--database", migration.EXPECTED_DATABASE_NAME, *retired_arguments]
+        )
+
+
+def test_plan_preserves_ids_locked_labels_winners_and_nonidentity_fields() -> None:
     winners = production_winners()
     before = copy.deepcopy(winners)
 
     plan = migration.build_migration_plan(winners)
 
+    assert winners == before, "planning must not mutate fetched winners"
     assert {document["_id"] for document in plan.updates} == {
         "config-categories",
         "unsched-legacy",
         "activity-legacy",
         "config-running-activity",
     }
-    migrated_taxonomy = next(d for d in plan.updates if d["_id"] == "config-categories")
-    assert [row["label"] for row in migrated_taxonomy["categories"]] == [
-        "Comms",
-        "Meetings",
+    taxonomy = next(document for document in plan.updates if document["_id"] == "config-categories")
+    assert [(row["key"], row["label"]) for row in taxonomy["categories"]] == [
+        ("work/meetings", "Comms"),
+        ("work/comms", "Meetings"),
     ]
-    assert migrated_taxonomy["categories"][0]["key"] == "work/meetings"
-    assert migrated_taxonomy["categories"][1]["key"] == "work/comms"
-    assert migrated_taxonomy["categories"][0]["id"] == ("9c52c0e9-c389-54e1-927f-52c16b13de99")
-    for old, new in zip(before, winners, strict=True):
-        assert old == new, "planning must not mutate the fetched winners"
-    task_update = next(d for d in plan.updates if d["_id"] == "unsched-legacy")
-    assert task_update["id"] == "unsched-legacy"
-    assert task_update["description"] == "private task text"
-    assert task_update["categoryIdentityVersion"] == 1
-    assert task_update["writerContract"]["categoryReference"] == {
+    assert taxonomy["categories"][0]["id"] == "9c52c0e9-c389-54e1-927f-52c16b13de99"
+    task = next(document for document in plan.updates if document["_id"] == "unsched-legacy")
+    assert task["id"] == "unsched-legacy"
+    assert task["description"] == "private task text"
+    assert task["writerContract"]["categoryReference"] == {
         "key": "work/meetings",
-        "id": task_update["categoryId"],
+        "id": task["categoryId"],
         "identityVersion": 1,
     }
-    assert all(tombstone["writerContract"] == {"version": 1} for tombstone in plan.conflict_tombstones)
+    assert plan.conflict_tombstones == [
+        {
+            "_id": "activity-legacy",
+            "_rev": "3-activity-loser",
+            "_deleted": True,
+            "writerContract": {"version": 1},
+        }
+    ]
 
 
-def test_plan_maps_direct_group_references_without_inferring_from_key_text():
+def test_plan_resolves_references_from_current_taxonomy_not_legacy_key_semantics() -> None:
     winners = production_winners()
     winners[1]["category"] = "work"
 
     plan = migration.build_migration_plan(winners)
+    task = next(document for document in plan.updates if document["_id"] == "unsched-legacy")
 
-    task_update = next(d for d in plan.updates if d["_id"] == "unsched-legacy")
-    assert task_update["categoryId"] == "3930ae01-aef6-5c5f-8db3-d91be139ea84"
-    assert task_update["categoryIdentityVersion"] == 1
+    assert task["categoryId"] == "3930ae01-aef6-5c5f-8db3-d91be139ea84"
+    assert task["categoryIdentityVersion"] == 1
 
 
-def test_plan_repairs_id_only_and_mismatched_references_with_app_resolution_rules():
-    initial = migration.build_migration_plan([taxonomy_doc()])
-    migrated_taxonomy = initial.updates[0]
+def test_plan_repairs_id_only_and_mismatched_references_using_current_rows() -> None:
+    migrated_taxonomy = migration.build_migration_plan([taxonomy_doc()]).updates[0]
     comms_id = migrated_taxonomy["categories"][0]["id"]
     meetings_id = migrated_taxonomy["categories"][1]["id"]
-    winners = [
+    documents = [
         migrated_taxonomy,
         {
             "_id": "task-id-only",
@@ -326,599 +314,85 @@ def test_plan_repairs_id_only_and_mismatched_references_with_app_resolution_rule
         },
     ]
 
-    plan = migration.build_migration_plan(winners)
-    updates = {document["_id"]: document for document in plan.updates}
+    updates = {
+        document["_id"]: document for document in migration.build_migration_plan(documents).updates
+    }
 
     assert updates["task-id-only"]["category"] == "work/meetings"
-    assert updates["task-id-only"]["categoryIdentityVersion"] == 1
     assert updates["task-mismatch"]["categoryId"] == comms_id
     assert updates["activity-stale-key"]["category"] == "work/comms"
 
 
-def test_plan_preserves_existing_random_identity_and_archive_metadata():
-    first = migration.build_migration_plan([taxonomy_doc()])
-    migrated_taxonomy = first.updates[0]
+def test_plan_preserves_existing_identity_archive_metadata_and_unknown_fields() -> None:
+    migrated_taxonomy = migration.build_migration_plan([taxonomy_doc()]).updates[0]
+    migrated_taxonomy["privateExtension"] = {"retained": [1, 2, 3]}
     migrated_taxonomy["groups"][0]["status"] = "archived"
     migrated_taxonomy["groups"][0]["archivedAt"] = "2026-07-21T12:00:00Z"
-    migrated_taxonomy["groups"].append(
-        {
-            "key": "g-11111111-1111-4111-8111-111111111111",
-            "id": "11111111-1111-4111-8111-111111111111",
-            "legacyKeys": [],
-            "label": "New group",
-            "colorFamily": "blue",
-            "color": "#0ea5e9",
-            "status": "active",
-            "archivedAt": None,
-        }
-    )
 
-    rerun = migration.build_migration_plan([migrated_taxonomy])
+    plan = migration.build_migration_plan([migrated_taxonomy])
+
+    assert plan.updates == []
+    assert plan.counts["taxonomyRecordsMigrated"] == 0
+    assert migrated_taxonomy["privateExtension"] == {"retained": [1, 2, 3]}
+
+
+def test_complete_plan_is_idempotent_after_all_successors_and_tombstones() -> None:
+    documents = production_winners()
+    first = migration.build_migration_plan(documents)
+    updates = {document["_id"]: document for document in first.updates}
+    settled = []
+    for source in documents:
+        successor = copy.deepcopy(updates.get(source["_id"], source))
+        successor.pop("_conflicts", None)
+        settled.append(successor)
+
+    rerun = migration.build_migration_plan(settled)
 
     assert rerun.updates == []
-    assert rerun.counts["taxonomyRecordsMigrated"] == 0
+    assert rerun.conflict_tombstones == []
+    assert rerun.counts["documentsUpdated"] == 0
+    assert rerun.counts["conflictLeaves"] == 0
 
 
-def test_unknown_reference_and_duplicate_taxonomy_id_abort_before_backup(tmp_path):
+def test_non_activity_conflicts_require_manual_review() -> None:
+    documents = production_winners()
+    documents[1]["_conflicts"] = ["1-other-task"]
+
+    with pytest.raises(migration.MigrationSafetyError, match="non-activity conflict"):
+        migration.build_migration_plan(documents)
+
+
+def test_unknown_reference_and_duplicate_taxonomy_identity_fail_closed() -> None:
     unknown = production_winners()
     unknown[1]["category"] = "work/unknown"
     with pytest.raises(migration.MigrationSafetyError, match="unknown taxonomy reference"):
         migration.build_migration_plan(unknown)
 
-    duplicate = migration.build_migration_plan(production_winners()).updates
-    duplicate_taxonomy = next(d for d in duplicate if d["_id"] == "config-categories")
-    duplicate_taxonomy["categories"][0]["id"] = duplicate_taxonomy["groups"][0]["id"]
+    migrated = migration.build_migration_plan([taxonomy_doc()]).updates[0]
+    migrated["categories"][0]["id"] = migrated["groups"][0]["id"]
     with pytest.raises(migration.MigrationSafetyError, match="duplicate taxonomy ID"):
-        migration.build_migration_plan(duplicate)
-    assert list(tmp_path.iterdir()) == []
+        migration.build_migration_plan([migrated])
 
 
-def test_backup_contains_every_winner_and_conflict_leaf_with_verified_checksum(tmp_path):
-    client = FakeCloudant()
-    winners = client.get_all_documents(migration.EXPECTED_DATABASE_NAME, include_conflicts=True)
-
-    backup = migration.create_backup(
-        client,
-        migration.EXPECTED_DATABASE_NAME,
-        client.get_database_info(migration.EXPECTED_DATABASE_NAME),
-        winners,
-        tmp_path,
-        timestamp="20260721T120000Z",
-    )
-
-    manifest = migration.verify_backup(backup.path)
-    assert backup.path.parent == tmp_path.resolve()
-    assert manifest["databaseName"] == migration.EXPECTED_DATABASE_NAME
-    assert manifest["winnerCount"] == len(winners)
-    assert manifest["conflictLeafCount"] == 1
-    assert len(manifest["backupChecksum"]) == 64
-    winner_rows = (backup.path / "winning-documents.ndjson").read_text(encoding="utf-8")
-    leaf_rows = (backup.path / "conflict-leaves.ndjson").read_text(encoding="utf-8")
-    assert "private task text" in winner_rows
-    assert "private losing text" in leaf_rows
-
-
-def test_backup_verification_detects_data_tampering(tmp_path):
-    client = FakeCloudant()
-    backup = migration.create_backup(
-        client,
-        migration.EXPECTED_DATABASE_NAME,
-        client.get_database_info(migration.EXPECTED_DATABASE_NAME),
-        client.winners,
-        tmp_path,
-        timestamp="20260721T120000Z",
-    )
-    with (backup.path / "winning-documents.ndjson").open("ab") as stream:
-        stream.write(b"{}\n")
-
-    with pytest.raises(migration.MigrationSafetyError, match="checksum mismatch"):
-        migration.verify_backup(backup.path)
-
-
-def test_apply_requires_matching_seq_typed_database_and_no_running_timer(tmp_path):
-    client = FakeCloudant(update_seq="changed-seq")
-    with pytest.raises(migration.MigrationSafetyError, match="update_seq changed"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="dry-run-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=tmp_path / "not-needed-before-sequence-lock",
-        )
-    assert client.bulk_calls == []
-    assert list(tmp_path.iterdir()) == []
-
-    client = FakeCloudant()
-    snapshot = create_s1_snapshot(client, tmp_path)
-    with pytest.raises(migration.MigrationSafetyError, match="running timer"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-        )
-    assert client.bulk_calls == []
-
-
-def test_apply_backs_up_before_writes_and_tombstones_only_losing_activity_leaf(tmp_path):
-    client = FakeCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    result = migration.apply_migration(
-        client,
-        database=migration.EXPECTED_DATABASE_NAME,
-        expected_update_seq="42-seq",
-        confirmation=migration.EXPECTED_DATABASE_NAME,
-        snapshot_path=snapshot,
-        timestamp="20260721T120000Z",
-    )
-
-    assert result.mode == "apply"
-    assert result.backup_path is not None
-    assert (result.backup_path / "manifest.json").is_file()
-    written = [document for batch in client.bulk_calls for document in batch]
-    tombstones = [document for document in written if document.get("_deleted")]
-    assert tombstones == [
-        {
-            "_id": "activity-legacy",
-            "_rev": "3-activity-loser",
-            "_deleted": True,
-            "writerContract": {"version": 1},
-        }
-    ]
-    activity_update = next(
-        document
-        for document in written
-        if document["_id"] == "activity-legacy" and not document.get("_deleted")
-    )
-    assert activity_update["_rev"] == "4-activity-winner"
-    assert activity_update["description"] == "private activity text"
-    assert activity_update["categoryId"] == "0dfac102-30f3-56d9-86c0-c3b414aeaf6e"
-    assert all(document["_id"] != migration.MIGRATION_COMPLETION_ID for document in written)
-    completion = client.put_calls[-1]
-    assert completion["_id"] == migration.MIGRATION_COMPLETION_ID
-    assert completion["s1SnapshotChecksum"] == result.backup_checksum
-    assert len(completion["verifiedStateFingerprint"]) == 64
-    assert completion["writerContract"] == {"version": 1, "categoryReference": None}
-
-
-@pytest.mark.parametrize("drift", ["account", "security", "leaf", "winner"])
-def test_apply_binds_every_live_precondition_to_the_complete_s1_snapshot(tmp_path, drift):
-    client = FakeCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    if drift == "account":
-        client.account_checksum = "b" * 64
-    elif drift == "security":
-        client.security["members"]["names"] = ["changed"]
-    elif drift == "leaf":
-        extra = {"_id": "task-concurrent", "_rev": "1-concurrent", "docType": "task"}
-        client.winners.append(extra)
-        client.revision_ancestries[(extra["_id"], extra["_rev"])] = [extra["_rev"]]
-    else:
-        client.winners[0]["_rev"] = "4-concurrent"
-
-    with pytest.raises(migration.MigrationSafetyError, match="complete S1 snapshot"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-        )
-
-    assert client.bulk_calls == []
-    assert client.put_calls == []
-
-
-def test_apply_retains_backup_but_aborts_if_a_winning_revision_changes(tmp_path):
-    class ChangingCloudant(FakeCloudant):
-        graph_reads = 0
-
-        def get_current_leaf_graph(self, database: str):
-            leaves, winners = super().get_current_leaf_graph(database)
-            if self.graph_reads == 4:
-                leaves[0]["_rev"] = "4-concurrent-change"
-            return leaves, winners
-
-    client = ChangingCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    with pytest.raises(migration.MigrationSafetyError, match="complete S1 snapshot"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-            timestamp="20260721T120000Z",
-        )
-
-    assert client.bulk_calls == []
-    assert len(list(tmp_path.iterdir())) == 2
-
-
-def test_apply_rejects_unrelated_valid_write_that_races_with_journal_application(tmp_path):
-    class ConcurrentInsertCloudant(FakeCloudant):
-        inserted = False
-
-        def bulk_docs(self, database: str, documents: list[dict]) -> list[dict]:
-            result = super().bulk_docs(database, documents)
-            if not self.inserted:
-                self.inserted = True
-                concurrent = {
-                    "_id": "task-concurrent",
-                    "_rev": "1-concurrent",
-                    "id": "task-concurrent",
-                    "docType": "task",
-                    "type": "unscheduled",
-                    "description": "valid concurrent writer",
-                    "category": None,
-                    "categoryId": None,
-                    "categoryIdentityVersion": None,
-                    "writerContract": {"version": 1, "categoryReference": None},
-                }
-                self.winners.append(concurrent)
-                self.revision_ancestries[(concurrent["_id"], concurrent["_rev"])] = [
-                    concurrent["_rev"]
-                ]
-            return result
-
-    client = ConcurrentInsertCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    with pytest.raises(migration.MigrationSafetyError, match="unrelated changes"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-            timestamp="20260721T120000Z",
-        )
-
-    assert client.put_calls == []
-
-
-def test_apply_rechecks_security_after_journal_application(tmp_path):
-    class SecurityDriftCloudant(FakeCloudant):
-        drifted = False
-
-        def bulk_docs(self, database: str, documents: list[dict]) -> list[dict]:
-            result = super().bulk_docs(database, documents)
-            if not self.drifted:
-                self.drifted = True
-                self.security["members"]["names"] = ["concurrent-change"]
-            return result
-
-    client = SecurityDriftCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    with pytest.raises(migration.MigrationSafetyError, match="complete S1 snapshot"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-            timestamp="20260721T120000Z",
-        )
-
-    assert client.put_calls == []
-
-
-def test_apply_rechecks_security_after_completion_marker(tmp_path):
-    class PostMarkerSecurityDriftCloudant(FakeCloudant):
-        def put_document(self, database: str, document: dict) -> dict:
-            result = super().put_document(database, document)
-            self.security["members"]["names"] = ["post-marker-change"]
-            return result
-
-    client = PostMarkerSecurityDriftCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    with pytest.raises(migration.MigrationSafetyError, match="complete S1 snapshot"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-            timestamp="20260721T120000Z",
-        )
-
-    assert client.put_calls[-1]["_id"] == migration.MIGRATION_COMPLETION_ID
-
-
-def test_migration_plan_is_idempotent_after_identity_fields_exist():
-    first = migration.build_migration_plan(production_winners())
-    migrated = []
-    updates_by_id = {document["_id"]: document for document in first.updates}
-    for document in production_winners():
-        migrated.append(copy.deepcopy(updates_by_id.get(document["_id"], document)))
-
-    second = migration.build_migration_plan(migrated)
-
-    assert second.updates == []
-    assert second.counts["taxonomyRecordsMigrated"] == 0
-    assert second.counts["referencesMigrated"] == 0
-
-
-def test_existing_completion_marker_requires_manual_verified_state_review(tmp_path):
-    client = FakeCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    first = migration.build_migration_plan(client.winners)
-    updates_by_id = {document["_id"]: document for document in first.updates}
-    client.winners = [
-        copy.deepcopy(updates_by_id.get(document["_id"], document)) for document in client.winners
-    ]
-    client.winners.append(
-        {
-            "_id": migration.MIGRATION_COMPLETION_ID,
-            "_rev": "1-complete",
-            "id": migration.MIGRATION_COMPLETION_ID,
-            "docType": "config",
-            "migration": "taxonomy-identity-v1",
-            "backupChecksum": "a" * 64,
-        }
-    )
-    snapshot = create_s1_snapshot(client, tmp_path)
-
-    with pytest.raises(migration.MigrationSafetyError, match="manual verification"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-        )
-
-    assert client.bulk_calls == []
-    assert client.put_calls == []
-
-
-def test_direct_production_restore_is_disabled_in_favor_of_quarantine(tmp_path):
-    client = FakeCloudant()
-    backup = migration.create_backup(
-        client,
-        migration.EXPECTED_DATABASE_NAME,
-        client.get_database_info(migration.EXPECTED_DATABASE_NAME),
-        client.winners,
-        tmp_path,
-        timestamp="20260721T120000Z",
-    )
-    client.bulk_calls.clear()
-    with pytest.raises(migration.MigrationSafetyError, match="quarantine"):
-        migration.restore_backup(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            backup_path=backup.path,
-        )
-
-    assert client.bulk_calls == []
-
-
-def test_journal_classifies_partial_results_and_resumes_only_locked_pre_states(tmp_path):
-    class PartialCloudant(FakeCloudant):
-        first_attempt = True
-
-        def bulk_docs(self, database: str, documents: list[dict]) -> list[dict]:
-            if self.first_attempt:
-                self.first_attempt = False
-                committed = super().bulk_docs(database, documents[:1])
-                return [*committed, *({"error": "forbidden"} for _ in documents[1:])]
-            return super().bulk_docs(database, documents)
-
-    client = PartialCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    plan = migration.build_migration_plan(client.winners)
-    writes = [*plan.updates, *plan.conflict_tombstones]
-    journal = migration.create_migration_journal(
-        writes, tmp_path, timestamp="20260721T120000Z"
-    )
-
-    with pytest.raises(migration.MigrationSafetyError, match="safe to resume"):
-        migration.apply_or_resume_journal(
-            client, database=migration.EXPECTED_DATABASE_NAME, journal_path=journal
-        )
-
-    result = migration.apply_or_resume_journal(
-        client, database=migration.EXPECTED_DATABASE_NAME, journal_path=journal
-    )
-    assert result["exactIntendedResults"] == len(writes)
-    assert result["resumedPreStates"] == len(writes) - 1
-    assert client.graph_reads == 4
-
-
-def test_apply_migration_resumes_only_s1_or_ancestry_proven_partial_state(tmp_path):
-    class PartialCloudant(FakeCloudant):
-        first_attempt = True
-
-        def bulk_docs(self, database: str, documents: list[dict]) -> list[dict]:
-            if self.first_attempt:
-                self.first_attempt = False
-                committed = super().bulk_docs(database, documents[:1])
-                return [*committed, *({"error": "forbidden"} for _ in documents[1:])]
-            return super().bulk_docs(database, documents)
-
-    client = PartialCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-    plan = migration.build_migration_plan(client.winners)
-    journal = migration.create_migration_journal(
-        [*plan.updates, *plan.conflict_tombstones],
-        tmp_path,
-        timestamp="20260721T120001Z",
-    )
-
-    with pytest.raises(migration.MigrationSafetyError, match="safe to resume"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-            journal_path=journal,
-            timestamp="20260721T120002Z",
-        )
-
-    result = migration.apply_migration(
-        client,
-        database=migration.EXPECTED_DATABASE_NAME,
-        expected_update_seq="42-seq",
-        confirmation=migration.EXPECTED_DATABASE_NAME,
-        snapshot_path=snapshot,
-        journal_path=journal,
-        timestamp="20260721T120002Z",
-    )
-
-    assert result.mode == "apply"
-    assert client.put_calls[-1]["_id"] == migration.MIGRATION_COMPLETION_ID
-
-
-def test_completion_intent_resume_reuses_original_timestamp_after_marker_crash(tmp_path):
-    class MarkerCrashCloudant(FakeCloudant):
-        fail_marker_once = True
-
-        def put_document(self, database: str, document: dict) -> dict:
-            if document.get("_id") == migration.MIGRATION_COMPLETION_ID and self.fail_marker_once:
-                self.fail_marker_once = False
-                raise migration.MigrationSafetyError("simulated marker crash")
-            return super().put_document(database, document)
-
-    client = MarkerCrashCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    snapshot = create_s1_snapshot(client, tmp_path)
-    plan = migration.build_migration_plan(client.winners)
-    journal = migration.create_migration_journal(
-        [*plan.updates, *plan.conflict_tombstones],
-        tmp_path,
-        timestamp="20260721T120001Z",
-    )
-
-    with pytest.raises(migration.MigrationSafetyError, match="simulated marker crash"):
-        migration.apply_migration(
-            client,
-            database=migration.EXPECTED_DATABASE_NAME,
-            expected_update_seq="42-seq",
-            confirmation=migration.EXPECTED_DATABASE_NAME,
-            snapshot_path=snapshot,
-            journal_path=journal,
-            timestamp="20260721T120002Z",
-        )
-
-    result = migration.apply_migration(
-        client,
-        database=migration.EXPECTED_DATABASE_NAME,
-        expected_update_seq="42-seq",
-        confirmation=migration.EXPECTED_DATABASE_NAME,
-        snapshot_path=snapshot,
-        journal_path=journal,
-        timestamp="20260722T090000Z",
-    )
-
-    assert result.mode == "apply"
-    assert client.put_calls[-1]["completedAt"] == "20260721T120002Z"
-
-
-def test_journal_rejects_matching_body_without_locked_pre_revision_ancestry(tmp_path):
-    client = FakeCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    plan = migration.build_migration_plan(client.winners)
-    journal = migration.create_migration_journal(
-        plan.updates, tmp_path, timestamp="20260721T120000Z"
-    )
-    intended = copy.deepcopy(plan.updates[0])
-    pre_revision = intended["_rev"]
-    generation = int(pre_revision.split("-", 1)[0]) + 1
-    wrong_revision = f"{generation}-wrongbranch"
-    intended["_rev"] = wrong_revision
-    winner_index = next(
-        index for index, winner in enumerate(client.winners) if winner["_id"] == intended["_id"]
-    )
-    client.winners[winner_index] = intended
-    client.revision_ancestries[(intended["_id"], wrong_revision)] = [
-        wrong_revision,
-        f"{generation - 1}-differentparent",
-    ]
-
-    with pytest.raises(migration.MigrationSafetyError, match="divergent state"):
-        migration.apply_or_resume_journal(
-            client, database=migration.EXPECTED_DATABASE_NAME, journal_path=journal
-        )
-
-
-def test_journal_halts_on_divergent_remote_state(tmp_path):
-    client = FakeCloudant()
-    client.winners = [
-        document for document in client.winners if document["_id"] != "config-running-activity"
-    ]
-    plan = migration.build_migration_plan(client.winners)
-    journal = migration.create_migration_journal(
-        plan.updates, tmp_path, timestamp="20260721T120000Z"
-    )
-    client.winners[0]["_rev"] = "4-concurrent"
-    client.winners[0]["label"] = "concurrent semantic change"
-
-    with pytest.raises(migration.MigrationSafetyError, match="divergent state"):
-        migration.apply_or_resume_journal(
-            client, database=migration.EXPECTED_DATABASE_NAME, journal_path=journal
-        )
-
-
-def test_backup_must_be_outside_repository(tmp_path):
-    repository_backup = Path(__file__).resolve().parents[1] / "unsafe-backups"
-    with pytest.raises(migration.MigrationSafetyError, match="outside the repository"):
-        migration.validate_backup_root(repository_backup)
-
-
-def test_private_artifact_path_must_remain_a_direct_child(tmp_path):
-    root = tmp_path.resolve()
-
-    assert migration._exact_artifact_path(root, "snapshot-S0").parent == root
-    with pytest.raises(migration.MigrationSafetyError, match="escaped"):
-        migration._exact_artifact_path(root, "../escaped")
-    with pytest.raises(migration.MigrationSafetyError, match="unverified"):
-        migration._remove_exact_artifact(root.parent, root)
-
-
-def test_cli_rejects_wrong_database_and_never_echoes_credentials(capsys, tmp_path):
-    with pytest.raises(migration.MigrationSafetyError, match="unexpected database name"):
+def test_wrong_database_and_missing_credential_fail_before_remote_reads() -> None:
+    with pytest.raises(migration.MigrationSafetyError, match="expected exactly"):
         migration.execute(
-            ["--database", "dat-411", "--backup-root", str(tmp_path)],
-            environ={migration.CREDENTIAL_ENV_VAR: "https://user:super-secret@example.invalid"},
-            client_factory=lambda _url: FakeCloudant(),
+            ["--database", "fortudo-other"],
+            environ={migration.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
         )
 
-    assert "super-secret" not in capsys.readouterr().out
+    with pytest.raises(migration.MigrationSafetyError, match=migration.CREDENTIAL_ENV_VAR):
+        migration.execute(["--database", migration.EXPECTED_DATABASE_NAME], environ={})
+
+
+def test_main_sanitizes_cloudant_failures(monkeypatch, capsys) -> None:
+    def fail_execute():
+        raise migration.MigrationSafetyError("Cloudant request failed during winning document read")
+
+    monkeypatch.setattr(migration, "execute", fail_execute)
+
+    assert migration.main() == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Migration blocked: Cloudant request failed during winning document read\n"
+    assert "Traceback" not in captured.err

--- a/tests/test_migrate_taxonomy_identity.py
+++ b/tests/test_migrate_taxonomy_identity.py
@@ -13,6 +13,9 @@ import pytest
 from scripts import migrate_taxonomy_identity as migration
 
 
+TARGET_DATABASE = "fortudo-dat-411"
+
+
 def taxonomy_doc() -> dict:
     return {
         "_id": "config-categories",
@@ -110,8 +113,8 @@ def test_cloudant_transport_issues_get_requests_only(monkeypatch) -> None:
     monkeypatch.setattr(migration.urllib.request, "urlopen", open_request)
     client = migration.CloudantClient("https://user:secret@example.invalid")
 
-    client.get_database_info(migration.EXPECTED_DATABASE_NAME)
-    client.get_all_documents(migration.EXPECTED_DATABASE_NAME, include_conflicts=True)
+    client.get_database_info(TARGET_DATABASE)
+    client.get_all_documents(TARGET_DATABASE, include_conflicts=True)
 
     assert methods == ["GET", "GET"]
 
@@ -132,9 +135,9 @@ def test_cloudant_reads_reject_malformed_payloads_without_echoing_them(
 
     with pytest.raises(migration.MigrationSafetyError, match=message) as error:
         if operation == "info":
-            client.get_database_info(migration.EXPECTED_DATABASE_NAME)
+            client.get_database_info(TARGET_DATABASE)
         else:
-            client.get_all_documents(migration.EXPECTED_DATABASE_NAME, include_conflicts=True)
+            client.get_all_documents(TARGET_DATABASE, include_conflicts=True)
 
     assert "private" not in str(error.value)
 
@@ -188,7 +191,7 @@ def test_dry_run_is_the_only_mode_and_never_writes_or_exposes_private_values(cap
     client = ReadOnlyCloudant()
 
     result = migration.execute(
-        ["--database", migration.EXPECTED_DATABASE_NAME],
+        ["--database", TARGET_DATABASE],
         environ={migration.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
         client_factory=lambda _url: client,
     )
@@ -203,14 +206,29 @@ def test_dry_run_is_the_only_mode_and_never_writes_or_exposes_private_values(cap
         "documentsUpdated": 4,
     }
     assert client.calls == [
-        ("info", migration.EXPECTED_DATABASE_NAME),
-        ("documents", migration.EXPECTED_DATABASE_NAME, True),
+        ("info", TARGET_DATABASE),
+        ("documents", TARGET_DATABASE, True),
     ]
     output = capsys.readouterr().out
     assert "private task text" not in output
     assert "private activity text" not in output
     assert "secret" not in output
-    assert migration.EXPECTED_DATABASE_NAME not in output
+    assert TARGET_DATABASE not in output
+
+
+def test_dry_run_accepts_another_explicit_fortudo_database(capsys) -> None:
+    client = ReadOnlyCloudant()
+    database = "fortudo-family-123"
+
+    result = migration.execute(
+        ["--database", database],
+        environ={migration.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+        client_factory=lambda _url: client,
+    )
+
+    assert result.mode == "dry-run"
+    assert client.calls == [("info", database), ("documents", database, True)]
+    assert database not in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -221,13 +239,13 @@ def test_dry_run_is_the_only_mode_and_never_writes_or_exposes_private_values(cap
         ["--s1-snapshot", "private/S1"],
         ["--journal", "private/journal.json"],
         ["--expected-update-seq", "opaque"],
-        ["--confirm-database", migration.EXPECTED_DATABASE_NAME],
+        ["--confirm-database", TARGET_DATABASE],
     ],
 )
 def test_parser_rejects_all_retired_mutation_and_backup_flags(retired_arguments) -> None:
     with pytest.raises(SystemExit):
         migration._parser().parse_args(
-            ["--database", migration.EXPECTED_DATABASE_NAME, *retired_arguments]
+            ["--database", TARGET_DATABASE, *retired_arguments]
         )
 
 
@@ -374,15 +392,19 @@ def test_unknown_reference_and_duplicate_taxonomy_identity_fail_closed() -> None
         migration.build_migration_plan([migrated])
 
 
-def test_wrong_database_and_missing_credential_fail_before_remote_reads() -> None:
-    with pytest.raises(migration.MigrationSafetyError, match="expected exactly"):
+@pytest.mark.parametrize("database", ["_users", "dat-411", "fortudo-", "fortudo-UPPER"])
+def test_non_fortudo_database_fails_before_remote_reads(database) -> None:
+    with pytest.raises(migration.MigrationSafetyError, match="Fortudo namespace"):
         migration.execute(
-            ["--database", "fortudo-other"],
+            ["--database", database],
             environ={migration.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
         )
 
+
+def test_missing_credential_fails_before_remote_reads() -> None:
+
     with pytest.raises(migration.MigrationSafetyError, match=migration.CREDENTIAL_ENV_VAR):
-        migration.execute(["--database", migration.EXPECTED_DATABASE_NAME], environ={})
+        migration.execute(["--database", TARGET_DATABASE], environ={})
 
 
 def test_main_sanitizes_cloudant_failures(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary

This PR removes the premature custom Cloudant backup, restore, and production-mutation machinery
added during the entity/taxonomy hardening work.

- Replaces `document_contract_ops.py` with a GET-only validator inspector.
- Replaces `migrate_taxonomy_identity.py` with a namespace-scoped, read-only planner for explicitly
  named `fortudo-*` databases.
- Removes local snapshot formats, backup manifests, restore engines, inventory/provision/install
  commands, mutation journals, completion orchestration, target-binding checksums, and
  `update_seq` equality gates.
- Rewrites the operational runbook to state that production migration is paused.
- Adds the smaller Cloudant-native quarantine design that a later implementation PR must prove on
  disposable Cloudant databases before merge.
- Corrects `COUCHDB-SETUP.md`: browsers use `skip_setup: true` and do not auto-provision remote room
  databases.

This is a partial reversal by responsibility, not a mechanical revert of the earlier commits.

## Relationship to earlier PRs

| Earlier PR | Retired or superseded here | Explicitly retained |
| --- | --- | --- |
| [#103 — Harden entity and taxonomy identity](https://github.com/iconix/fortudo/pull/103) | The Python migration tool's production apply, local backup/restore, conflict-write, and sequence-locking paths. | Entity and taxonomy IDs, locked taxonomy meanings, browser persistence behavior, UI/insights support, preview coverage, and the deterministic read-only planner. The planner reads and preserves each selected room's own schema-3.5 taxonomy; it does not hardcode `dat-411` labels. |
| [#104 — Harden document contracts and migration recovery](https://github.com/iconix/fortudo/pull/104) | `document_contract_ops.py` inventory/snapshot/install/provision/quarantine commands; Python migration journaling, fingerprint/completion, restore, and write orchestration; the old snapshot-centric runbook. | Browser document contracts, startup divergence audit, multi-tab invalidation, recovery UX, lossless taxonomy persistence, golden corpus, real-Cloudant contract gate, and the architectural diagnosis documents. |
| [#105 — Fix document contract operations CLI entry point](https://github.com/iconix/fortudo/pull/105) | No behavioral rollback. The large CLI is superseded by a much smaller one. | The direct-script import/bootstrap fix remains, so the read-only `verify` command still works from any working directory. |
| [#106 — Record temporary unencrypted backup override](https://github.com/iconix/fortudo/pull/106) | The temporary-unencrypted backup mode, retention metadata, and backup-specific documentation/tests. | CI deployable-path detection, one preview deployment per PR, seven-day preview expiry, and preview-channel cleanup behavior. |
| [#107 — Harden Cloudant target state binding](https://github.com/iconix/fortudo/pull/107) | The snapshot target-binding scheme: account checksum, opaque-sequence equality, leaf-graph/winner binding, and the install/apply gates built around it. | Read-only commands still validate the `fortudo-*` namespace. The future production executor remains exactly locked to `fortudo-dat-411`; no generalized room mutation is introduced. |

## Why remove this machinery

Read-only production observation showed that Cloudant's opaque `update_seq` can change while the
application leaf set remains unchanged, so exact sequence equality is not a valid content-stability
gate for this deployment.

The local archive also reimplemented responsibilities Cloudant replication already owns: current
leaf transfer, conflicts, deletions, attachments, ancestry, checkpoints, retries, and reconstruction.
That was too much custom infrastructure for one guarded migration.

## Current supported operational surface

Only these read-only commands remain:

```powershell
python scripts/document_contract_ops.py verify --database fortudo-dat-411
python scripts/migrate_taxonomy_identity.py --database fortudo-<room>
```

The planner accepts an explicitly named, valid `fortudo-*` database. It reads that database's own
taxonomy and reports aggregate intended changes; a successful plan is not authorization to mutate
that room. The later write executor remains separately locked to `fortudo-dat-411`.

The HTTP transport used by these scripts is GET-only. Retired modes and flags no longer exist; old
commands fail during argument parsing rather than entering compatibility behavior.

## Replacement design (not implemented in this PR)

The new design uses:

1. A randomly named empty Cloudant quarantine database.
2. Default one-shot `_replicator` replication with no filter, selector, `doc_ids`,
   `winning_revs_only`, or continuous mode.
3. Exact source/quarantine comparison of current leaf identities, deletion state, winner map,
   counts, and canonical fingerprint; `_local` checkpoints are excluded.
4. `_security` hashes before capture, before fencing, and after migration—never a local `_security`
   backup or restore command.
5. A zero-write live-timer preflight, create-only validator installation, deterministic per-document
   compare-and-set successors, idempotent resume, and manual selective recovery only.

The later implementation PR may not merge until the exact machinery passes an end-to-end disposable
Cloudant exercise covering conflicts, tombstones, attachments, live-timer blocking, source and
`_security` drift, interrupted/resumed migration, temporary-credential revocation, and exact cleanup.

## Verification

- `npm run verify`
  - Jest: **76 suites, 1,592 tests passed**
  - Python unit/guard tests: **164 passed**
  - Playwright E2E: **18 passed**
  - Coverage: **91.07% statements, 79.4% branches, 93.53% functions, 91.97% lines**
- Focused cleanup/planner tests: **41 passed**
- Independent Kleppmann/DDIA-style review: **APPROVE** after timer, `_security`, credential,
  provisioning, replication-subset, validator-resume, idempotence, and malformed-payload findings
  were addressed.
- GitHub CI: all required test, build, security, CodeQL, and Playwright checks passed for commit `59ebdf5`.
- Firebase preview and production deployment: expected to skip because this PR changes no deployable
  `public/**` or Firebase configuration.

## Production status

- Production Cloudant writes performed by this PR: **none**
- Production snapshot/quarantine created: **none**
- Validator installed: **no**
- Taxonomy migration run: **no**
- Production migration remains paused until the later implementation is merged, deployed, proven on
  disposable Cloudant, freshly audited, and explicitly approved.
