### PR TITLE
Add minimal Cloudant quarantine migration

### DIFF
--- a/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
+++ b/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
@@ -2,10 +2,10 @@
 
 ## Current status
 
-The production entity and taxonomy migration is paused. The compatibility release exists, but
-this repository intentionally has no command that can install a production validator, create a
-backup, restore a database, provision a room, apply the taxonomy migration, resolve production
-conflicts, or write a completion marker.
+The production entity and taxonomy migration is paused until the guarded quarantine implementation
+has passed its disposable Cloudant proof, merged, deployed, and received a fresh production
+approval. This repository now contains a narrowly scoped write-capable command for that later
+operation. Its presence is not authorization to run it against production.
 
 This is deliberate. The retired tooling attempted to implement a complete revision-graph snapshot
 and restore format locally and treated Cloudant's opaque `update_seq` as a stable content lock.
@@ -14,16 +14,14 @@ so it is not a valid equality gate for this deployment. Maintaining a second rep
 implementation in Python was also unnecessary when Cloudant already implements CouchDB replication.
 
 The replacement design is [Cloudant Quarantine Migration Design](plans/design/2026-07-22-cloudant-quarantine-migration-design.md).
-It must be implemented and proven on disposable Cloudant databases in a later pull request before
-any production mutation resumes.
+It uses Cloudant-native quarantine replication without a local backup format, reverse restore,
+durable `_replicator` document, or `update_seq` lock.
 
 Never paste the Cloudant credential URL, document bodies, descriptions, or private database
 metadata into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only
 in the local process environment.
 
-## Supported commands
-
-Only two read-only operations remain.
+## Read-only commands
 
 Inspect whether a named Fortudo database contains the exact reviewed validator:
 
@@ -40,11 +38,29 @@ python scripts/migrate_taxonomy_identity.py --database fortudo-dat-411
 The read-only planner accepts any explicit, valid `fortudo-*` database name and has no apply mode.
 Its transformation rules are application-wide: it reads and preserves the selected database's
 current taxonomy rather than hardcoding the `dat-411` labels. This permits comparison and auditing;
-it does not authorize taxonomy migration in another room. The future production executor remains
+it does not authorize taxonomy migration in another room. The production executor remains
 locked to `fortudo-dat-411`.
 
 Both commands print only a state or aggregate counts. They do not print the database name,
 credentials, document bodies, descriptions, revision identifiers, or opaque database metadata.
+
+## Guarded migration commands
+
+`scripts/cloudant_quarantine_migration.py` provides `preflight`, `capture`, `fence`, `migrate`, and
+`delete-quarantine`. Production mutations are hard-locked to `fortudo-dat-411`; every mutating mode
+requires the expected account checksum, an exact source confirmation where applicable, and
+`--approve-remote-writes`. Capture creates one exact quarantine database and uses transient
+`POST /_replicate`; it never writes a durable replication document.
+
+Before this command may be used on production, run the exact disposable proof:
+
+```powershell
+python scripts/cloudant-quarantine-gate.py
+```
+
+The proof creates two random preview databases, exercises capture, retry, fencing, interruption,
+completion, and invariant failures, and deletes exactly those two databases. It prints only counts
+and hashes. A passing proof does not authorize production.
 
 ## Compatibility-release verification
 
@@ -60,8 +76,8 @@ npm run verify
 ```
 
 An isolated Firebase preview and `node scripts/cloudant-contract-gate.mjs` verify the browser-side
-contract behavior. They do not prove the future quarantine/migration machinery because that
-machinery is not present yet.
+contract behavior. The separate real-Cloudant quarantine gate proves the operational migration
+machinery.
 
 ## Gates before production work can resume
 

--- a/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
+++ b/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
@@ -1,6 +1,6 @@
 # Cloudant quarantine migration design
 
-**Status:** Design for a later implementation pull request. It is not an operational authorization.
+**Status:** Implemented by a guarded migration pull request. It is not production authorization.
 
 ## Decision
 
@@ -11,9 +11,22 @@ then install the document validator and run a narrowly scoped, resumable taxonom
 Do not build or retain a local snapshot format, portable dump, general restore engine, database
 inventory system, or opaque-`update_seq` lock.
 
-IBM recommends managed `_replicator` jobs over the transient `/_replicate` endpoint because jobs are
-restartable and observable. Normal CouchDB replication transfers all current leaf revisions;
-`winning_revs_only` must not be enabled because it intentionally discards conflicting leaves.
+Use the transient `POST /_replicate` endpoint. A persistent `_replicator` document would retain its
+credential in CouchDB revision history after deletion and a retry could not recreate the deleted
+document ID without its tombstone revision. Scheduler restartability is not worth those risks for
+this bounded operation. A transient request is safely rerunnable into the retained quarantine;
+exact verified state, not the request response alone, establishes success.
+
+The request uses the existing accepted legacy credential as structured authentication inside its
+TLS request body. This creates no new authority and no durable replication document. It is an
+explicitly approved exception to IBM's general preference for scoped replication credentials,
+proportionate to Fortudo's existing browser-visible Manager credential documented in
+[COUCHDB-SETUP.md](../../COUCHDB-SETUP.md) and
+[ROOM-IDENTITY-AND-ACCESS-RISK.md](../../ROOM-IDENTITY-AND-ACCESS-RISK.md). The request body,
+credential, URLs, and response details must never be logged.
+
+Normal CouchDB replication transfers all current leaf revisions; `winning_revs_only` must not be
+enabled because it intentionally discards conflicting leaves.
 
 References:
 
@@ -64,13 +77,17 @@ The set includes application and design documents. `_local/*` documents are excl
 replication checkpoints are local implementation metadata and replication itself can change them.
 Derived `_conflicts` arrays are not hashed separately because the leaf set already represents them.
 
+Enumerate current leaves with `_changes?style=all_docs`, fetch their exact bodies through bounded
+`_bulk_get` batches, and obtain winners with a keyed `_all_docs` request over those IDs. The keyed
+request is required because an unkeyed `_all_docs` scan omits deleted documents. Cloudant 429
+responses receive bounded backoff; exhausted retries fail closed with sanitized output.
+
 Matching revision identities across source and quarantine are the verification boundary for the
 native replication protocol. Attachments travel as part of those replicated revisions. The design
 does not duplicate every body and attachment into a second local archive merely to reimplement that
 integrity check.
 
-Cloudant's `update_seq` may be recorded diagnostically but must never be compared for equality or
-used as a content-stability gate.
+The tool does not record or compare Cloudant's opaque `update_seq`.
 
 ## `_security`
 
@@ -92,24 +109,27 @@ is outside this document. Any intentional security change is a separate approved
    output exposes neither.
 3. Create one empty, nonpartitioned database with a random high-entropy
    `fortudo-quarantine-<random>` name. Abort if it already exists or is not empty.
-4. Create a one-shot `_replicator` job from `fortudo-dat-411` to that exact database. Use no selector,
-   filter, `doc_ids`, `winning_revs_only`, or continuous mode. Any replication credential must be
-   temporary and narrowly scoped, must never be logged or committed, and must be revoked after the
-   job is removed.
-5. Wait for the scheduler to report completion. A terminal error or timeout blocks the operation.
+4. Send one transient `POST /_replicate` request from `fortudo-dat-411` to that exact database. Use
+   no selector, filter, `doc_ids`, `winning_revs_only`, or continuous mode. Authenticate both legs
+   with the existing accepted credential as structured authentication; never put it in a URL or
+   output.
+5. Require a successful response with zero document write failures. A timeout or disconnect is
+   ambiguous, not proof of failure: retain the quarantine and rerun before trusting state.
 6. Read the source and quarantine state models. Require exact leaf-set, winner-map, count, and
    fingerprint equality.
 7. Re-read and compare the source `_security` hash.
-8. Remove the completed replication job and revoke its temporary credential. Retain the quarantine
-   database through the known-client exercise.
+8. Retain the quarantine database through the known-client exercise. No `_replicator` document or
+   temporary credential exists to clean up.
 
 The replication may write `_local` checkpoints to the source. Those writes are expected and do not
 invalidate the application-state comparison.
 
-If source state changes before the validator is installed, do not proceed. Repeat the one-shot
+If source state changes before the validator is installed, do not proceed. Repeat transient
 replication into the same quarantine database, reverify exact equality, and establish a new locked
-fingerprint. Unexpected quarantine-only leaves or any ambiguous result require a new empty
-quarantine database rather than destructive cleanup.
+fingerprint. Do not require the old quarantine leaves to be a subset of the source before retry: a
+normal source update replaces a leaf with its child while the quarantine still exposes the parent
+as a leaf. Replication can converge that ancestry safely. Unexpected quarantine-only leaves remain
+after replication and fail final equality; do not destructively clean or trust that target.
 
 ## Fence installation
 
@@ -198,25 +218,28 @@ The fixture must initially include:
 - a running-timer configuration document used only to prove the zero-write preflight.
 
 First run the production preflight with that live timer. It must fail before creating a quarantine
-database, replication job, validator revision, or migration revision. The preview harness then stops
-the timer through the same compatible persistence behavior used by the application and proves the
-configuration is absent before starting the successful capture path.
+database, transient replication request, validator revision, or migration revision. The preview
+harness then stops the timer through the same compatible persistence behavior used by the
+application and proves the configuration is absent before starting the successful capture path.
 
 The exercise must prove:
 
 1. default one-shot replication preserves the exact leaf set, winners, deletions, conflicts, and
    attachment-bearing revisions;
-2. `winning_revs_only`, filters, selectors, `doc_ids`, and continuous mode are absent;
-3. source leaf drift after capture blocks validator installation without a validator or migration
+2. a successful replication whose client response is deliberately treated as lost can be rerun
+   into the retained target and converge exactly, including after an existing source document is
+   edited;
+3. `winning_revs_only`, filters, selectors, `doc_ids`, and continuous mode are absent;
+4. source leaf drift after capture blocks validator installation without a validator or migration
    write;
-4. a deliberate `_security` change after capture blocks validator installation, and the successful
+5. a deliberate `_security` change after capture blocks validator installation, and the successful
    path finishes with the original source `_security` hash unchanged;
-5. validator installation changes exactly one expected design leaf;
-6. a forced interruption leaves a state that a fresh run safely classifies and completes;
-7. invalid legacy writes are denied after fencing while compatible writes succeed;
-8. the final invariant and completion checks detect any unexpected revision; and
-9. cleanup deletes only the two exact disposable databases and the exact replication job, and
-   verifies revocation of the exact temporary replication credential.
+6. validator installation changes exactly one expected design leaf;
+7. a forced interruption leaves a state that a fresh run safely classifies and completes;
+8. invalid legacy writes are denied after fencing while compatible writes succeed;
+9. the final invariant and completion checks detect any unexpected revision; and
+10. no `_replicator` document is created, output remains sanitized, and cleanup deletes only the two
+    exact disposable databases.
 
 Record only aggregate counts, state fingerprints, validator checksum/revision, test result, and
 cleanup confirmation in the pull request. Credentials, URLs, descriptions, bodies, attachment

--- a/scripts/cloudant-quarantine-gate.py
+++ b/scripts/cloudant-quarantine-gate.py
@@ -1,0 +1,584 @@
+"""Disposable real-Cloudant proof for the minimal quarantine migration machinery."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import os
+import secrets
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.cloudant_quarantine_migration import (
+    COMPLETION_MARKER_ID,
+    PREVIEW_QUARANTINE_PATTERN,
+    PREVIEW_SOURCE_PATTERN,
+    OperationalCloudantClient,
+    QuarantineSafetyError,
+    build_state_model,
+    capture_quarantine,
+    execute_migration,
+    install_fence,
+)
+from scripts.document_contract_ops import CONTRACT_DESIGN_ID, load_design_document
+from scripts.migrate_taxonomy_identity import CREDENTIAL_ENV_VAR, RUNNING_ACTIVITY_ID
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise QuarantineSafetyError(message)
+
+
+class DisposablePreviewCloudantClient(OperationalCloudantClient):
+    """Fixture-only mutations that are deliberately absent from the production CLI client."""
+
+    def seed_revisions(self, database: str, documents: Sequence[Mapping[str, Any]]) -> None:
+        require(
+            bool(PREVIEW_SOURCE_PATTERN.fullmatch(database)),
+            "target is not a disposable preview source",
+        )
+        require(bool(documents), "disposable preview seed is empty")
+        payload = self._request(
+            "POST",
+            "disposable preview seed",
+            f"{self._database_path(database)}/_bulk_docs",
+            body={"docs": list(documents), "new_edits": False},
+        )
+        if not isinstance(payload, list):
+            raise QuarantineSafetyError("Cloudant returned an invalid preview seed response")
+        rejected = sum(
+            not isinstance(row, Mapping)
+            or isinstance(row.get("error"), str)
+            or row.get("ok") is False
+            for row in payload
+        )
+        if rejected:
+            raise QuarantineSafetyError(
+                f"Cloudant rejected {rejected} disposable preview revisions"
+            )
+
+    def put_preview_security(self, database: str, security: Mapping[str, Any]) -> None:
+        require(
+            bool(PREVIEW_SOURCE_PATTERN.fullmatch(database)),
+            "target is not a disposable preview source",
+        )
+        payload = self._request(
+            "PUT",
+            "disposable preview security write",
+            f"{self._database_path(database)}/_security",
+            body=security,
+        )
+        require(
+            isinstance(payload, Mapping) and payload.get("ok") is True,
+            "Cloudant returned an invalid security write response",
+        )
+
+
+def fixture_documents() -> list[dict[str, Any]]:
+    activity_parent = "b" * 32
+    deleted_parent = "c" * 32
+    return [
+        {
+            "_id": "config-categories",
+            "_rev": f"1-{'1' * 32}",
+            "id": "config-categories",
+            "docType": "config",
+            "schemaVersion": "3.5",
+            "groups": [
+                {
+                    "key": "work",
+                    "label": "Work",
+                    "colorFamily": "blue",
+                    "color": "#0ea5e9",
+                }
+            ],
+            "categories": [
+                {
+                    "key": "work/meetings",
+                    "label": "Comms",
+                    "groupKey": "work",
+                    "color": "#38bdf8",
+                },
+                {
+                    "key": "work/comms",
+                    "label": "Meetings",
+                    "groupKey": "work",
+                    "color": "#7dd3fc",
+                },
+            ],
+        },
+        {
+            "_id": "task-preview",
+            "_rev": f"1-{'2' * 32}",
+            "id": "task-preview",
+            "docType": "task",
+            "type": "unscheduled",
+            "description": "private preview task",
+            "category": "work/meetings",
+        },
+        {
+            "_id": "activity-preview",
+            "_rev": f"2-{'f' * 32}",
+            "_revisions": {"start": 2, "ids": ["f" * 32, activity_parent]},
+            "id": "activity-preview",
+            "docType": "activity",
+            "description": "private winning activity",
+            "category": "work/comms",
+        },
+        {
+            "_id": "activity-preview",
+            "_rev": f"2-{'a' * 32}",
+            "_revisions": {"start": 2, "ids": ["a" * 32, activity_parent]},
+            "id": "activity-preview",
+            "docType": "activity",
+            "description": "private losing activity",
+            "category": "work/meetings",
+        },
+        {
+            "_id": "task-deleted-preview",
+            "_rev": f"2-{'d' * 32}",
+            "_revisions": {"start": 2, "ids": ["d" * 32, deleted_parent]},
+            "_deleted": True,
+        },
+        {
+            "_id": "config-attachment-preview",
+            "_rev": f"1-{'4' * 32}",
+            "id": "config-attachment-preview",
+            "docType": "config",
+            "_attachments": {
+                "proof.txt": {
+                    "content_type": "text/plain",
+                    "revpos": 1,
+                    "data": base64.b64encode(b"private attachment proof").decode("ascii"),
+                }
+            },
+        },
+        {
+            "_id": RUNNING_ACTIVITY_ID,
+            "_rev": f"1-{'5' * 32}",
+            "id": RUNNING_ACTIVITY_ID,
+            "docType": "config",
+            "activityId": "activity-preview",
+            "category": "work/comms",
+        },
+        {
+            "_id": "config-preview-ordinary",
+            "_rev": f"1-{'6' * 32}",
+            "id": "config-preview-ordinary",
+            "docType": "config",
+        },
+    ]
+
+
+def expected_fixture_state():
+    rows = [
+        {"id": "config-categories", "rev": f"1-{'1' * 32}", "deleted": False},
+        {"id": "task-preview", "rev": f"1-{'2' * 32}", "deleted": False},
+        {"id": "activity-preview", "rev": f"2-{'f' * 32}", "deleted": False},
+        {"id": "activity-preview", "rev": f"2-{'a' * 32}", "deleted": False},
+        {"id": "task-deleted-preview", "rev": f"2-{'d' * 32}", "deleted": True},
+        {
+            "id": "config-attachment-preview",
+            "rev": f"1-{'4' * 32}",
+            "deleted": False,
+        },
+        {"id": RUNNING_ACTIVITY_ID, "rev": f"1-{'5' * 32}", "deleted": False},
+        {"id": "config-preview-ordinary", "rev": f"1-{'6' * 32}", "deleted": False},
+    ]
+    winners = {
+        row["id"]: row["rev"] for row in rows if row["id"] != "activity-preview"
+    }
+    winners["activity-preview"] = f"2-{'f' * 32}"
+    return build_state_model(rows, winners)
+
+
+def stop_timer_compatibly(client: OperationalCloudantClient, database: str) -> None:
+    timer = client.get_document(database, RUNNING_ACTIVITY_ID)
+    require(timer is not None and isinstance(timer.get("_rev"), str), "preview timer is absent")
+    client.put_document(
+        database,
+        {
+            "_id": RUNNING_ACTIVITY_ID,
+            "_rev": timer["_rev"],
+            "_deleted": True,
+            "writerContract": {"version": 1},
+        },
+        create_only=False,
+    )
+    require(
+        client.get_document(database, RUNNING_ACTIVITY_ID) is None,
+        "compatible timer stop did not remove the running configuration",
+    )
+
+
+def attachment_revision(client: OperationalCloudantClient, database: str) -> tuple[str, str]:
+    matches = [
+        document
+        for document in client.get_leaf_documents(database)
+        if document.get("_id") == "config-attachment-preview"
+    ]
+    require(len(matches) == 1, "attachment leaf count differs from expectation")
+    attachments = matches[0].get("_attachments")
+    proof = attachments.get("proof.txt") if isinstance(attachments, dict) else None
+    require(
+        isinstance(proof, dict) and isinstance(proof.get("digest"), str),
+        "attachment digest is absent",
+    )
+    return matches[0]["_rev"], proof["digest"]
+
+
+class InterruptOnce:
+    def __init__(self, client: OperationalCloudantClient) -> None:
+        self.client = client
+        self.application_writes = 0
+        self.interrupted = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.client, name)
+
+    def put_document(self, database: str, document: dict, *, create_only: bool = False):
+        if document.get("_id") not in {CONTRACT_DESIGN_ID, COMPLETION_MARKER_ID}:
+            if self.application_writes == 1 and not self.interrupted:
+                self.interrupted = True
+                raise QuarantineSafetyError("forced interruption")
+            self.application_writes += 1
+        return self.client.put_document(database, document, create_only=create_only)
+
+
+class AmbiguousReplicationOnce:
+    """Lose one successful transient response to prove retained-target retry."""
+
+    def __init__(self, client: OperationalCloudantClient) -> None:
+        self.client = client
+        self.interrupted = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.client, name)
+
+    def replicate_once(self, source: str, target: str, *, allow_disposable_preview: bool = False):
+        result = self.client.replicate_once(
+            source,
+            target,
+            allow_disposable_preview=allow_disposable_preview,
+        )
+        if not self.interrupted:
+            self.interrupted = True
+            raise QuarantineSafetyError("forced ambiguous transient response")
+        return result
+
+
+def safe_report(
+    *,
+    capture: Any,
+    fence: Any,
+    migration: Any,
+    counts: dict[str, int],
+) -> None:
+    print(
+        json.dumps(
+            {
+                "mode": "real-cloudant-quarantine-gate",
+                "result": "passed",
+                "counts": counts,
+                "quarantineFingerprint": capture.state.fingerprint,
+                "validatorChecksum": load_design_document()["fortudoDocumentContract"]["checksum"],
+                "validatorRevision": fence.validator_revision,
+                "verifiedStateFingerprint": migration.verified_state_fingerprint,
+                "markerRevision": migration.marker_revision,
+                "cleanup": "verified",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def main() -> int:
+    credential_url = os.environ.get(CREDENTIAL_ENV_VAR)
+    require(bool(credential_url), f"required environment variable {CREDENTIAL_ENV_VAR} is unset")
+    nonce = secrets.token_hex(12)
+    source_database = f"fortudo-preview-quarantine-gate-{nonce}-source"
+    quarantine_database = f"fortudo-preview-quarantine-gate-{nonce}-quarantine"
+    require(
+        bool(PREVIEW_SOURCE_PATTERN.fullmatch(source_database)), "preview source name is invalid"
+    )
+    require(
+        bool(PREVIEW_QUARANTINE_PATTERN.fullmatch(quarantine_database)),
+        "preview quarantine name is invalid",
+    )
+    client = DisposablePreviewCloudantClient(credential_url)
+    source_may_be_owned = False
+    quarantine_may_be_owned = False
+    phase = "initialization"
+    report_values = None
+    counts = {
+        "timerZeroWritePreflights": 0,
+        "ambiguousReplicationRetries": 0,
+        "leafDriftBlocks": 0,
+        "securityDriftBlocks": 0,
+        "forcedInterruptions": 0,
+        "legacyWritesDenied": 0,
+        "compatibleWritesAccepted": 0,
+        "unexpectedRevisionBlocks": 0,
+        "disposableDatabases": 2,
+    }
+    try:
+        phase = "disposable identity preflight"
+        require(not client.database_exists(source_database), "preview source already exists")
+        require(
+            not client.database_exists(quarantine_database), "preview quarantine already exists"
+        )
+
+        phase = "source fixture setup"
+        source_may_be_owned = True
+        client.create_database(source_database, partitioned=False, allow_disposable_preview=True)
+        client.seed_revisions(source_database, fixture_documents())
+        require(
+            client.get_state_model(source_database) == expected_fixture_state(),
+            "preview fixture state differs after seeding",
+        )
+        winners = client.get_all_documents(source_database, include_conflicts=True)
+        winning_activity = next(
+            document for document in winners if document.get("_id") == "activity-preview"
+        )
+        require(
+            winning_activity.get("_rev") == f"2-{'f' * 32}",
+            "preview conflict winner differs from the locked fixture",
+        )
+
+        phase = "timer zero-write preflight"
+        before_timer_gate = client.get_state_model(source_database)
+        quarantine_may_be_owned = True
+        try:
+            capture_quarantine(
+                client,
+                source_database,
+                quarantine_database,
+                allow_disposable_preview=True,
+            )
+        except QuarantineSafetyError as error:
+            require("running timer" in str(error), "timer preflight failed for another reason")
+        else:
+            raise QuarantineSafetyError("running timer did not block capture")
+        require(
+            client.get_state_model(source_database) == before_timer_gate
+            and not client.database_exists(quarantine_database),
+            "timer preflight wrote remote state",
+        )
+        counts["timerZeroWritePreflights"] += 1
+        stop_timer_compatibly(client, source_database)
+
+        phase = "ambiguous quarantine capture"
+        ambiguous_client = AmbiguousReplicationOnce(client)
+        try:
+            capture_quarantine(
+                ambiguous_client,
+                source_database,
+                quarantine_database,
+                allow_disposable_preview=True,
+            )
+        except QuarantineSafetyError as error:
+            require(
+                "forced ambiguous transient response" in str(error),
+                "initial transient replication failed before response ambiguity",
+            )
+            counts["ambiguousReplicationRetries"] += 1
+        else:
+            raise QuarantineSafetyError("transient response ambiguity was not exercised")
+        require(
+            client.database_exists(quarantine_database),
+            "ambiguous replication did not retain its quarantine target",
+        )
+
+        phase = "retained-target quarantine retry"
+        capture = capture_quarantine(
+            client,
+            source_database,
+            quarantine_database,
+            allow_disposable_preview=True,
+            resume_existing=True,
+        )
+        source_attachment = attachment_revision(client, source_database)
+        quarantine_attachment = attachment_revision(client, quarantine_database)
+        require(
+            source_attachment == quarantine_attachment,
+            "attachment revision did not survive quarantine replication",
+        )
+
+        phase = "source drift fence gate"
+        drifted_task = client.get_document(source_database, "task-preview")
+        require(
+            drifted_task is not None and isinstance(drifted_task.get("_rev"), str),
+            "preview task is absent before source drift",
+        )
+        drifted_task["description"] = "private edited preview task"
+        client.put_document(
+            source_database,
+            drifted_task,
+            create_only=False,
+        )
+        try:
+            install_fence(client, capture)
+        except QuarantineSafetyError:
+            counts["leafDriftBlocks"] += 1
+        else:
+            raise QuarantineSafetyError("source leaf drift did not block fencing")
+        require(
+            client.get_document(source_database, CONTRACT_DESIGN_ID) is None,
+            "source leaf drift installed a validator",
+        )
+
+        phase = "resumed quarantine capture"
+        capture = capture_quarantine(
+            client,
+            source_database,
+            quarantine_database,
+            allow_disposable_preview=True,
+            resume_existing=True,
+        )
+
+        phase = "security drift fence gate"
+        original_security = client.get_security_document(source_database)
+        drifted_security = copy.deepcopy(original_security)
+        cloudant_roles = drifted_security.setdefault("cloudant", {})
+        require(isinstance(cloudant_roles, dict), "preview security shape is unsupported")
+        cloudant_roles[f"preview-drift-{nonce}"] = ["_reader"]
+        client.put_preview_security(source_database, drifted_security)
+        try:
+            try:
+                install_fence(client, capture)
+            except QuarantineSafetyError:
+                counts["securityDriftBlocks"] += 1
+            else:
+                raise QuarantineSafetyError("security drift did not block fencing")
+        finally:
+            client.put_preview_security(source_database, original_security)
+        require(
+            client.get_security_hash(source_database) == capture.security_hash,
+            "preview security was not restored exactly",
+        )
+
+        phase = "validator installation"
+        fence = install_fence(client, capture)
+        require(
+            client.get_state_model(source_database) == fence.fenced_state,
+            "validator installation state was not stable",
+        )
+
+        phase = "legacy denial"
+        try:
+            client.put_document(
+                source_database,
+                {
+                    "_id": "task-preview-legacy-denied",
+                    "id": "task-preview-legacy-denied",
+                    "docType": "task",
+                    "type": "unscheduled",
+                },
+                create_only=True,
+            )
+        except QuarantineSafetyError:
+            counts["legacyWritesDenied"] += 1
+        else:
+            raise QuarantineSafetyError("legacy write was not denied")
+
+        phase = "forced migration interruption"
+        interrupted_client = InterruptOnce(client)
+        try:
+            execute_migration(
+                interrupted_client,
+                fence,
+                completed_at=datetime.now(UTC).isoformat(),
+            )
+        except QuarantineSafetyError as error:
+            require("forced interruption" in str(error), "migration failed before interruption")
+            counts["forcedInterruptions"] += 1
+        else:
+            raise QuarantineSafetyError("forced interruption did not occur")
+
+        phase = "fresh migration resume"
+        fresh_client = OperationalCloudantClient(credential_url)
+        migration = execute_migration(
+            fresh_client,
+            fence,
+            completed_at=datetime.now(UTC).isoformat(),
+        )
+
+        phase = "compatible write and final invariant"
+        fresh_client.put_document(
+            source_database,
+            {
+                "_id": "config-preview-unexpected",
+                "id": "config-preview-unexpected",
+                "docType": "config",
+                "category": None,
+                "categoryId": None,
+                "categoryIdentityVersion": None,
+                "writerContract": {"version": 1, "categoryReference": None},
+            },
+            create_only=True,
+        )
+        counts["compatibleWritesAccepted"] += 1
+        try:
+            execute_migration(
+                fresh_client,
+                fence,
+                completed_at=datetime.now(UTC).isoformat(),
+            )
+        except QuarantineSafetyError:
+            counts["unexpectedRevisionBlocks"] += 1
+        else:
+            raise QuarantineSafetyError("unexpected revision did not block final verification")
+        require(
+            fresh_client.get_security_hash(source_database) == capture.security_hash,
+            "source security changed during successful migration",
+        )
+        report_values = (capture, fence, migration)
+    except QuarantineSafetyError as error:
+        print(f"Cloudant quarantine gate blocked during {phase}: {error}", file=sys.stderr)
+        return_code = 2
+    else:
+        return_code = 0
+    finally:
+        cleanup_errors = 0
+        if quarantine_may_be_owned:
+            try:
+                if client.database_exists(quarantine_database):
+                    client.delete_database(quarantine_database, allow_disposable_preview=True)
+            except QuarantineSafetyError:
+                cleanup_errors += 1
+        if source_may_be_owned:
+            try:
+                if client.database_exists(source_database):
+                    client.delete_database(source_database, allow_disposable_preview=True)
+            except QuarantineSafetyError:
+                cleanup_errors += 1
+        try:
+            if client.database_exists(source_database) or client.database_exists(
+                quarantine_database
+            ):
+                cleanup_errors += 1
+        except QuarantineSafetyError:
+            cleanup_errors += 1
+        if cleanup_errors:
+            print("Cloudant quarantine gate cleanup verification failed", file=sys.stderr)
+            return_code = 2
+
+    if return_code == 0 and report_values is not None:
+        safe_report(
+            capture=report_values[0],
+            fence=report_values[1],
+            migration=report_values[2],
+            counts=counts,
+        )
+    return return_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cloudant_quarantine_migration.py
+++ b/scripts/cloudant_quarantine_migration.py
@@ -1,0 +1,1297 @@
+"""Minimal Cloudant-native quarantine and migration safety operations.
+
+This module deliberately delegates revision-tree transfer to Cloudant replication.
+It does not implement a local backup format or a reverse-restore path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import base64
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.document_contract_ops import (
+    CONTRACT_DESIGN_ID,
+    load_design_document,
+    verify_validator,
+)
+from scripts.migrate_taxonomy_identity import (
+    CREDENTIAL_ENV_VAR,
+    MigrationSafetyError,
+    RUNNING_ACTIVITY_ID,
+    TAXONOMY_DOCUMENT_ID,
+    build_migration_plan,
+)
+
+
+SOURCE_DATABASE = "fortudo-dat-411"
+PREVIEW_SOURCE_PATTERN = re.compile(r"fortudo-preview-quarantine-gate-[a-f0-9]{24,64}-source")
+PREVIEW_QUARANTINE_PATTERN = re.compile(
+    r"fortudo-preview-quarantine-gate-[a-f0-9]{24,64}-quarantine"
+)
+QUARANTINE_PATTERN = re.compile(r"fortudo-quarantine-[a-f0-9]{24,64}")
+COMPLETION_MARKER_ID = "config-taxonomy-identity-migration-v1"
+LEAF_READ_BATCH_SIZE = 100
+RATE_LIMIT_RETRIES = 6
+RATE_LIMIT_BASE_DELAY_SECONDS = 0.5
+
+
+class QuarantineSafetyError(RuntimeError):
+    """Raised when a remote mutation safety gate does not hold."""
+
+
+@dataclass(frozen=True, order=True)
+class LeafRevision:
+    """One current non-local revision-tree leaf."""
+
+    document_id: str
+    revision: str
+    deleted: bool
+
+
+@dataclass(frozen=True)
+class StateModel:
+    """Canonical current revision state."""
+
+    leaves: tuple[LeafRevision, ...]
+    winners: tuple[tuple[str, str], ...]
+    counts: dict[str, int]
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class CaptureReceipt:
+    source_database: str
+    quarantine_database: str
+    state: StateModel
+    security_hash: str
+    disposable_preview: bool = False
+
+
+@dataclass(frozen=True)
+class FenceReceipt:
+    capture: CaptureReceipt
+    validator_revision: str
+    fenced_state: StateModel
+
+
+@dataclass(frozen=True)
+class MigrationClassification:
+    complete: bool
+    transitioned_updates: int
+    transitioned_tombstones: int
+
+
+@dataclass(frozen=True)
+class MigrationExecutionResult:
+    state: str
+    counts: dict[str, int]
+    verified_state_fingerprint: str
+    marker_revision: str
+
+
+class OperationalCloudantClient:
+    """Small write-capable client limited to this migration's Cloudant endpoints."""
+
+    def __init__(self, credential_url: str) -> None:
+        parsed = urllib.parse.urlsplit(credential_url)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise QuarantineSafetyError("Cloudant credential URL must use HTTPS")
+        if parsed.username is None or parsed.password is None:
+            raise QuarantineSafetyError("Cloudant credential URL is missing credentials")
+        port = f":{parsed.port}" if parsed.port else ""
+        self._endpoint = urllib.parse.urlunsplit(
+            (parsed.scheme, f"{parsed.hostname}{port}", parsed.path.rstrip("/"), "", "")
+        )
+        self._username = urllib.parse.unquote(parsed.username)
+        self._password = urllib.parse.unquote(parsed.password)
+        token = base64.b64encode(f"{self._username}:{self._password}".encode("utf-8")).decode(
+            "ascii"
+        )
+        self._authorization = f"Basic {token}"
+
+    @property
+    def account_checksum(self) -> str:
+        """Stable non-secret binding for the credential's account endpoint."""
+
+        return hashlib.sha256(self._endpoint.encode("utf-8")).hexdigest()
+
+    def _request(
+        self,
+        method: str,
+        operation: str,
+        path: str,
+        *,
+        body: Mapping[str, Any] | None = None,
+        allow_not_found: bool = False,
+    ) -> Any:
+        encoded_body = None
+        headers = {"Authorization": self._authorization, "Accept": "application/json"}
+        if body is not None:
+            encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self._endpoint}/{path.lstrip('/')}",
+            data=encoded_body,
+            method=method,
+            headers=headers,
+        )
+        for attempt in range(RATE_LIMIT_RETRIES + 1):
+            try:
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    payload = response.read()
+                return json.loads(payload) if payload else {}
+            except urllib.error.HTTPError as error:
+                if allow_not_found and error.code == 404:
+                    return None
+                if error.code == 429 and attempt < RATE_LIMIT_RETRIES:
+                    delay = RATE_LIMIT_BASE_DELAY_SECONDS * (2**attempt)
+                    retry_after = error.headers.get("Retry-After") if error.headers else None
+                    try:
+                        delay = max(delay, float(retry_after))
+                    except (TypeError, ValueError):
+                        pass
+                    time.sleep(min(delay, 8.0))
+                    continue
+                raise QuarantineSafetyError(
+                    f"Cloudant request failed with HTTP {error.code} during {operation}"
+                ) from None
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+                raise QuarantineSafetyError(
+                    f"Cloudant request failed during {operation}"
+                ) from None
+        raise AssertionError("unreachable Cloudant retry state")
+
+    @staticmethod
+    def _database_path(database: str) -> str:
+        return urllib.parse.quote(database, safe="")
+
+    def get_document(self, database: str, document_id: str) -> dict[str, Any] | None:
+        path = f"{self._database_path(database)}/{urllib.parse.quote(document_id, safe='')}"
+        payload = self._request("GET", "document read", path, allow_not_found=True)
+        if payload is None:
+            return None
+        if not isinstance(payload, Mapping):
+            raise QuarantineSafetyError("Cloudant returned an invalid document response")
+        return dict(payload)
+
+    def get_security_hash(self, database: str) -> str:
+        payload = self._request(
+            "GET", "security read", f"{self._database_path(database)}/_security"
+        )
+        if not isinstance(payload, Mapping):
+            raise QuarantineSafetyError("Cloudant returned an invalid security response")
+        return canonical_hash(payload)
+
+    def database_exists(self, database: str) -> bool:
+        payload = self._request(
+            "GET",
+            "database existence read",
+            self._database_path(database),
+            allow_not_found=True,
+        )
+        if payload is None:
+            return False
+        if not isinstance(payload, Mapping) or payload.get("db_name") != database:
+            raise QuarantineSafetyError("Cloudant reported a different database identity")
+        return True
+
+    def create_database(
+        self,
+        database: str,
+        *,
+        partitioned: bool,
+        allow_disposable_preview: bool = False,
+    ) -> None:
+        _require_database_lifecycle_target(
+            database, allow_disposable_preview=allow_disposable_preview
+        )
+        partition_value = "true" if partitioned else "false"
+        payload = self._request(
+            "PUT",
+            "database create",
+            f"{self._database_path(database)}?partitioned={partition_value}",
+        )
+        if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+            raise QuarantineSafetyError("Cloudant returned an invalid database create response")
+
+    def delete_database(self, database: str, *, allow_disposable_preview: bool = False) -> None:
+        _require_database_lifecycle_target(
+            database, allow_disposable_preview=allow_disposable_preview
+        )
+        payload = self._request("DELETE", "database delete", self._database_path(database))
+        if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+            raise QuarantineSafetyError("Cloudant returned an invalid database delete response")
+
+    def get_security_document(self, database: str) -> dict[str, Any]:
+        payload = self._request(
+            "GET", "security read", f"{self._database_path(database)}/_security"
+        )
+        if not isinstance(payload, Mapping):
+            raise QuarantineSafetyError("Cloudant returned an invalid security response")
+        return dict(payload)
+
+    def replicate_once(
+        self,
+        source_database: str,
+        quarantine_database: str,
+        *,
+        allow_disposable_preview: bool = False,
+    ) -> dict[str, Any]:
+        """Run one non-persistent replication request.
+
+        A timeout or disconnected response is deliberately reported as ambiguous. The caller
+        retains the target and may safely rerun this request before trusting exact state equality.
+        """
+
+        body = build_replication_document(
+            source_database,
+            quarantine_database,
+            endpoint=self._endpoint,
+            username=self._username,
+            password=self._password,
+            allow_disposable_preview=allow_disposable_preview,
+        )
+        payload = self._request(
+            "POST",
+            "transient replication",
+            "_replicate",
+            body=body,
+        )
+        if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+            raise QuarantineSafetyError("Cloudant returned an invalid replication response")
+        history = payload.get("history")
+        if not isinstance(history, list) or not history:
+            raise QuarantineSafetyError("Cloudant replication response omitted its history")
+        latest = history[0]
+        if not isinstance(latest, Mapping) or latest.get("doc_write_failures", 0) != 0:
+            raise QuarantineSafetyError("replication completed with document write failures")
+        return dict(payload)
+
+    def put_document(
+        self, database: str, document: Mapping[str, Any], *, create_only: bool = False
+    ) -> dict[str, Any]:
+        document_id = document.get("_id")
+        if not isinstance(document_id, str) or not document_id:
+            raise QuarantineSafetyError("document write is missing an ID")
+        if create_only and "_rev" in document:
+            raise QuarantineSafetyError("create-only document must not contain a revision")
+        operation = "document create" if create_only else "document update"
+        payload = self._request(
+            "PUT",
+            operation,
+            f"{self._database_path(database)}/{urllib.parse.quote(document_id, safe='')}",
+            body=document,
+        )
+        if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+            raise QuarantineSafetyError("Cloudant returned an invalid document write response")
+        return dict(payload)
+
+    def get_all_documents(self, database: str, *, include_conflicts: bool) -> list[dict[str, Any]]:
+        query = "include_docs=true"
+        if include_conflicts:
+            query += "&conflicts=true"
+        payload = self._request(
+            "GET",
+            "winning document read",
+            f"{self._database_path(database)}/_all_docs?{query}",
+        )
+        if not isinstance(payload, Mapping) or not isinstance(payload.get("rows"), list):
+            raise QuarantineSafetyError("Cloudant returned an invalid winning document response")
+        documents: list[dict[str, Any]] = []
+        for row in payload["rows"]:
+            if not isinstance(row, Mapping):
+                raise QuarantineSafetyError(
+                    "Cloudant returned an invalid winning document response"
+                )
+            document = row.get("doc")
+            if document is None:
+                continue
+            if not isinstance(document, Mapping):
+                raise QuarantineSafetyError(
+                    "Cloudant returned an invalid winning document response"
+                )
+            documents.append(dict(document))
+        return documents
+
+    def _get_current_leaf_documents(
+        self, database: str, *, include_ancestry: bool
+    ) -> list[dict[str, Any]]:
+        database_path = self._database_path(database)
+        changes = self._request(
+            "GET",
+            "leaf enumeration",
+            f"{database_path}/_changes?since=0&style=all_docs&include_docs=false",
+        )
+        if not isinstance(changes, Mapping) or not isinstance(changes.get("results"), list):
+            raise QuarantineSafetyError("Cloudant returned an invalid leaf enumeration")
+        expected: set[tuple[str, str]] = set()
+        for row in changes["results"]:
+            document_id = row.get("id") if isinstance(row, Mapping) else None
+            revision_rows = row.get("changes") if isinstance(row, Mapping) else None
+            if (
+                not isinstance(document_id, str)
+                or not isinstance(revision_rows, list)
+                or not revision_rows
+            ):
+                raise QuarantineSafetyError("Cloudant returned an invalid leaf enumeration")
+            for revision_row in revision_rows:
+                revision = revision_row.get("rev") if isinstance(revision_row, Mapping) else None
+                identity = (document_id, revision)
+                if not isinstance(revision, str) or not revision or identity in expected:
+                    raise QuarantineSafetyError("Cloudant returned an invalid leaf enumeration")
+                expected.add((document_id, revision))
+
+        leaf_documents: list[dict[str, Any]] = []
+        returned: set[tuple[str, str]] = set()
+        requested = sorted(expected)
+        for offset in range(0, len(requested), LEAF_READ_BATCH_SIZE):
+            batch = requested[offset : offset + LEAF_READ_BATCH_SIZE]
+            payload = self._request(
+                "POST",
+                "leaf body read",
+                f"{database_path}/_bulk_get"
+                f"?revs={'true' if include_ancestry else 'false'}&attachments=false",
+                body={
+                    "docs": [
+                        {"id": document_id, "rev": revision} for document_id, revision in batch
+                    ]
+                },
+            )
+            if not isinstance(payload, Mapping) or not isinstance(payload.get("results"), list):
+                raise QuarantineSafetyError("Cloudant returned an invalid leaf body response")
+            for result in payload["results"]:
+                result_id = result.get("id") if isinstance(result, Mapping) else None
+                documents = result.get("docs") if isinstance(result, Mapping) else None
+                if not isinstance(result_id, str) or not isinstance(documents, list):
+                    raise QuarantineSafetyError("Cloudant returned an invalid leaf body response")
+                for document_result in documents:
+                    document = (
+                        document_result.get("ok") if isinstance(document_result, Mapping) else None
+                    )
+                    revision = document.get("_rev") if isinstance(document, Mapping) else None
+                    identity = (result_id, revision)
+                    if (
+                        not isinstance(document, Mapping)
+                        or document.get("_id") != result_id
+                        or not isinstance(revision, str)
+                        or identity not in expected
+                        or identity in returned
+                    ):
+                        raise QuarantineSafetyError("Cloudant returned an inconsistent leaf body")
+                    returned.add((result_id, revision))
+                    leaf_documents.append(dict(document))
+        if returned != expected:
+            raise QuarantineSafetyError("Cloudant omitted a current leaf body")
+        return leaf_documents
+
+    def get_leaf_documents(self, database: str) -> list[dict[str, Any]]:
+        return self._get_current_leaf_documents(database, include_ancestry=True)
+
+    def get_state_model(self, database: str) -> StateModel:
+        database_path = self._database_path(database)
+        metadata = self._request("GET", "database metadata read", database_path)
+        leaf_documents = self._get_current_leaf_documents(database, include_ancestry=False)
+        all_documents = self._request(
+            "POST",
+            "winner enumeration",
+            f"{database_path}/_all_docs",
+            body={"keys": sorted({document["_id"] for document in leaf_documents})},
+        )
+        if not isinstance(metadata, Mapping) or metadata.get("db_name") != database:
+            raise QuarantineSafetyError("Cloudant returned invalid database metadata")
+        if not isinstance(all_documents, Mapping) or not isinstance(
+            all_documents.get("rows"), list
+        ):
+            raise QuarantineSafetyError("Cloudant returned an invalid winner enumeration")
+
+        leaf_rows = [
+            {
+                "id": document["_id"],
+                "rev": document["_rev"],
+                "deleted": document.get("_deleted") is True,
+            }
+            for document in leaf_documents
+        ]
+
+        winners: dict[str, str] = {}
+        for row in all_documents["rows"]:
+            value = row.get("value") if isinstance(row, Mapping) else None
+            document_id = row.get("id") if isinstance(row, Mapping) else None
+            revision = value.get("rev") if isinstance(value, Mapping) else None
+            if not isinstance(document_id, str) or not isinstance(revision, str):
+                raise QuarantineSafetyError("Cloudant returned an invalid winner enumeration")
+            winners[document_id] = revision
+        return build_state_model(leaf_rows, winners)
+
+
+def canonical_hash(value: Any) -> str:
+    """Hash a JSON value with deterministic object-key and whitespace handling."""
+
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_state_model(
+    leaf_rows: Sequence[Mapping[str, Any]],
+    winner_revisions: Mapping[str, str],
+) -> StateModel:
+    """Validate and canonicalize the current non-``_local`` leaf graph."""
+
+    leaves: list[LeafRevision] = []
+    seen: set[tuple[str, str]] = set()
+    revisions_by_document: dict[str, set[str]] = {}
+    for row in leaf_rows:
+        document_id = row.get("id")
+        revision = row.get("rev")
+        deleted = row.get("deleted")
+        if isinstance(document_id, str) and document_id.startswith("_local/"):
+            continue
+        if not isinstance(document_id, str) or not document_id:
+            raise QuarantineSafetyError("leaf enumeration contains an invalid document ID")
+        if not isinstance(revision, str) or not revision:
+            raise QuarantineSafetyError("leaf enumeration contains an invalid revision")
+        if not isinstance(deleted, bool):
+            raise QuarantineSafetyError("leaf enumeration contains an invalid deletion state")
+        identity = (document_id, revision)
+        if identity in seen:
+            raise QuarantineSafetyError("leaf enumeration contains a duplicate revision")
+        seen.add(identity)
+        revisions_by_document.setdefault(document_id, set()).add(revision)
+        leaves.append(LeafRevision(document_id, revision, deleted))
+
+    winners: dict[str, str] = {}
+    for document_id, revision in winner_revisions.items():
+        if document_id.startswith("_local/"):
+            continue
+        if not document_id or not isinstance(revision, str) or not revision:
+            raise QuarantineSafetyError("winner enumeration is invalid")
+        winners[document_id] = revision
+
+    if set(winners) != set(revisions_by_document):
+        raise QuarantineSafetyError("winner enumeration does not match the leaf documents")
+    for document_id, revision in winners.items():
+        if revision not in revisions_by_document[document_id]:
+            raise QuarantineSafetyError("winner revision is absent from the current leaf set")
+
+    canonical_leaves = tuple(sorted(leaves))
+    canonical_winners = tuple(sorted(winners.items()))
+    counts = {
+        "documents": len(revisions_by_document),
+        "liveLeaves": sum(not leaf.deleted for leaf in canonical_leaves),
+        "deletedLeaves": sum(leaf.deleted for leaf in canonical_leaves),
+        "conflictLeaves": sum(
+            max(0, len(revisions) - 1) for revisions in revisions_by_document.values()
+        ),
+    }
+    fingerprint_payload = {
+        "leaves": [[leaf.document_id, leaf.revision, leaf.deleted] for leaf in canonical_leaves],
+        "winners": [list(winner) for winner in canonical_winners],
+    }
+    return StateModel(
+        leaves=canonical_leaves,
+        winners=canonical_winners,
+        counts=counts,
+        fingerprint=canonical_hash(fingerprint_payload),
+    )
+
+
+def add_leaf_to_state(
+    source: StateModel,
+    document_id: str,
+    revision: str,
+    *,
+    deleted: bool,
+) -> StateModel:
+    """Return a state with one new document leaf, failing on identity reuse."""
+
+    if document_id in dict(source.winners):
+        raise QuarantineSafetyError("cannot add a leaf for an existing document")
+    rows = [
+        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
+        for leaf in source.leaves
+    ]
+    rows.append({"id": document_id, "rev": revision, "deleted": deleted})
+    winners = dict(source.winners)
+    winners[document_id] = revision
+    return build_state_model(rows, winners)
+
+
+def _remove_document_from_state(source: StateModel, document_id: str) -> StateModel:
+    rows = [
+        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
+        for leaf in source.leaves
+        if leaf.document_id != document_id
+    ]
+    winners = dict(source.winners)
+    winners.pop(document_id, None)
+    return build_state_model(rows, winners)
+
+
+def _require_source_database(database: str, *, allow_disposable_preview: bool = False) -> None:
+    if database == SOURCE_DATABASE:
+        return
+    if allow_disposable_preview and PREVIEW_SOURCE_PATTERN.fullmatch(database):
+        return
+    raise QuarantineSafetyError("database is not an approved source target")
+
+
+def _require_quarantine_database(database: str, *, allow_disposable_preview: bool = False) -> None:
+    if QUARANTINE_PATTERN.fullmatch(database):
+        return
+    if allow_disposable_preview and PREVIEW_QUARANTINE_PATTERN.fullmatch(database):
+        return
+    raise QuarantineSafetyError("quarantine database name is invalid")
+
+
+def _require_database_lifecycle_target(database: str, *, allow_disposable_preview: bool) -> None:
+    if QUARANTINE_PATTERN.fullmatch(database):
+        return
+    if allow_disposable_preview and (
+        PREVIEW_SOURCE_PATTERN.fullmatch(database) or PREVIEW_QUARANTINE_PATTERN.fullmatch(database)
+    ):
+        return
+    raise QuarantineSafetyError("database lifecycle target is invalid")
+
+
+def build_replication_document(
+    source_database: str,
+    quarantine_database: str,
+    *,
+    endpoint: str,
+    username: str,
+    password: str,
+    allow_disposable_preview: bool = False,
+) -> dict[str, Any]:
+    """Build the only supported one-shot, unfiltered replication definition."""
+
+    _require_source_database(source_database, allow_disposable_preview=allow_disposable_preview)
+    _require_quarantine_database(
+        quarantine_database, allow_disposable_preview=allow_disposable_preview
+    )
+    root = endpoint.rstrip("/")
+    if not root.startswith("https://") or not username or not password:
+        raise QuarantineSafetyError("replication authentication is invalid")
+    authentication = {"basic": {"username": username, "password": password}}
+    return {
+        "source": {
+            "url": f"{root}/{source_database}",
+            "auth": copy.deepcopy(authentication),
+        },
+        "target": {
+            "url": f"{root}/{quarantine_database}",
+            "auth": copy.deepcopy(authentication),
+        },
+    }
+
+
+def _require_no_running_timer(client: Any, database: str) -> None:
+    if client.get_document(database, RUNNING_ACTIVITY_ID) is not None:
+        raise QuarantineSafetyError("running timer must be stopped before any remote mutation")
+
+
+def require_locked_taxonomy_meanings(documents: Sequence[Mapping[str, Any]]) -> None:
+    """Check the two approved production meanings from the current taxonomy rows."""
+
+    matches = [document for document in documents if document.get("_id") == TAXONOMY_DOCUMENT_ID]
+    if len(matches) != 1 or not isinstance(matches[0].get("categories"), list):
+        raise QuarantineSafetyError("locked taxonomy meaning cannot be verified")
+    labels: dict[str, str] = {}
+    for row in matches[0]["categories"]:
+        if isinstance(row, Mapping) and isinstance(row.get("key"), str):
+            labels[row["key"]] = row.get("label")
+    if labels.get("work/meetings") != "Comms" or labels.get("work/comms") != "Meetings":
+        raise QuarantineSafetyError("locked taxonomy meaning differs from the approved mapping")
+
+
+def _checked_migration_plan(documents: Sequence[Mapping[str, Any]]) -> Any:
+    try:
+        return build_migration_plan(documents)
+    except MigrationSafetyError:
+        raise QuarantineSafetyError("migration planning precondition failed") from None
+
+
+def _normalized_successor(document: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(dict(document))
+    normalized.pop("_revisions", None)
+    normalized.pop("_conflicts", None)
+    normalized.pop("_deleted_conflicts", None)
+    return normalized
+
+
+def _immediate_parent(document: Mapping[str, Any]) -> str | None:
+    revision = document.get("_rev")
+    history = document.get("_revisions")
+    if not isinstance(revision, str) or not isinstance(history, Mapping):
+        return None
+    try:
+        generation_text, digest = revision.split("-", 1)
+        generation = int(generation_text)
+    except (ValueError, AttributeError):
+        return None
+    start = history.get("start")
+    identifiers = history.get("ids")
+    if (
+        not isinstance(start, int)
+        or start != generation
+        or not isinstance(identifiers, list)
+        or len(identifiers) < 2
+        or identifiers[0] != digest
+        or not isinstance(identifiers[1], str)
+        or generation < 2
+    ):
+        return None
+    return f"{generation - 1}-{identifiers[1]}"
+
+
+def classify_migration_state(
+    base_documents: Sequence[Mapping[str, Any]],
+    base_state: StateModel,
+    current_leaf_documents: Sequence[Mapping[str, Any]],
+    current_state: StateModel,
+    *,
+    validator_revision: str,
+    completion_marker: Mapping[str, Any] | None = None,
+) -> MigrationClassification:
+    """Accept only unchanged quarantine leaves or exact one-step migration descendants."""
+
+    require_locked_taxonomy_meanings(base_documents)
+    plan = _checked_migration_plan(base_documents)
+    if plan.running_timer_present:
+        raise QuarantineSafetyError("quarantine contains a running timer")
+    base_winners = dict(base_state.winners)
+    expected_updates = {document["_id"]: document for document in plan.updates}
+    expected_tombstones = {
+        (document["_id"], document["_rev"]): document for document in plan.conflict_tombstones
+    }
+
+    state_deletions = {
+        (leaf.document_id, leaf.revision): leaf.deleted for leaf in current_state.leaves
+    }
+    current_by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    children_by_parent: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for source in current_leaf_documents:
+        document = copy.deepcopy(dict(source))
+        document_id = document.get("_id")
+        revision = document.get("_rev")
+        identity = (document_id, revision)
+        if (
+            not isinstance(document_id, str)
+            or not isinstance(revision, str)
+            or identity in current_by_identity
+            or identity not in state_deletions
+            or (document.get("_deleted") is True) != state_deletions[identity]
+        ):
+            raise QuarantineSafetyError("current leaf bodies do not match current state")
+        current_by_identity[identity] = document
+        parent = _immediate_parent(document)
+        if parent is not None:
+            children_by_parent.setdefault((document_id, parent), []).append(document)
+    if set(current_by_identity) != set(state_deletions):
+        raise QuarantineSafetyError("current leaf bodies do not cover current state")
+
+    consumed: set[tuple[str, str]] = set()
+    winner_transitions: dict[str, str] = {}
+    transitioned_updates = 0
+    transitioned_tombstones = 0
+    for leaf in base_state.leaves:
+        identity = (leaf.document_id, leaf.revision)
+        if identity in current_by_identity:
+            consumed.add(identity)
+            continue
+        candidates = children_by_parent.get(identity, [])
+        if len(candidates) != 1:
+            raise QuarantineSafetyError("base leaf has no unique immediate migration successor")
+        candidate = candidates[0]
+        candidate_identity = (candidate["_id"], candidate["_rev"])
+        intended: Mapping[str, Any] | None = None
+        if base_winners.get(leaf.document_id) == leaf.revision:
+            intended = expected_updates.get(leaf.document_id)
+            if intended is not None:
+                transitioned_updates += 1
+                winner_transitions[leaf.document_id] = candidate["_rev"]
+        if intended is None:
+            intended = expected_tombstones.get(identity)
+            if intended is not None:
+                transitioned_tombstones += 1
+        if intended is None:
+            raise QuarantineSafetyError("unexpected successor of a quarantined leaf")
+        comparable_intended = copy.deepcopy(dict(intended))
+        comparable_intended["_rev"] = candidate["_rev"]
+        if _normalized_successor(candidate) != _normalized_successor(comparable_intended):
+            raise QuarantineSafetyError("leaf is not the intended migration successor")
+        consumed.add(candidate_identity)
+
+    design_identity = (CONTRACT_DESIGN_ID, validator_revision)
+    design = current_by_identity.get(design_identity)
+    if design is None:
+        raise QuarantineSafetyError("expected validator leaf is absent")
+    comparable_design = load_design_document()
+    comparable_design["_rev"] = validator_revision
+    if _normalized_successor(design) != comparable_design:
+        raise QuarantineSafetyError("validator leaf differs from the reviewed contract")
+    consumed.add(design_identity)
+    if completion_marker is not None:
+        marker_revision = completion_marker.get("_rev")
+        marker_identity = (COMPLETION_MARKER_ID, marker_revision)
+        current_marker = current_by_identity.get(marker_identity)
+        if (
+            not isinstance(marker_revision, str)
+            or current_marker is None
+            or _normalized_successor(current_marker) != _normalized_successor(completion_marker)
+        ):
+            raise QuarantineSafetyError("completion marker leaf differs from expectation")
+        consumed.add(marker_identity)
+    if consumed != set(current_by_identity):
+        raise QuarantineSafetyError("current state contains an unrelated leaf")
+
+    expected_winners = dict(base_state.winners)
+    expected_winners.update(winner_transitions)
+    expected_winners[CONTRACT_DESIGN_ID] = validator_revision
+    if completion_marker is not None:
+        expected_winners[COMPLETION_MARKER_ID] = completion_marker["_rev"]
+    if dict(current_state.winners) != expected_winners:
+        raise QuarantineSafetyError("current winners differ from the intended migration state")
+    return MigrationClassification(
+        complete=(
+            transitioned_updates == len(expected_updates)
+            and transitioned_tombstones == len(expected_tombstones)
+        ),
+        transitioned_updates=transitioned_updates,
+        transitioned_tombstones=transitioned_tombstones,
+    )
+
+
+def _completion_marker(
+    fence: FenceReceipt,
+    verified_state: StateModel,
+    counts: Mapping[str, int],
+    completed_at: str,
+) -> dict[str, Any]:
+    if not isinstance(completed_at, str) or not completed_at:
+        raise QuarantineSafetyError("completion timestamp is required")
+    return {
+        "_id": COMPLETION_MARKER_ID,
+        "id": COMPLETION_MARKER_ID,
+        "docType": "config",
+        "migrationVersion": 1,
+        "quarantineFingerprint": fence.capture.state.fingerprint,
+        "verifiedStateFingerprint": verified_state.fingerprint,
+        "validatorRevision": fence.validator_revision,
+        "counts": dict(counts),
+        "completedAt": completed_at,
+        "category": None,
+        "categoryId": None,
+        "categoryIdentityVersion": None,
+        "writerContract": {"version": 1, "categoryReference": None},
+    }
+
+
+def _validate_completion_marker(
+    marker: Mapping[str, Any],
+    fence: FenceReceipt,
+    data_state: StateModel,
+    counts: Mapping[str, int],
+) -> None:
+    expected_fields = {
+        "_id": COMPLETION_MARKER_ID,
+        "id": COMPLETION_MARKER_ID,
+        "docType": "config",
+        "migrationVersion": 1,
+        "quarantineFingerprint": fence.capture.state.fingerprint,
+        "verifiedStateFingerprint": data_state.fingerprint,
+        "validatorRevision": fence.validator_revision,
+        "counts": dict(counts),
+        "category": None,
+        "categoryId": None,
+        "categoryIdentityVersion": None,
+        "writerContract": {"version": 1, "categoryReference": None},
+    }
+    if any(marker.get(key) != value for key, value in expected_fields.items()):
+        raise QuarantineSafetyError("completion marker does not match verified state")
+    if not isinstance(marker.get("completedAt"), str) or not marker["completedAt"]:
+        raise QuarantineSafetyError("completion marker timestamp is invalid")
+    allowed = {*expected_fields, "completedAt", "_rev", "_revisions"}
+    if set(marker) - allowed:
+        raise QuarantineSafetyError("completion marker contains unexpected fields")
+
+
+def _require_exact_validator(client: Any, database: str, expected_revision: str) -> None:
+    document = client.get_document(database, CONTRACT_DESIGN_ID)
+    if document is None or document.get("_rev") != expected_revision:
+        raise QuarantineSafetyError("validator revision differs from the fenced revision")
+    comparable = copy.deepcopy(dict(document))
+    comparable.pop("_rev", None)
+    if comparable != load_design_document():
+        raise QuarantineSafetyError("validator differs from the reviewed contract")
+
+
+def _ordered_updates(plan: Any) -> list[dict[str, Any]]:
+    kind_order = {"task": 1, "activity": 2}
+    return sorted(
+        plan.updates,
+        key=lambda document: (
+            0
+            if document.get("_id") == TAXONOMY_DOCUMENT_ID
+            else kind_order.get(document.get("docType"), 3),
+            str(document.get("_id")),
+        ),
+    )
+
+
+def execute_migration(
+    client: Any,
+    fence: FenceReceipt,
+    *,
+    completed_at: str,
+) -> MigrationExecutionResult:
+    """Resume or complete the exact ``fortudo-dat-411`` identity migration."""
+
+    source_database = fence.capture.source_database
+    quarantine_database = fence.capture.quarantine_database
+    _require_source_database(
+        source_database, allow_disposable_preview=fence.capture.disposable_preview
+    )
+    _require_quarantine_database(
+        quarantine_database,
+        allow_disposable_preview=fence.capture.disposable_preview,
+    )
+    _require_no_running_timer(client, source_database)
+    if client.get_security_hash(source_database) != fence.capture.security_hash:
+        raise QuarantineSafetyError("source security drift blocks migration")
+    if client.get_state_model(quarantine_database) != fence.capture.state:
+        raise QuarantineSafetyError("quarantine state drift blocks migration")
+    base_documents = client.get_all_documents(quarantine_database, include_conflicts=True)
+    require_locked_taxonomy_meanings(base_documents)
+    base_plan = _checked_migration_plan(base_documents)
+    if base_plan.running_timer_present:
+        raise QuarantineSafetyError("quarantine contains a running timer")
+    _require_exact_validator(client, source_database, fence.validator_revision)
+
+    current_state = client.get_state_model(source_database)
+    current_leaves = client.get_leaf_documents(source_database)
+    existing_marker = client.get_document(source_database, COMPLETION_MARKER_ID)
+    data_state = (
+        _remove_document_from_state(current_state, COMPLETION_MARKER_ID)
+        if existing_marker is not None
+        else current_state
+    )
+    if existing_marker is not None:
+        _validate_completion_marker(existing_marker, fence, data_state, base_plan.counts)
+    initial_classification = classify_migration_state(
+        base_documents,
+        fence.capture.state,
+        current_leaves,
+        current_state,
+        validator_revision=fence.validator_revision,
+        completion_marker=existing_marker,
+    )
+    if existing_marker is not None:
+        if not initial_classification.complete:
+            raise QuarantineSafetyError("completion marker exists before migration convergence")
+        return MigrationExecutionResult(
+            state="complete",
+            counts=base_plan.counts,
+            verified_state_fingerprint=data_state.fingerprint,
+            marker_revision=existing_marker["_rev"],
+        )
+
+    current_documents = client.get_all_documents(source_database, include_conflicts=True)
+    require_locked_taxonomy_meanings(current_documents)
+    current_plan = _checked_migration_plan(current_documents)
+    if current_plan.running_timer_present:
+        raise QuarantineSafetyError("running timer appeared before migration writes")
+    for document in _ordered_updates(current_plan):
+        response = client.put_document(source_database, document, create_only=False)
+        if (
+            not isinstance(response, Mapping)
+            or response.get("id") != document["_id"]
+            or not isinstance(response.get("rev"), str)
+        ):
+            raise QuarantineSafetyError("migration successor response is invalid")
+    for tombstone in sorted(
+        current_plan.conflict_tombstones,
+        key=lambda document: (document["_id"], document["_rev"]),
+    ):
+        response = client.put_document(source_database, tombstone, create_only=False)
+        if (
+            not isinstance(response, Mapping)
+            or response.get("id") != tombstone["_id"]
+            or not isinstance(response.get("rev"), str)
+        ):
+            raise QuarantineSafetyError("conflict tombstone response is invalid")
+
+    verified_state = client.get_state_model(source_database)
+    verified_leaves = client.get_leaf_documents(source_database)
+    classification = classify_migration_state(
+        base_documents,
+        fence.capture.state,
+        verified_leaves,
+        verified_state,
+        validator_revision=fence.validator_revision,
+    )
+    if not classification.complete:
+        raise QuarantineSafetyError("migration did not reach complete identity state")
+    settled_documents = client.get_all_documents(source_database, include_conflicts=True)
+    require_locked_taxonomy_meanings(settled_documents)
+    settled_plan = _checked_migration_plan(settled_documents)
+    if settled_plan.updates or settled_plan.conflict_tombstones:
+        raise QuarantineSafetyError("post-migration invariants are incomplete")
+    if client.get_security_hash(source_database) != fence.capture.security_hash:
+        raise QuarantineSafetyError("source security drifted during migration")
+
+    marker_body = _completion_marker(fence, verified_state, base_plan.counts, completed_at)
+    marker_response = client.put_document(source_database, marker_body, create_only=True)
+    if not isinstance(marker_response, Mapping):
+        raise QuarantineSafetyError("completion marker response is invalid")
+    marker_revision = marker_response.get("rev")
+    if marker_response.get("id") != COMPLETION_MARKER_ID or not isinstance(marker_revision, str):
+        raise QuarantineSafetyError("completion marker response is invalid")
+
+    final_state = client.get_state_model(source_database)
+    final_leaves = client.get_leaf_documents(source_database)
+    marker = client.get_document(source_database, COMPLETION_MARKER_ID)
+    if marker is None or marker.get("_rev") != marker_revision:
+        raise QuarantineSafetyError("completion marker reread differs from write response")
+    _validate_completion_marker(marker, fence, verified_state, base_plan.counts)
+    final_classification = classify_migration_state(
+        base_documents,
+        fence.capture.state,
+        final_leaves,
+        final_state,
+        validator_revision=fence.validator_revision,
+        completion_marker=marker,
+    )
+    if not final_classification.complete:
+        raise QuarantineSafetyError("final migration verification is incomplete")
+    if _remove_document_from_state(final_state, COMPLETION_MARKER_ID) != verified_state:
+        raise QuarantineSafetyError("source changed while writing the completion marker")
+    if client.get_security_hash(source_database) != fence.capture.security_hash:
+        raise QuarantineSafetyError("source security drifted after completion")
+    return MigrationExecutionResult(
+        state="complete",
+        counts=base_plan.counts,
+        verified_state_fingerprint=verified_state.fingerprint,
+        marker_revision=marker_revision,
+    )
+
+
+def capture_quarantine(
+    client: Any,
+    source_database: str,
+    quarantine_database: str,
+    *,
+    allow_disposable_preview: bool = False,
+    resume_existing: bool = False,
+) -> CaptureReceipt:
+    """Create and verify one Cloudant-native quarantine copy."""
+
+    _require_source_database(source_database, allow_disposable_preview=allow_disposable_preview)
+    _require_quarantine_database(
+        quarantine_database, allow_disposable_preview=allow_disposable_preview
+    )
+    _require_no_running_timer(client, source_database)
+
+    security_hash = client.get_security_hash(source_database)
+    locked_source = client.get_state_model(source_database)
+    if client.database_exists(quarantine_database):
+        if not resume_existing:
+            raise QuarantineSafetyError("quarantine database already exists")
+    else:
+        client.create_database(
+            quarantine_database,
+            partitioned=False,
+            allow_disposable_preview=allow_disposable_preview,
+        )
+
+    client.replicate_once(
+        source_database,
+        quarantine_database,
+        allow_disposable_preview=allow_disposable_preview,
+    )
+    current_source = client.get_state_model(source_database)
+    quarantine_state = client.get_state_model(quarantine_database)
+    if current_source != locked_source:
+        raise QuarantineSafetyError("source state drifted during quarantine capture")
+    if quarantine_state != current_source:
+        raise QuarantineSafetyError("quarantine state differs from the source")
+    if client.get_security_hash(source_database) != security_hash:
+        raise QuarantineSafetyError("source security drifted during quarantine capture")
+    return CaptureReceipt(
+        source_database=source_database,
+        quarantine_database=quarantine_database,
+        state=current_source,
+        security_hash=security_hash,
+        disposable_preview=allow_disposable_preview,
+    )
+
+
+def _expected_fenced_state(before: StateModel, validator_revision: str) -> StateModel:
+    leaf_rows = [
+        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
+        for leaf in before.leaves
+    ]
+    leaf_rows.append({"id": CONTRACT_DESIGN_ID, "rev": validator_revision, "deleted": False})
+    winners = dict(before.winners)
+    winners[CONTRACT_DESIGN_ID] = validator_revision
+    return build_state_model(leaf_rows, winners)
+
+
+def install_fence(
+    client: Any,
+    capture: CaptureReceipt,
+    *,
+    expected_existing_validator_revision: str | None = None,
+) -> FenceReceipt:
+    """Install the reviewed validator only if the captured state is still current."""
+
+    _require_source_database(
+        capture.source_database,
+        allow_disposable_preview=capture.disposable_preview,
+    )
+    _require_quarantine_database(
+        capture.quarantine_database,
+        allow_disposable_preview=capture.disposable_preview,
+    )
+    _require_no_running_timer(client, capture.source_database)
+    current = client.get_state_model(capture.source_database)
+    if client.get_security_hash(capture.source_database) != capture.security_hash:
+        raise QuarantineSafetyError("source security drift blocks fence installation")
+    if any(leaf.document_id == CONTRACT_DESIGN_ID for leaf in capture.state.leaves):
+        raise QuarantineSafetyError("validator revision tree existed before fence installation")
+    existing = client.get_document(capture.source_database, CONTRACT_DESIGN_ID)
+    if existing is not None:
+        if expected_existing_validator_revision is None:
+            raise QuarantineSafetyError("existing validator requires an explicit expected revision")
+        if existing.get("_rev") != expected_existing_validator_revision:
+            raise QuarantineSafetyError("existing validator revision differs from expectation")
+        comparable_existing = copy.deepcopy(dict(existing))
+        comparable_existing.pop("_rev", None)
+        if comparable_existing != load_design_document():
+            raise QuarantineSafetyError("existing validator differs from the reviewed contract")
+        validator_revision = expected_existing_validator_revision
+        fenced_state = current
+    else:
+        if current != capture.state:
+            raise QuarantineSafetyError("source leaf drift blocks fence installation")
+        response = client.put_document(
+            capture.source_database, load_design_document(), create_only=True
+        )
+        validator_revision = response.get("rev") if isinstance(response, Mapping) else None
+        if not isinstance(validator_revision, str) or not validator_revision:
+            raise QuarantineSafetyError("validator create response is invalid")
+        fenced_state = client.get_state_model(capture.source_database)
+    expected = _expected_fenced_state(capture.state, validator_revision)
+    if fenced_state != expected:
+        raise QuarantineSafetyError("source drifted while installing the validator")
+    if client.get_security_hash(capture.source_database) != capture.security_hash:
+        raise QuarantineSafetyError("source security drifted while installing the validator")
+    return FenceReceipt(
+        capture=capture,
+        validator_revision=validator_revision,
+        fenced_state=fenced_state,
+    )
+
+
+def _sha256_argument(value: str) -> str:
+    if not re.fullmatch(r"[a-f0-9]{64}", value):
+        raise argparse.ArgumentTypeError("expected a lowercase SHA-256 value")
+    return value
+
+
+def _add_mutation_gates(parser: argparse.ArgumentParser, *, source: bool = True) -> None:
+    parser.add_argument("--expected-account-checksum", required=True, type=_sha256_argument)
+    if source:
+        parser.add_argument("--confirm-source", required=True, choices=[SOURCE_DATABASE])
+    parser.add_argument("--approve-remote-writes", required=True, action="store_true")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    modes = parser.add_subparsers(dest="mode", required=True)
+    modes.add_parser("preflight")
+
+    capture = modes.add_parser("capture")
+    capture.add_argument("--quarantine-database", required=True)
+    capture.add_argument("--resume-existing", action="store_true")
+    _add_mutation_gates(capture)
+
+    fence = modes.add_parser("fence")
+    fence.add_argument("--quarantine-database", required=True)
+    fence.add_argument("--expected-quarantine-fingerprint", required=True, type=_sha256_argument)
+    fence.add_argument("--expected-security-hash", required=True, type=_sha256_argument)
+    fence.add_argument("--expected-existing-validator-revision")
+    _add_mutation_gates(fence)
+
+    migrate = modes.add_parser("migrate")
+    migrate.add_argument("--quarantine-database", required=True)
+    migrate.add_argument("--expected-quarantine-fingerprint", required=True, type=_sha256_argument)
+    migrate.add_argument("--expected-security-hash", required=True, type=_sha256_argument)
+    migrate.add_argument("--validator-revision", required=True)
+    migrate.add_argument("--completed-at", required=True)
+    _add_mutation_gates(migrate)
+
+    delete = modes.add_parser("delete-quarantine")
+    delete.add_argument("--quarantine-database", required=True)
+    delete.add_argument("--expected-quarantine-fingerprint", required=True, type=_sha256_argument)
+    delete.add_argument("--confirm-delete-quarantine", required=True)
+    _add_mutation_gates(delete, source=False)
+    return parser
+
+
+def _capture_from_quarantine(
+    client: Any,
+    quarantine_database: str,
+    expected_fingerprint: str,
+    security_hash: str,
+) -> CaptureReceipt:
+    _require_quarantine_database(quarantine_database)
+    quarantine_state = client.get_state_model(quarantine_database)
+    if quarantine_state.fingerprint != expected_fingerprint:
+        raise QuarantineSafetyError("quarantine fingerprint differs from expectation")
+    return CaptureReceipt(
+        source_database=SOURCE_DATABASE,
+        quarantine_database=quarantine_database,
+        state=quarantine_state,
+        security_hash=security_hash,
+    )
+
+
+def _safe_print(report: Mapping[str, Any]) -> None:
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+def execute_cli(
+    argv: Sequence[str] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    client_factory: Any = OperationalCloudantClient,
+) -> dict[str, Any]:
+    args = _parser().parse_args(argv)
+    environment = os.environ if environ is None else environ
+    credential_url = environment.get(CREDENTIAL_ENV_VAR)
+    if not credential_url:
+        raise QuarantineSafetyError(f"required environment variable {CREDENTIAL_ENV_VAR} is unset")
+    client = client_factory(credential_url)
+
+    if args.mode == "preflight":
+        source_state = client.get_state_model(SOURCE_DATABASE)
+        security_hash = client.get_security_hash(SOURCE_DATABASE)
+        timer_present = client.get_document(SOURCE_DATABASE, RUNNING_ACTIVITY_ID) is not None
+        validator = verify_validator(client, SOURCE_DATABASE)
+        report = {
+            "mode": "preflight",
+            "accountChecksum": client.account_checksum,
+            "sourceFingerprint": source_state.fingerprint,
+            "securityHash": security_hash,
+            "counts": source_state.counts,
+            "runningTimerPresent": timer_present,
+            "validatorState": validator["state"],
+            "validatorRevision": validator["validatorRevision"],
+        }
+        _safe_print(report)
+        return report
+
+    if client.account_checksum != args.expected_account_checksum:
+        raise QuarantineSafetyError("Cloudant account binding differs from expectation")
+
+    if args.mode == "capture":
+        _require_quarantine_database(args.quarantine_database)
+        receipt = capture_quarantine(
+            client,
+            SOURCE_DATABASE,
+            args.quarantine_database,
+            resume_existing=args.resume_existing,
+        )
+        report = {
+            "mode": "capture",
+            "state": "verified",
+            "sourceFingerprint": receipt.state.fingerprint,
+            "quarantineFingerprint": receipt.state.fingerprint,
+            "securityHash": receipt.security_hash,
+            "counts": receipt.state.counts,
+            "replicationMode": "transient",
+        }
+    elif args.mode == "fence":
+        capture = _capture_from_quarantine(
+            client,
+            args.quarantine_database,
+            args.expected_quarantine_fingerprint,
+            args.expected_security_hash,
+        )
+        receipt = install_fence(
+            client,
+            capture,
+            expected_existing_validator_revision=(args.expected_existing_validator_revision),
+        )
+        report = {
+            "mode": "fence",
+            "state": "verified",
+            "validatorRevision": receipt.validator_revision,
+            "validatorChecksum": load_design_document()["fortudoDocumentContract"]["checksum"],
+            "fencedFingerprint": receipt.fenced_state.fingerprint,
+            "counts": receipt.fenced_state.counts,
+        }
+    elif args.mode == "migrate":
+        capture = _capture_from_quarantine(
+            client,
+            args.quarantine_database,
+            args.expected_quarantine_fingerprint,
+            args.expected_security_hash,
+        )
+        fence = FenceReceipt(
+            capture=capture,
+            validator_revision=args.validator_revision,
+            fenced_state=client.get_state_model(SOURCE_DATABASE),
+        )
+        result = execute_migration(client, fence, completed_at=args.completed_at)
+        report = {
+            "mode": "migrate",
+            "state": result.state,
+            "counts": result.counts,
+            "verifiedStateFingerprint": result.verified_state_fingerprint,
+            "markerRevision": result.marker_revision,
+        }
+    else:
+        _require_quarantine_database(args.quarantine_database)
+        if args.confirm_delete_quarantine != args.quarantine_database:
+            raise QuarantineSafetyError("quarantine deletion confirmation differs from target")
+        quarantine_state = client.get_state_model(args.quarantine_database)
+        if quarantine_state.fingerprint != args.expected_quarantine_fingerprint:
+            raise QuarantineSafetyError("quarantine fingerprint differs from expectation")
+        client.delete_database(args.quarantine_database, allow_disposable_preview=False)
+        if client.database_exists(args.quarantine_database):
+            raise QuarantineSafetyError("quarantine database still exists after deletion")
+        report = {"mode": "delete-quarantine", "state": "deleted"}
+    _safe_print(report)
+    return report
+
+
+def main() -> int:
+    try:
+        execute_cli()
+    except QuarantineSafetyError as error:
+        print(f"Quarantine operation blocked: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_taxonomy_identity.py
+++ b/scripts/migrate_taxonomy_identity.py
@@ -1,8 +1,10 @@
 """Read-only planner for Fortudo taxonomy identity version 1.
 
-This command validates the exact production database and reports aggregate dry-run
-counts. It has no backup, restore, or write capability. Document bodies, database
-names, opaque database metadata, and credentials are never printed.
+This command validates one explicitly selected ``fortudo-*`` database and reports
+aggregate dry-run counts. Its transformation is derived from that database's current
+taxonomy rows; no room labels are hardcoded here. It has no backup, restore, or write
+capability. Document bodies, database names, opaque database metadata, and credentials
+are never printed.
 """
 
 from __future__ import annotations
@@ -31,7 +33,7 @@ TAXONOMY_NAMESPACE = uuid.UUID("8e2e8b7a-5c3f-4f3e-9c5d-7a1b2e4f6c80")
 
 
 class MigrationSafetyError(RuntimeError):
-    """Raised when a read-only migration-planning precondition is not satisfied."""
+    """Raised when a migration-planning precondition is not satisfied."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_cloudant_quarantine_migration.py
+++ b/tests/test_cloudant_quarantine_migration.py
@@ -1,0 +1,1244 @@
+"""Safety properties for the minimal Cloudant-native quarantine migration."""
+
+from __future__ import annotations
+
+import copy
+import io
+import subprocess
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from scripts import cloudant_quarantine_migration as quarantine
+from scripts import migrate_taxonomy_identity as migration
+from scripts.document_contract_ops import CONTRACT_DESIGN_ID, load_design_document
+
+
+SOURCE = "fortudo-dat-411"
+QUARANTINE = "fortudo-quarantine-0123456789abcdef01234567"
+
+
+def state(*leaves: tuple[str, str, bool], winners: dict[str, str] | None = None):
+    rows = [
+        {"id": document_id, "rev": revision, "deleted": deleted}
+        for document_id, revision, deleted in leaves
+    ]
+    if winners is None:
+        winners = {}
+        for row in rows:
+            winners.setdefault(row["id"], row["rev"])
+    return quarantine.build_state_model(rows, winners)
+
+
+def test_state_model_is_order_independent_and_covers_deleted_and_conflicting_leaves() -> None:
+    leaves = [
+        {"id": "task-b", "rev": "2-winner", "deleted": False},
+        {"id": "task-a", "rev": "3-deleted", "deleted": True},
+        {"id": "task-b", "rev": "1-loser", "deleted": False},
+        {"id": "_design/example", "rev": "1-design", "deleted": False},
+        {"id": "_local/checkpoint", "rev": "0-local", "deleted": False},
+    ]
+    winners = {
+        "task-a": "3-deleted",
+        "task-b": "2-winner",
+        "_design/example": "1-design",
+    }
+
+    first = quarantine.build_state_model(leaves, winners)
+    second = quarantine.build_state_model(
+        list(reversed(leaves)), dict(reversed(list(winners.items())))
+    )
+
+    assert first.fingerprint == second.fingerprint
+    assert first.leaves == second.leaves
+    assert first.winners == second.winners
+    assert first.counts == {
+        "documents": 3,
+        "liveLeaves": 3,
+        "deletedLeaves": 1,
+        "conflictLeaves": 1,
+    }
+    assert all(not leaf.document_id.startswith("_local/") for leaf in first.leaves)
+
+
+@pytest.mark.parametrize(
+    ("leaves", "winners", "message"),
+    [
+        ([{"id": "task-a", "rev": "1-a", "deleted": False}] * 2, {"task-a": "1-a"}, "duplicate"),
+        ([{"id": "task-a", "rev": "1-a", "deleted": False}], {}, "winner"),
+        (
+            [{"id": "task-a", "rev": "1-a", "deleted": False}],
+            {"task-a": "2-missing"},
+            "winner",
+        ),
+    ],
+)
+def test_state_model_rejects_inconsistent_enumeration(leaves, winners, message) -> None:
+    with pytest.raises(quarantine.QuarantineSafetyError, match=message):
+        quarantine.build_state_model(leaves, winners)
+
+
+def test_replication_document_is_one_shot_unfiltered_and_uses_structured_auth() -> None:
+    document = quarantine.build_replication_document(
+        SOURCE,
+        QUARANTINE,
+        endpoint="https://account.example.invalid",
+        username="private-user",
+        password="private-password",
+    )
+
+    assert document == {
+        "source": {
+            "url": f"https://account.example.invalid/{SOURCE}",
+            "auth": {"basic": {"username": "private-user", "password": "private-password"}},
+        },
+        "target": {
+            "url": f"https://account.example.invalid/{QUARANTINE}",
+            "auth": {"basic": {"username": "private-user", "password": "private-password"}},
+        },
+    }
+    for forbidden in (
+        "create_target",
+        "continuous",
+        "doc_ids",
+        "filter",
+        "selector",
+        "winning_revs_only",
+    ):
+        assert forbidden not in document
+
+
+def test_random_source_is_allowed_only_through_the_disposable_preview_gate() -> None:
+    preview_source = "fortudo-preview-quarantine-gate-0123456789abcdef01234567-source"
+    preview_quarantine = "fortudo-preview-quarantine-gate-0123456789abcdef01234567-quarantine"
+    with pytest.raises(quarantine.QuarantineSafetyError, match="approved source"):
+        quarantine.build_replication_document(
+            preview_source,
+            QUARANTINE,
+            endpoint="https://account.example.invalid",
+            username="user",
+            password="password",
+        )
+
+    document = quarantine.build_replication_document(
+        preview_source,
+        preview_quarantine,
+        endpoint="https://account.example.invalid",
+        username="user",
+        password="password",
+        allow_disposable_preview=True,
+    )
+
+    assert document["source"]["url"].endswith(f"/{preview_source}")
+    assert document["target"]["url"].endswith(f"/{preview_quarantine}")
+
+
+class CaptureCloudant:
+    def __init__(
+        self,
+        *,
+        timer=None,
+        source_states=None,
+        quarantine_state=None,
+        post_replication_quarantine_state=None,
+        security=None,
+        database_exists=False,
+        fail_replication=False,
+    ):
+        self.timer = timer
+        self.source_states = list(source_states or [])
+        self.quarantine_state = quarantine_state
+        self.post_replication_quarantine_state = post_replication_quarantine_state
+        self.security = security or {"cloudant": {"accepted-user": ["_reader"]}}
+        self._database_exists = database_exists
+        self.fail_replication = fail_replication
+        self.calls: list[tuple] = []
+
+    def get_document(self, database, document_id):
+        self.calls.append(("get-document", database, document_id))
+        return copy.deepcopy(self.timer)
+
+    def get_state_model(self, database):
+        self.calls.append(("state", database))
+        if database == SOURCE:
+            return self.source_states.pop(0)
+        return self.quarantine_state
+
+    def get_security_hash(self, database):
+        self.calls.append(("security", database))
+        return quarantine.canonical_hash(self.security)
+
+    def database_exists(self, database):
+        self.calls.append(("exists", database))
+        return self._database_exists
+
+    def create_database(self, database, *, partitioned, allow_disposable_preview=False):
+        assert allow_disposable_preview is False
+        self.calls.append(("create-database", database, partitioned))
+
+    def replicate_once(self, source, target, *, allow_disposable_preview=False):
+        assert allow_disposable_preview is False
+        self.calls.append(("replicate-once", source, target))
+        if self.fail_replication:
+            raise quarantine.QuarantineSafetyError("uncertain transient replication")
+        if self.post_replication_quarantine_state is not None:
+            self.quarantine_state = self.post_replication_quarantine_state
+        return {"ok": True, "history": [{"doc_write_failures": 0}]}
+
+
+def test_running_timer_blocks_before_any_remote_mutation() -> None:
+    client = CaptureCloudant(timer={"_id": "config-running-activity"})
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="running timer"):
+        quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+
+    assert client.calls == [("get-document", SOURCE, "config-running-activity")]
+
+
+def test_capture_creates_one_exact_database_and_uses_transient_replication() -> None:
+    captured = state(
+        ("_design/existing", "1-design", False),
+        ("task-a", "2-live", False),
+        ("activity-a", "3-winner", False),
+        ("activity-a", "2-loser", False),
+        ("task-deleted", "2-deleted", True),
+        winners={
+            "_design/existing": "1-design",
+            "task-a": "2-live",
+            "activity-a": "3-winner",
+            "task-deleted": "2-deleted",
+        },
+    )
+    client = CaptureCloudant(source_states=[captured, captured], quarantine_state=captured)
+
+    receipt = quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+
+    assert receipt.source_database == SOURCE
+    assert receipt.quarantine_database == QUARANTINE
+    assert receipt.state == captured
+    assert receipt.security_hash == quarantine.canonical_hash(client.security)
+    assert ("create-database", QUARANTINE, False) in client.calls
+    assert ("replicate-once", SOURCE, QUARANTINE) in client.calls
+    assert all("job" not in call[0] for call in client.calls)
+
+
+def test_capture_halts_on_source_drift_without_a_persistent_job() -> None:
+    before = state(("task-a", "1-a", False))
+    after = state(("task-a", "2-a", False))
+    client = CaptureCloudant(source_states=[before, after], quarantine_state=before)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="source state drifted"):
+        quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+
+    assert ("replicate-once", SOURCE, QUARANTINE) in client.calls
+    assert not any(call[0] == "delete-database" for call in client.calls)
+
+
+def test_uncertain_transient_replication_is_safe_to_resume() -> None:
+    source_state = state(("task-a", "1-a", False))
+    client = CaptureCloudant(
+        source_states=[source_state],
+        quarantine_state=source_state,
+        fail_replication=True,
+    )
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="uncertain"):
+        quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+
+    client.fail_replication = False
+    client._database_exists = True
+    client.source_states = [source_state, source_state]
+    receipt = quarantine.capture_quarantine(client, SOURCE, QUARANTINE, resume_existing=True)
+    assert receipt.state == source_state
+
+
+def test_interrupted_capture_reruns_after_an_existing_source_document_was_edited() -> None:
+    source_state = state(("task-a", "2-edited", False), ("task-b", "1-b", False))
+    stale_quarantine = state(("task-a", "1-original", False))
+    client = CaptureCloudant(
+        source_states=[source_state, source_state],
+        quarantine_state=stale_quarantine,
+        post_replication_quarantine_state=source_state,
+        database_exists=True,
+    )
+
+    receipt = quarantine.capture_quarantine(client, SOURCE, QUARANTINE, resume_existing=True)
+
+    assert receipt.state == source_state
+    assert not any(call[0] == "create-database" for call in client.calls)
+    assert ("replicate-once", SOURCE, QUARANTINE) in client.calls
+
+    unrelated = state(("task-other", "1-other", False))
+    blocked = CaptureCloudant(
+        source_states=[source_state, source_state],
+        quarantine_state=unrelated,
+        database_exists=True,
+    )
+    with pytest.raises(quarantine.QuarantineSafetyError, match="differs from the source"):
+        quarantine.capture_quarantine(blocked, SOURCE, QUARANTINE, resume_existing=True)
+    assert ("replicate-once", SOURCE, QUARANTINE) in blocked.calls
+
+
+class FenceCloudant:
+    def __init__(self, before, after=None, *, security_hash="security", existing=None):
+        self.states = [before, after or before]
+        self.security_hash = security_hash
+        self.existing = copy.deepcopy(existing)
+        self.calls: list[tuple] = []
+
+    def get_document(self, database, document_id):
+        self.calls.append(("get-document", database, document_id))
+        if document_id == "config-running-activity":
+            return None
+        return copy.deepcopy(self.existing)
+
+    def get_state_model(self, database):
+        self.calls.append(("state", database))
+        return self.states.pop(0)
+
+    def get_security_hash(self, database):
+        self.calls.append(("security", database))
+        return self.security_hash
+
+    def put_document(self, database, document, *, create_only=False):
+        self.calls.append(("put-document", database, copy.deepcopy(document), create_only))
+        return {"id": CONTRACT_DESIGN_ID, "rev": "1-validator"}
+
+
+def test_fence_installation_is_create_only_and_allows_exactly_the_validator_leaf() -> None:
+    before = state(("task-a", "1-a", False))
+    after = state(
+        ("task-a", "1-a", False),
+        (CONTRACT_DESIGN_ID, "1-validator", False),
+        winners={"task-a": "1-a", CONTRACT_DESIGN_ID: "1-validator"},
+    )
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, before, "security")
+    client = FenceCloudant(before, after)
+
+    receipt = quarantine.install_fence(client, capture)
+
+    assert receipt.validator_revision == "1-validator"
+    assert receipt.fenced_state == after
+    put = next(call for call in client.calls if call[0] == "put-document")
+    assert put[1] == SOURCE
+    assert put[2] == load_design_document()
+    assert put[3] is True
+
+
+@pytest.mark.parametrize("kind", ["leaf", "security"])
+def test_fence_drift_blocks_before_validator_write(kind) -> None:
+    captured = state(("task-a", "1-a", False))
+    current = state(("task-a", "2-a", False)) if kind == "leaf" else captured
+    security = "changed" if kind == "security" else "security"
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, captured, "security")
+    client = FenceCloudant(current, security_hash=security)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="drift"):
+        quarantine.install_fence(client, capture)
+
+    assert not any(call[0] == "put-document" for call in client.calls)
+
+
+def test_fence_blocks_a_deleted_validator_revision_tree_before_create_attempt() -> None:
+    captured = state((CONTRACT_DESIGN_ID, "2-deleted", True))
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, captured, "security")
+    client = FenceCloudant(captured)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="revision tree"):
+        quarantine.install_fence(client, capture)
+
+    assert not any(call[0] == "put-document" for call in client.calls)
+
+
+def test_fence_resume_requires_the_explicit_exact_existing_revision_and_state() -> None:
+    before = state(("task-a", "1-a", False))
+    after = state(
+        ("task-a", "1-a", False),
+        (CONTRACT_DESIGN_ID, "1-validator", False),
+        winners={"task-a": "1-a", CONTRACT_DESIGN_ID: "1-validator"},
+    )
+    existing = {**load_design_document(), "_rev": "1-validator"}
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, before, "security")
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="explicit expected revision"):
+        quarantine.install_fence(FenceCloudant(after, existing=existing), capture)
+
+    client = FenceCloudant(after, existing=existing)
+    receipt = quarantine.install_fence(
+        client, capture, expected_existing_validator_revision="1-validator"
+    )
+
+    assert receipt.validator_revision == "1-validator"
+    assert receipt.fenced_state == after
+    assert not any(call[0] == "put-document" for call in client.calls)
+
+
+def test_operational_client_enumerates_exact_leaf_bodies_without_storing_update_seq(
+    monkeypatch,
+) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+    calls: list[tuple] = []
+
+    def request(method, operation, path, **kwargs):
+        calls.append((method, operation, path, kwargs))
+        if operation == "database metadata read":
+            return {"db_name": SOURCE, "update_seq": "opaque-update-sequence"}
+        if operation == "leaf enumeration":
+            return {
+                "results": [
+                    {"id": "activity-a", "changes": [{"rev": "3-win"}, {"rev": "2-lose"}]},
+                    {"id": "task-deleted", "changes": [{"rev": "2-deleted"}]},
+                ]
+            }
+        if operation == "winner enumeration":
+            return {
+                "rows": [
+                    {"id": "activity-a", "value": {"rev": "3-win"}},
+                    {
+                        "id": "task-deleted",
+                        "value": {"rev": "2-deleted", "deleted": True},
+                    },
+                ]
+            }
+        if operation == "leaf body read":
+            assert method == "POST"
+            assert kwargs["body"] == {
+                "docs": [
+                    {"id": "activity-a", "rev": "2-lose"},
+                    {"id": "activity-a", "rev": "3-win"},
+                    {"id": "task-deleted", "rev": "2-deleted"},
+                ]
+            }
+            return {
+                "results": [
+                    {
+                        "id": "activity-a",
+                        "docs": [
+                            {"ok": {"_id": "activity-a", "_rev": "3-win"}},
+                            {"ok": {"_id": "activity-a", "_rev": "2-lose"}},
+                        ],
+                    },
+                    {
+                        "id": "task-deleted",
+                        "docs": [
+                            {
+                                "ok": {
+                                    "_id": "task-deleted",
+                                    "_rev": "2-deleted",
+                                    "_deleted": True,
+                                }
+                            }
+                        ],
+                    },
+                ]
+            }
+        raise AssertionError((method, operation, path, kwargs))
+
+    monkeypatch.setattr(client, "_request", request)
+
+    result = client.get_state_model(SOURCE)
+
+    assert not hasattr(result, "update_sequence")
+    assert result.counts == {
+        "documents": 2,
+        "liveLeaves": 2,
+        "deletedLeaves": 1,
+        "conflictLeaves": 1,
+    }
+    winner_call = next(call for call in calls if call[1] == "winner enumeration")
+    assert winner_call[0] == "POST"
+    assert winner_call[3]["body"] == {"keys": ["activity-a", "task-deleted"]}
+    assert len([call for call in calls if call[1] == "leaf body read"]) == 1
+    assert all("attachments=true" not in call[2] for call in calls)
+
+
+def test_operational_client_returns_leaf_ancestry_and_winners_without_private_output(
+    monkeypatch, capsys
+) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+
+    def request(method, operation, path, **kwargs):
+        if operation == "leaf enumeration":
+            assert method == "GET"
+            return {"results": [{"id": "task-a", "changes": [{"rev": "2-win"}]}]}
+        if operation == "leaf body read":
+            assert method == "POST"
+            assert "revs=true" in path
+            assert kwargs["body"] == {"docs": [{"id": "task-a", "rev": "2-win"}]}
+            return {
+                "results": [
+                    {
+                        "id": "task-a",
+                        "docs": [
+                            {
+                                "ok": {
+                                    "_id": "task-a",
+                                    "_rev": "2-win",
+                                    "_revisions": {"start": 2, "ids": ["win", "base"]},
+                                    "description": "private body",
+                                }
+                            }
+                        ],
+                    }
+                ]
+            }
+        if operation == "winning document read":
+            assert method == "GET"
+            assert "conflicts=true" in path
+            return {
+                "rows": [
+                    {
+                        "id": "task-a",
+                        "doc": {
+                            "_id": "task-a",
+                            "_rev": "2-win",
+                            "description": "private body",
+                        },
+                    },
+                    {"id": "deleted", "value": {"rev": "2-deleted", "deleted": True}},
+                ]
+            }
+        raise AssertionError((operation, path))
+
+    monkeypatch.setattr(client, "_request", request)
+
+    leaves = client.get_leaf_documents(SOURCE)
+    winners = client.get_all_documents(SOURCE, include_conflicts=True)
+
+    assert leaves[0]["_revisions"]["ids"] == ["win", "base"]
+    assert winners == [{"_id": "task-a", "_rev": "2-win", "description": "private body"}]
+    assert capsys.readouterr().out == ""
+
+
+def test_operational_client_reads_leaf_bodies_in_bounded_batches(monkeypatch) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+    identities = [(f"task-{index:03d}", f"1-rev-{index:03d}") for index in range(101)]
+    batch_sizes = []
+
+    def request(method, operation, path, **kwargs):
+        if operation == "leaf enumeration":
+            return {
+                "results": [
+                    {"id": document_id, "changes": [{"rev": revision}]}
+                    for document_id, revision in identities
+                ]
+            }
+        if operation == "leaf body read":
+            assert method == "POST"
+            assert "_bulk_get?revs=true" in path
+            requested = kwargs["body"]["docs"]
+            batch_sizes.append(len(requested))
+            return {
+                "results": [
+                    {
+                        "id": item["id"],
+                        "docs": [
+                            {
+                                "ok": {
+                                    "_id": item["id"],
+                                    "_rev": item["rev"],
+                                    "_revisions": {"start": 1, "ids": [item["rev"][2:]]},
+                                }
+                            }
+                        ],
+                    }
+                    for item in requested
+                ]
+            }
+        raise AssertionError((method, operation, path))
+
+    monkeypatch.setattr(client, "_request", request)
+
+    assert len(client.get_leaf_documents(SOURCE)) == 101
+    assert batch_sizes == [quarantine.LEAF_READ_BATCH_SIZE, 1]
+
+
+def test_operational_client_writes_only_exact_database_replication_and_document_targets(
+    monkeypatch,
+) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+    calls: list[tuple] = []
+
+    def request(method, operation, path, **kwargs):
+        calls.append((method, operation, path, copy.deepcopy(kwargs)))
+        if operation == "transient replication":
+            return {"ok": True, "history": [{"doc_write_failures": 0}]}
+        return {"ok": True, "id": CONTRACT_DESIGN_ID, "rev": "1-validator"}
+
+    monkeypatch.setattr(client, "_request", request)
+
+    client.create_database(QUARANTINE, partitioned=False)
+    client.replicate_once(SOURCE, QUARANTINE)
+    client.put_document(SOURCE, load_design_document(), create_only=True)
+
+    assert calls[0][:3] == (
+        "PUT",
+        "database create",
+        f"{QUARANTINE}?partitioned=false",
+    )
+    replication_body = calls[1][3]["body"]
+    assert replication_body["source"]["url"].endswith(f"/{SOURCE}")
+    assert replication_body["target"]["url"].endswith(f"/{QUARANTINE}")
+    assert set(replication_body) == {"source", "target"}
+    assert calls[1][0:3] == ("POST", "transient replication", "_replicate")
+    assert calls[2][0:2] == ("PUT", "document create")
+    assert calls[2][2].endswith("/_design%2Ffortudo-document-contract")
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        ({"ok": False}, "invalid replication response"),
+        ({"ok": True}, "omitted its history"),
+        (
+            {"ok": True, "history": [{"doc_write_failures": 1}]},
+            "document write failures",
+        ),
+        (
+            {
+                "ok": True,
+                "history": [
+                    {"doc_write_failures": 1},
+                    {"doc_write_failures": 0},
+                ],
+            },
+            "document write failures",
+        ),
+    ],
+)
+def test_transient_replication_rejects_incomplete_or_failed_responses(
+    monkeypatch, response, message
+) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: response)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match=message):
+        client.replicate_once(SOURCE, QUARANTINE)
+
+
+def test_operational_transport_sanitizes_http_error_bodies_credentials_and_urls(
+    monkeypatch,
+) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+    private_body = io.BytesIO(b'{"reason":"private document contents"}')
+
+    def fail(_request, *, timeout):
+        assert timeout == 60
+        raise urllib.error.HTTPError(
+            "https://private-user:private-password@account.example.invalid/private-db",
+            409,
+            "conflict",
+            {},
+            private_body,
+        )
+
+    monkeypatch.setattr(quarantine.urllib.request, "urlopen", fail)
+
+    with pytest.raises(quarantine.QuarantineSafetyError) as error:
+        client.create_database(QUARANTINE, partitioned=False)
+
+    message = str(error.value)
+    assert "HTTP 409" in message
+    assert "private" not in message
+    assert "account.example.invalid" not in message
+    assert QUARANTINE not in message
+
+
+def test_operational_transport_retries_rate_limits_without_exposing_response(
+    monkeypatch,
+) -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+    attempts = 0
+    delays = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"db_name":"fortudo-quarantine-0123456789abcdef01234567"}'
+
+    def rate_limited_then_succeed(_request, *, timeout):
+        nonlocal attempts
+        assert timeout == 60
+        attempts += 1
+        if attempts < 3:
+            raise urllib.error.HTTPError(
+                "https://private.invalid",
+                429,
+                "rate limited",
+                {"Retry-After": "0"},
+                io.BytesIO(b"private response"),
+            )
+        return Response()
+
+    monkeypatch.setattr(quarantine.urllib.request, "urlopen", rate_limited_then_succeed)
+    monkeypatch.setattr(quarantine.time, "sleep", delays.append)
+
+    assert client.database_exists(QUARANTINE) is True
+    assert attempts == 3
+    assert delays == [0.5, 1.0]
+
+
+def test_migration_planner_errors_are_translated_to_sanitized_operational_errors(
+    monkeypatch,
+) -> None:
+    def fail(_documents):
+        raise migration.MigrationSafetyError("private structural detail")
+
+    monkeypatch.setattr(quarantine, "build_migration_plan", fail)
+
+    with pytest.raises(
+        quarantine.QuarantineSafetyError, match="migration planning precondition failed"
+    ) as error:
+        quarantine._checked_migration_plan([])
+
+    assert "private" not in str(error.value)
+
+
+def migration_winners() -> list[dict]:
+    return [
+        {
+            "_id": "config-categories",
+            "_rev": "3-taxonomy",
+            "id": "config-categories",
+            "docType": "config",
+            "schemaVersion": "3.5",
+            "groups": [{"key": "work", "label": "Work", "colorFamily": "blue", "color": "#111111"}],
+            "categories": [
+                {
+                    "key": "work/meetings",
+                    "label": "Comms",
+                    "groupKey": "work",
+                    "color": "#222222",
+                },
+                {
+                    "key": "work/comms",
+                    "label": "Meetings",
+                    "groupKey": "work",
+                    "color": "#333333",
+                },
+            ],
+        },
+        {
+            "_id": "task-a",
+            "_rev": "2-task",
+            "id": "task-a",
+            "docType": "task",
+            "type": "unscheduled",
+            "description": "private task",
+            "category": "work/meetings",
+        },
+        {
+            "_id": "activity-a",
+            "_rev": "4-winner",
+            "_conflicts": ["3-loser"],
+            "id": "activity-a",
+            "docType": "activity",
+            "description": "private activity",
+            "category": "work/comms",
+        },
+    ]
+
+
+def migration_base_state():
+    return state(
+        ("config-categories", "3-taxonomy", False),
+        ("task-a", "2-task", False),
+        ("activity-a", "4-winner", False),
+        ("activity-a", "3-loser", False),
+        winners={
+            "config-categories": "3-taxonomy",
+            "task-a": "2-task",
+            "activity-a": "4-winner",
+        },
+    )
+
+
+def successor(document: dict, revision: str, parent: str) -> dict:
+    result = copy.deepcopy(document)
+    result["_rev"] = revision
+    generation, digest = revision.split("-", 1)
+    _parent_generation, parent_digest = parent.split("-", 1)
+    result["_revisions"] = {
+        "start": int(generation),
+        "ids": [digest, parent_digest],
+    }
+    return result
+
+
+def test_resume_classifier_accepts_only_exact_deterministic_children_of_quarantine_leaves() -> None:
+    base_documents = migration_winners()
+    plan = migration.build_migration_plan(base_documents)
+    intended = {document["_id"]: document for document in plan.updates}
+    partial_leaves = [
+        successor(intended["config-categories"], "4-taxonomy-next", "3-taxonomy"),
+        copy.deepcopy(base_documents[1]),
+        copy.deepcopy(base_documents[2]),
+        {"_id": "activity-a", "_rev": "3-loser"},
+        {**load_design_document(), "_rev": "1-validator"},
+    ]
+    partial_state = state(
+        ("config-categories", "4-taxonomy-next", False),
+        ("task-a", "2-task", False),
+        ("activity-a", "4-winner", False),
+        ("activity-a", "3-loser", False),
+        (CONTRACT_DESIGN_ID, "1-validator", False),
+        winners={
+            "config-categories": "4-taxonomy-next",
+            "task-a": "2-task",
+            "activity-a": "4-winner",
+            CONTRACT_DESIGN_ID: "1-validator",
+        },
+    )
+
+    classification = quarantine.classify_migration_state(
+        base_documents,
+        migration_base_state(),
+        partial_leaves,
+        partial_state,
+        validator_revision="1-validator",
+    )
+
+    assert classification.complete is False
+    assert classification.transitioned_updates == 1
+    assert classification.transitioned_tombstones == 0
+
+    changed = copy.deepcopy(partial_leaves)
+    changed[0]["categories"][0]["label"] = "Semantically changed"
+    with pytest.raises(quarantine.QuarantineSafetyError, match="intended migration successor"):
+        quarantine.classify_migration_state(
+            base_documents,
+            migration_base_state(),
+            changed,
+            partial_state,
+            validator_revision="1-validator",
+        )
+
+
+def test_resume_classifier_accepts_complete_successors_and_conflict_tombstone() -> None:
+    base_documents = migration_winners()
+    plan = migration.build_migration_plan(base_documents)
+    intended = {document["_id"]: document for document in plan.updates}
+    current_leaves = [
+        successor(intended["config-categories"], "4-taxonomy-next", "3-taxonomy"),
+        successor(intended["task-a"], "3-task-next", "2-task"),
+        successor(intended["activity-a"], "5-activity-next", "4-winner"),
+        successor(plan.conflict_tombstones[0], "4-loser-deleted", "3-loser"),
+        {**load_design_document(), "_rev": "1-validator"},
+    ]
+    current_state = state(
+        ("config-categories", "4-taxonomy-next", False),
+        ("task-a", "3-task-next", False),
+        ("activity-a", "5-activity-next", False),
+        ("activity-a", "4-loser-deleted", True),
+        (CONTRACT_DESIGN_ID, "1-validator", False),
+        winners={
+            "config-categories": "4-taxonomy-next",
+            "task-a": "3-task-next",
+            "activity-a": "5-activity-next",
+            CONTRACT_DESIGN_ID: "1-validator",
+        },
+    )
+
+    classification = quarantine.classify_migration_state(
+        base_documents,
+        migration_base_state(),
+        current_leaves,
+        current_state,
+        validator_revision="1-validator",
+    )
+
+    assert classification.complete is True
+    assert classification.transitioned_updates == 3
+    assert classification.transitioned_tombstones == 1
+
+
+def test_locked_taxonomy_meanings_are_checked_from_current_rows_without_key_inference() -> None:
+    documents = migration_winners()
+    quarantine.require_locked_taxonomy_meanings(documents)
+
+    documents[0]["categories"][0]["label"] = "Meetings"
+    with pytest.raises(quarantine.QuarantineSafetyError, match="locked taxonomy meaning"):
+        quarantine.require_locked_taxonomy_meanings(documents)
+
+
+def fully_migrated_fixture():
+    base_documents = migration_winners()
+    plan = migration.build_migration_plan(base_documents)
+    intended = {document["_id"]: document for document in plan.updates}
+    settled = [
+        successor(intended["config-categories"], "4-taxonomy-next", "3-taxonomy"),
+        successor(intended["task-a"], "3-task-next", "2-task"),
+        successor(intended["activity-a"], "5-activity-next", "4-winner"),
+    ]
+    for document in settled:
+        document.pop("_revisions")
+        document.pop("_conflicts", None)
+    leaves = [
+        successor(intended["config-categories"], "4-taxonomy-next", "3-taxonomy"),
+        successor(intended["task-a"], "3-task-next", "2-task"),
+        successor(intended["activity-a"], "5-activity-next", "4-winner"),
+        successor(plan.conflict_tombstones[0], "4-loser-deleted", "3-loser"),
+        {**load_design_document(), "_rev": "1-validator"},
+    ]
+    complete_state = state(
+        ("config-categories", "4-taxonomy-next", False),
+        ("task-a", "3-task-next", False),
+        ("activity-a", "5-activity-next", False),
+        ("activity-a", "4-loser-deleted", True),
+        (CONTRACT_DESIGN_ID, "1-validator", False),
+        winners={
+            "config-categories": "4-taxonomy-next",
+            "task-a": "3-task-next",
+            "activity-a": "5-activity-next",
+            CONTRACT_DESIGN_ID: "1-validator",
+        },
+    )
+    return base_documents, plan, settled, leaves, complete_state
+
+
+class MigrationCloudant:
+    def __init__(self, *, final_state_override=None, fail_after_writes=None):
+        base_documents, plan, settled, leaves, complete_state = fully_migrated_fixture()
+        self.base_documents = base_documents
+        self.plan = plan
+        self.settled = settled
+        self.complete_leaves = leaves
+        self.complete_state = final_state_override or complete_state
+        self.fail_after_writes = fail_after_writes
+        self.write_count = 0
+        self.marker = None
+        self.calls: list[tuple] = []
+        self.fenced_state = state(
+            *(
+                tuple((leaf.document_id, leaf.revision, leaf.deleted))
+                for leaf in migration_base_state().leaves
+            ),
+            (CONTRACT_DESIGN_ID, "1-validator", False),
+            winners={**dict(migration_base_state().winners), CONTRACT_DESIGN_ID: "1-validator"},
+        )
+        self.fenced_leaves = [
+            *copy.deepcopy(self.base_documents),
+            {"_id": "activity-a", "_rev": "3-loser"},
+            {**load_design_document(), "_rev": "1-validator"},
+        ]
+
+    def _partial_snapshot(self):
+        if self.write_count == 0:
+            return self.base_documents, self.fenced_leaves, self.fenced_state
+        intended = {document["_id"]: document for document in self.plan.updates}
+        revisions = {
+            "config-categories": ("4-taxonomy-next", "3-taxonomy", 1),
+            "task-a": ("3-task-next", "2-task", 2),
+            "activity-a": ("5-activity-next", "4-winner", 3),
+        }
+        documents: list[dict] = []
+        leaves: list[dict] = []
+        rows: list[tuple[str, str, bool]] = []
+        winners: dict[str, str] = {}
+        for base in self.base_documents:
+            document_id = base["_id"]
+            revision, parent, threshold = revisions[document_id]
+            if self.write_count >= threshold:
+                migrated = successor(intended[document_id], revision, parent)
+                leaves.append(copy.deepcopy(migrated))
+                winner = copy.deepcopy(migrated)
+                winner.pop("_revisions")
+                if document_id == "activity-a" and self.write_count < 4:
+                    winner["_conflicts"] = ["3-loser"]
+                documents.append(winner)
+                rows.append((document_id, revision, False))
+                winners[document_id] = revision
+            else:
+                documents.append(copy.deepcopy(base))
+                leaves.append(copy.deepcopy(base))
+                rows.append((document_id, base["_rev"], False))
+                winners[document_id] = base["_rev"]
+        if self.write_count >= 4:
+            tombstone = successor(self.plan.conflict_tombstones[0], "4-loser-deleted", "3-loser")
+            leaves.append(tombstone)
+            rows.append(("activity-a", "4-loser-deleted", True))
+        else:
+            leaves.append({"_id": "activity-a", "_rev": "3-loser"})
+            rows.append(("activity-a", "3-loser", False))
+        leaves.append({**load_design_document(), "_rev": "1-validator"})
+        rows.append((CONTRACT_DESIGN_ID, "1-validator", False))
+        winners[CONTRACT_DESIGN_ID] = "1-validator"
+        return documents, leaves, state(*rows, winners=winners)
+
+    def get_document(self, database, document_id):
+        self.calls.append(("get-document", database, document_id))
+        if document_id == "config-running-activity":
+            return None
+        if document_id == CONTRACT_DESIGN_ID:
+            return {**load_design_document(), "_rev": "1-validator"}
+        if document_id == quarantine.COMPLETION_MARKER_ID:
+            return copy.deepcopy(self.marker)
+        return None
+
+    def get_security_hash(self, database):
+        self.calls.append(("security", database))
+        return "security"
+
+    def get_state_model(self, database):
+        self.calls.append(("state", database))
+        if database == QUARANTINE:
+            return migration_base_state()
+        if self.marker is not None:
+            return quarantine.add_leaf_to_state(
+                self.complete_state,
+                quarantine.COMPLETION_MARKER_ID,
+                self.marker["_rev"],
+                deleted=False,
+            )
+        if self.write_count == 4:
+            return self.complete_state
+        return self._partial_snapshot()[2]
+
+    def get_all_documents(self, database, *, include_conflicts):
+        self.calls.append(("winners", database, include_conflicts))
+        if database == QUARANTINE:
+            return copy.deepcopy(self.base_documents)
+        if self.write_count == 4:
+            result = copy.deepcopy(self.settled)
+            if self.marker is not None:
+                result.append(copy.deepcopy(self.marker))
+            return result
+        return copy.deepcopy(self._partial_snapshot()[0])
+
+    def get_leaf_documents(self, database):
+        self.calls.append(("leaves", database))
+        if database == QUARANTINE:
+            return copy.deepcopy(self.base_documents) + [{"_id": "activity-a", "_rev": "3-loser"}]
+        if self.write_count == 4:
+            result = copy.deepcopy(self.complete_leaves)
+            if self.marker is not None:
+                result.append(copy.deepcopy(self.marker))
+            return result
+        return copy.deepcopy(self._partial_snapshot()[1])
+
+    def put_document(self, database, document, *, create_only=False):
+        self.calls.append(("put", database, copy.deepcopy(document), create_only))
+        if self.fail_after_writes is not None and self.write_count == self.fail_after_writes:
+            raise quarantine.QuarantineSafetyError("forced interruption")
+        if document["_id"] == quarantine.COMPLETION_MARKER_ID:
+            assert self.write_count == 4
+            assert create_only is True
+            self.marker = {**copy.deepcopy(document), "_rev": "1-marker"}
+            return {"ok": True, "id": document["_id"], "rev": "1-marker"}
+        revisions = [
+            "4-taxonomy-next",
+            "3-task-next",
+            "5-activity-next",
+            "4-loser-deleted",
+        ]
+        revision = revisions[self.write_count]
+        self.write_count += 1
+        return {"ok": True, "id": document["_id"], "rev": revision}
+
+
+def test_executor_writes_taxonomy_entities_tombstone_then_separate_completion_marker() -> None:
+    client = MigrationCloudant()
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, migration_base_state(), "security")
+    fence = quarantine.FenceReceipt(capture, "1-validator", client.fenced_state)
+
+    result = quarantine.execute_migration(client, fence, completed_at="2026-07-22T12:00:00Z")
+
+    writes = [call for call in client.calls if call[0] == "put"]
+    assert [call[2]["_id"] for call in writes] == [
+        "config-categories",
+        "task-a",
+        "activity-a",
+        "activity-a",
+        quarantine.COMPLETION_MARKER_ID,
+    ]
+    assert writes[3][2]["_deleted"] is True
+    assert writes[3][2]["writerContract"] == {"version": 1}
+    assert writes[4][3] is True
+    assert result.state == "complete"
+    assert result.verified_state_fingerprint == client.complete_state.fingerprint
+    assert result.marker_revision == "1-marker"
+    assert client.marker["quarantineFingerprint"] == migration_base_state().fingerprint
+    assert client.marker["validatorRevision"] == "1-validator"
+
+
+def test_executor_blocks_unexpected_final_revision_before_writing_marker() -> None:
+    _base, _plan, _settled, leaves, complete = fully_migrated_fixture()
+    unexpected = quarantine.add_leaf_to_state(
+        complete, "task-unexpected", "1-unexpected", deleted=False
+    )
+    client = MigrationCloudant(final_state_override=unexpected)
+    client.complete_leaves = [
+        *leaves,
+        {"_id": "task-unexpected", "_rev": "1-unexpected"},
+    ]
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, migration_base_state(), "security")
+    fence = quarantine.FenceReceipt(capture, "1-validator", client.fenced_state)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="unrelated leaf"):
+        quarantine.execute_migration(client, fence, completed_at="2026-07-22T12:00:00Z")
+
+    assert client.marker is None
+    assert not any(
+        call[0] == "put" and call[2]["_id"] == quarantine.COMPLETION_MARKER_ID
+        for call in client.calls
+    )
+
+
+def test_executor_resumes_after_forced_interruption_without_rewriting_completed_successor() -> None:
+    client = MigrationCloudant(fail_after_writes=1)
+    capture = quarantine.CaptureReceipt(SOURCE, QUARANTINE, migration_base_state(), "security")
+    fence = quarantine.FenceReceipt(capture, "1-validator", client.fenced_state)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="forced interruption"):
+        quarantine.execute_migration(client, fence, completed_at="2026-07-22T12:00:00Z")
+    assert client.write_count == 1
+
+    client.fail_after_writes = None
+    result = quarantine.execute_migration(client, fence, completed_at="2026-07-22T12:00:00Z")
+
+    taxonomy_writes = [
+        call for call in client.calls if call[0] == "put" and call[2]["_id"] == "config-categories"
+    ]
+    assert len(taxonomy_writes) == 1
+    assert result.state == "complete"
+
+
+def test_operator_cli_exposes_only_minimal_quarantine_workflow(tmp_path: Path) -> None:
+    script = Path(quarantine.__file__).resolve()
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    for mode in ("preflight", "capture", "fence", "migrate", "delete-quarantine"):
+        assert mode in result.stdout
+    usage = result.stdout.splitlines()[0]
+    for retired in ("snapshot", "restore", "inventory", "portable", "backup-root"):
+        assert retired not in usage
+
+
+def test_account_binding_checksum_never_contains_endpoint_or_credentials() -> None:
+    client = quarantine.OperationalCloudantClient(
+        "https://private-user:private-password@account.example.invalid"
+    )
+
+    assert len(client.account_checksum) == 64
+    assert "private" not in client.account_checksum
+    assert "account.example.invalid" not in client.account_checksum
+
+
+def test_mutating_cli_requires_account_binding_source_confirmation_and_approval() -> None:
+    parser = quarantine._parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "capture",
+                "--quarantine-database",
+                QUARANTINE,
+                "--expected-account-checksum",
+                "a" * 64,
+            ]
+        )
+
+
+def test_preflight_reports_exact_validator_state_without_database_or_private_values(capsys) -> None:
+    class PreflightClient:
+        account_checksum = "a" * 64
+
+        def get_state_model(self, database):
+            assert database == SOURCE
+            return state(("task-a", "1-a", False))
+
+        def get_security_hash(self, database):
+            assert database == SOURCE
+            return "b" * 64
+
+        def get_document(self, database, document_id):
+            assert database == SOURCE
+            if document_id == migration.RUNNING_ACTIVITY_ID:
+                return None
+            return {**load_design_document(), "_rev": "1-validator"}
+
+    result = quarantine.execute_cli(
+        ["preflight"],
+        environ={quarantine.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+        client_factory=lambda _url: PreflightClient(),
+    )
+
+    assert result["validatorState"] == "compatible"
+    assert result["validatorRevision"] == "1-validator"
+    output = capsys.readouterr().out
+    assert SOURCE not in output
+    assert "secret" not in output
+
+
+def test_delete_quarantine_requires_exact_name_fingerprint_and_confirmation() -> None:
+    class DeleteClient:
+        account_checksum = "a" * 64
+
+        def __init__(self):
+            self.calls = []
+
+        def get_state_model(self, database):
+            self.calls.append(("state", database))
+            return state(("task-a", "1-a", False))
+
+        def delete_database(self, database, *, allow_disposable_preview=False):
+            self.calls.append(("delete", database, allow_disposable_preview))
+
+        def database_exists(self, database):
+            self.calls.append(("exists", database))
+            return False
+
+    client = DeleteClient()
+    fingerprint = state(("task-a", "1-a", False)).fingerprint
+    result = quarantine.execute_cli(
+        [
+            "delete-quarantine",
+            "--quarantine-database",
+            QUARANTINE,
+            "--expected-account-checksum",
+            "a" * 64,
+            "--expected-quarantine-fingerprint",
+            fingerprint,
+            "--confirm-delete-quarantine",
+            QUARANTINE,
+            "--approve-remote-writes",
+        ],
+        environ={quarantine.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+        client_factory=lambda _url: client,
+    )
+
+    assert result["state"] == "deleted"
+    assert client.calls == [
+        ("state", QUARANTINE),
+        ("delete", QUARANTINE, False),
+        ("exists", QUARANTINE),
+    ]


### PR DESCRIPTION
## Summary

- implement the minimal Cloudant quarantine migration architecture specified by #108
- capture revision trees through transient `POST /_replicate` rather than local snapshot/restore machinery or persistent `_replicator` jobs
- bind success to exact live, deleted, conflicting, winner, and attachment state
- add guarded `fortudo-dat-411` production operations, deterministic CAS migration/resume handling, and a disposable real-Cloudant proof gate
- clarify that the generic taxonomy planner derives mappings from current taxonomy data and remains read-only

## Context

#108 removed the premature backup-heavy approach associated with #106 and the expanded state-binding machinery in #107. This PR supplies the deliberately narrower replacement: Cloudant performs the revision/attachment transfer, the quarantine database is retained whenever an outcome is ambiguous, and exact source/quarantine equality is the recovery boundary.

The already accepted legacy Manager credential is used only in the TLS-protected body of a transient replication request. No new credential is created, no secret is placed in a URL or log, and no persistent `_replicator` document is written.

## Safety

- production remains untouched and unauthorized
- production mutations remain hard-locked to `fortudo-dat-411`
- timer activity blocks the migration preflight
- the validator is installed only after exact quarantine capture verification
- current winners, conflicts, deleted leaves, attachments, entity IDs, and the locked taxonomy meanings are verified
- migration completion is a separately verified marker after exact state convergence
- interruption/resume accepts only locked pre-state or the exact intended successor and halts on divergence

## Validation

- `npm run verify`
  - 76 Jest suites / 1,592 tests passed
  - coverage: 91.07% statements, 79.40% branches, 93.53% functions, 91.97% lines
  - 202 Python tests passed
  - 18 browser E2E tests passed
- exact disposable Cloudant gate passed using two random preview databases and verified cleanup
  - ambiguous replication retry: passed
  - leaf drift block: passed
  - `_security` drift block: passed
  - legacy write denial: passed
  - compatible write acceptance: passed
  - forced interruption/resume: passed
  - unexpected revision block: passed
- post-gate read-only orphan audit: `0`
- independent Kleppmann-style review: no code or architecture blockers
- service-worker precache remains current at version `33b27266708b`; there are no `public/**` or `firebase.json` changes

