### PR TITLE
Bind Cloudant capture to verified preflight

### DIFF
--- a/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
+++ b/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
@@ -3,9 +3,11 @@
 ## Current status
 
 The production entity and taxonomy migration is paused until the guarded quarantine implementation
-has passed its disposable Cloudant proof, merged, deployed, and received a fresh production
-approval. This repository now contains a narrowly scoped write-capable command for that later
-operation. Its presence is not authorization to run it against production.
+has passed its disposable Cloudant proof, merged, and received a fresh production approval. The
+browser compatibility release must be deployed and verified separately; operational-only changes
+under `scripts/` and `docs/` do not require or trigger a Firebase deployment. This repository now
+contains a narrowly scoped write-capable command for that later operation. Its presence is not
+authorization to run it against production.
 
 This is deliberate. The retired tooling attempted to implement a complete revision-graph snapshot
 and restore format locally and treated Cloudant's opaque `update_seq` as a stable content lock.
@@ -23,6 +25,16 @@ in the local process environment.
 
 ## Read-only commands
 
+Run the production operational preflight:
+
+```powershell
+python scripts/cloudant_quarantine_migration.py preflight
+```
+
+It verifies winning bodies, conflict arrays, locked labels, and timer state against one
+revision-bound source state, then reports the associated migration counts, source fingerprint, and
+`_security` hash. These are the authoritative production approval values.
+
 Inspect whether a named Fortudo database contains the exact reviewed validator:
 
 ```powershell
@@ -38,10 +50,10 @@ python scripts/migrate_taxonomy_identity.py --database fortudo-dat-411
 The read-only planner accepts any explicit, valid `fortudo-*` database name and has no apply mode.
 Its transformation rules are application-wide: it reads and preserves the selected database's
 current taxonomy rather than hardcoding the `dat-411` labels. This permits comparison and auditing;
-it does not authorize taxonomy migration in another room. The production executor remains
-locked to `fortudo-dat-411`.
+it is not a replacement for the revision-bound operational preflight and does not authorize
+taxonomy migration in another room. The production executor remains locked to `fortudo-dat-411`.
 
-Both commands print only a state or aggregate counts. They do not print the database name,
+These commands print only a state or aggregate counts. They do not print the database name,
 credentials, document bodies, descriptions, revision identifiers, or opaque database metadata.
 
 ## Guarded migration commands
@@ -49,8 +61,10 @@ credentials, document bodies, descriptions, revision identifiers, or opaque data
 `scripts/cloudant_quarantine_migration.py` provides `preflight`, `capture`, `fence`, `migrate`, and
 `delete-quarantine`. Production mutations are hard-locked to `fortudo-dat-411`; every mutating mode
 requires the expected account checksum, an exact source confirmation where applicable, and
-`--approve-remote-writes`. Capture creates one exact quarantine database and uses transient
-`POST /_replicate`; it never writes a durable replication document.
+`--approve-remote-writes`. Capture additionally requires the exact source fingerprint and
+`_security` hash emitted by the approved preflight, and rejects either mismatch before database
+creation. It creates one exact quarantine database and uses transient `POST /_replicate`; it never
+writes a durable replication document.
 
 Before this command may be used on production, run the exact disposable proof:
 
@@ -89,7 +103,8 @@ Production writes remain blocked until all of the following are true:
    including conflict leaves, tombstones, attachments, source-drift detection, partial migration
    recovery, and exact cleanup.
 3. The implementation pull request passes the complete repository suite and GitHub CI and is merged.
-4. The compatible release containing that exact commit is deployed and its live assets are verified.
+4. The compatible browser release is deployed and its live assets are verified byte-for-byte
+   against its exact source commit.
 5. A fresh read-only production dry-run matches the approved target, mappings, winner/conflict
    expectations, and reports no running timer.
 6. The operational preflight rechecks that the live timer configuration is absent and fails before

--- a/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
+++ b/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
@@ -87,6 +87,12 @@ native replication protocol. Attachments travel as part of those replicated revi
 does not duplicate every body and attachment into a second local archive merely to reimplement that
 integrity check.
 
+Planner inputs are also revision-bound to this state model. Every winning body returned for
+planning must have the exact locked winning `_rev`; its live `_conflicts` set must equal the locked
+nonwinning, nondeleted leaf revisions; and the complete set of live winners must agree. Equal state
+reads around an unbound `_all_docs` response are insufficient because Cloudant may serve an older
+body between them.
+
 The tool does not record or compare Cloudant's opaque `update_seq`.
 
 ## `_security`
@@ -105,8 +111,15 @@ is outside this document. Any intentional security change is a separate approved
    require `config-running-activity` to be absent. A live timer blocks before any remote mutation,
    including quarantine database creation. Stopping the timer through a compatible client deletes
    that live configuration; merely closing its UI is insufficient.
+   Read the current taxonomy rows, verify the two locked Meetings/Comms meanings, and require the
+   complete migration planner to accept the current winners and conflict metadata before creating
+   the quarantine. Repeat these checks inside the capture command rather than trusting that a
+   separately run preflight is still applicable. Re-read the source leaf state and `_security`
+   after those checks; drift invalidates the preflight report or blocks capture before database
+   creation.
 2. Lock the exact Cloudant account endpoint and source database name in process memory. Normal
-   output exposes neither.
+   output exposes neither. Require the exact source fingerprint and `_security` hash from the
+   operator-approved preflight; either mismatch blocks before database creation.
 3. Create one empty, nonpartitioned database with a random high-entropy
    `fortudo-quarantine-<random>` name. Abort if it already exists or is not empty.
 4. Send one transient `POST /_replicate` request from `fortudo-dat-411` to that exact database. Use
@@ -130,6 +143,12 @@ fingerprint. Do not require the old quarantine leaves to be a subset of the sour
 normal source update replaces a leaf with its child while the quarantine still exposes the parent
 as a leaf. Replication can converge that ancestry safely. Unexpected quarantine-only leaves remain
 after replication and fail final equality; do not destructively clean or trust that target.
+
+The second pre-creation state/security read is an observed stability point, not an atomic write
+fence. A source write immediately afterward can still race with database creation. The
+post-replication equality checks prevent that target from producing a trusted capture receipt, and
+the retained target must be treated as untrusted until a later exact retry converges. Operational
+client quiescence therefore remains required.
 
 ## Fence installation
 
@@ -232,13 +251,15 @@ The exercise must prove:
 3. `winning_revs_only`, filters, selectors, `doc_ids`, and continuous mode are absent;
 4. source leaf drift after capture blocks validator installation without a validator or migration
    write;
-5. a deliberate `_security` change after capture blocks validator installation, and the successful
+5. wrong preflight source/security bindings and deliberate source or `_security` drift during
+   capture preconditions block before quarantine creation;
+6. a deliberate `_security` change after capture blocks validator installation, and the successful
    path finishes with the original source `_security` hash unchanged;
-6. validator installation changes exactly one expected design leaf;
-7. a forced interruption leaves a state that a fresh run safely classifies and completes;
-8. invalid legacy writes are denied after fencing while compatible writes succeed;
-9. the final invariant and completion checks detect any unexpected revision; and
-10. no `_replicator` document is created, output remains sanitized, and cleanup deletes only the two
+7. validator installation changes exactly one expected design leaf;
+8. a forced interruption leaves a state that a fresh run safely classifies and completes;
+9. invalid legacy writes are denied after fencing while compatible writes succeed;
+10. the final invariant and completion checks detect any unexpected revision; and
+11. no `_replicator` document is created, output remains sanitized, and cleanup deletes only the two
     exact disposable databases.
 
 Record only aggregate counts, state fingerprints, validator checksum/revision, test result, and

--- a/scripts/cloudant-quarantine-gate.py
+++ b/scripts/cloudant-quarantine-gate.py
@@ -217,6 +217,26 @@ def stop_timer_compatibly(client: OperationalCloudantClient, database: str) -> N
     )
 
 
+def capture_with_current_bindings(
+    client: OperationalCloudantClient,
+    source_database: str,
+    quarantine_database: str,
+    *,
+    resume_existing: bool = False,
+):
+    preflight_state = client.get_state_model(source_database)
+    preflight_security_hash = client.get_security_hash(source_database)
+    return capture_quarantine(
+        client,
+        source_database,
+        quarantine_database,
+        allow_disposable_preview=True,
+        resume_existing=resume_existing,
+        expected_source_fingerprint=preflight_state.fingerprint,
+        expected_security_hash=preflight_security_hash,
+    )
+
+
 def attachment_revision(client: OperationalCloudantClient, database: str) -> tuple[str, str]:
     matches = [
         document
@@ -273,6 +293,58 @@ class AmbiguousReplicationOnce:
         return result
 
 
+class DriftDuringCapturePreconditions:
+    """Create a real source revision between capture's two state reads."""
+
+    def __init__(self, client: OperationalCloudantClient, database: str) -> None:
+        self.client = client
+        self.database = database
+        self.drifted = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.client, name)
+
+    def get_all_documents(self, database: str, *, include_conflicts: bool):
+        documents = self.client.get_all_documents(database, include_conflicts=include_conflicts)
+        if not self.drifted:
+            require(database == self.database, "capture precondition drift target differs")
+            task = self.client.get_document(database, "task-preview")
+            require(
+                task is not None and isinstance(task.get("_rev"), str),
+                "preview task is absent before capture precondition drift",
+            )
+            task["description"] = "private capture precondition drift"
+            self.client.put_document(database, task, create_only=False)
+            self.drifted = True
+        return documents
+
+
+class SecurityDriftDuringCapturePreconditions:
+    """Change preview `_security` between capture's two security reads."""
+
+    def __init__(
+        self,
+        client: DisposablePreviewCloudantClient,
+        database: str,
+        drifted_security: Mapping[str, Any],
+    ) -> None:
+        self.client = client
+        self.database = database
+        self.drifted_security = drifted_security
+        self.drifted = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.client, name)
+
+    def get_all_documents(self, database: str, *, include_conflicts: bool):
+        documents = self.client.get_all_documents(database, include_conflicts=include_conflicts)
+        if not self.drifted:
+            require(database == self.database, "capture security drift target differs")
+            self.client.put_preview_security(database, self.drifted_security)
+            self.drifted = True
+        return documents
+
+
 def safe_report(
     *,
     capture: Any,
@@ -319,6 +391,10 @@ def main() -> int:
     report_values = None
     counts = {
         "timerZeroWritePreflights": 0,
+        "taxonomyMeaningZeroWritePreflights": 0,
+        "captureBindingMismatchBlocks": 0,
+        "capturePreconditionDriftBlocks": 0,
+        "capturePreconditionSecurityDriftBlocks": 0,
         "ambiguousReplicationRetries": 0,
         "leafDriftBlocks": 0,
         "securityDriftBlocks": 0,
@@ -356,11 +432,10 @@ def main() -> int:
         before_timer_gate = client.get_state_model(source_database)
         quarantine_may_be_owned = True
         try:
-            capture_quarantine(
+            capture_with_current_bindings(
                 client,
                 source_database,
                 quarantine_database,
-                allow_disposable_preview=True,
             )
         except QuarantineSafetyError as error:
             require("running timer" in str(error), "timer preflight failed for another reason")
@@ -374,14 +449,155 @@ def main() -> int:
         counts["timerZeroWritePreflights"] += 1
         stop_timer_compatibly(client, source_database)
 
+        phase = "taxonomy meaning zero-write preflight"
+        taxonomy = client.get_document(source_database, "config-categories")
+        require(
+            taxonomy is not None and isinstance(taxonomy.get("_rev"), str),
+            "preview taxonomy is absent before meaning drift",
+        )
+        meeting_row = next(
+            (
+                row
+                for row in taxonomy.get("categories", [])
+                if isinstance(row, dict) and row.get("key") == "work/meetings"
+            ),
+            None,
+        )
+        require(meeting_row is not None, "preview locked taxonomy row is absent")
+        meeting_row["label"] = "Meetings"
+        drift_response = client.put_document(source_database, taxonomy, create_only=False)
+        require(
+            isinstance(drift_response, Mapping) and isinstance(drift_response.get("rev"), str),
+            "preview taxonomy drift response is invalid",
+        )
+        taxonomy["_rev"] = drift_response["rev"]
+        try:
+            capture_with_current_bindings(
+                client,
+                source_database,
+                quarantine_database,
+            )
+        except QuarantineSafetyError as error:
+            require(
+                "locked taxonomy meaning" in str(error),
+                "taxonomy meaning preflight failed for another reason",
+            )
+        else:
+            raise QuarantineSafetyError("taxonomy meaning drift did not block capture")
+        require(
+            not client.database_exists(quarantine_database),
+            "taxonomy meaning preflight created a quarantine database",
+        )
+        meeting_row["label"] = "Comms"
+        restore_response = client.put_document(source_database, taxonomy, create_only=False)
+        require(
+            isinstance(restore_response, Mapping) and isinstance(restore_response.get("rev"), str),
+            "preview taxonomy restore response is invalid",
+        )
+        counts["taxonomyMeaningZeroWritePreflights"] += 1
+
+        phase = "capture binding mismatch gates"
+        binding_state = client.get_state_model(source_database)
+        binding_security_hash = client.get_security_hash(source_database)
+        for changed_binding in ("source", "security"):
+            try:
+                capture_quarantine(
+                    client,
+                    source_database,
+                    quarantine_database,
+                    allow_disposable_preview=True,
+                    expected_source_fingerprint=(
+                        "0" * 64
+                        if changed_binding == "source"
+                        else binding_state.fingerprint
+                    ),
+                    expected_security_hash=(
+                        "0" * 64
+                        if changed_binding == "security"
+                        else binding_security_hash
+                    ),
+                )
+            except QuarantineSafetyError as error:
+                require(
+                    "preflight expectation" in str(error),
+                    "capture binding mismatch failed for another reason",
+                )
+            else:
+                raise QuarantineSafetyError("capture binding mismatch did not block capture")
+            require(
+                not client.database_exists(quarantine_database),
+                "capture binding mismatch created a quarantine database",
+            )
+            counts["captureBindingMismatchBlocks"] += 1
+
+        phase = "capture precondition drift gate"
+        drift_client = DriftDuringCapturePreconditions(client, source_database)
+        try:
+            capture_with_current_bindings(
+                drift_client,
+                source_database,
+                quarantine_database,
+            )
+        except QuarantineSafetyError as error:
+            require(
+                "capture preconditions" in str(error),
+                "capture precondition drift failed for another reason",
+            )
+        else:
+            raise QuarantineSafetyError("capture precondition drift did not block capture")
+        require(
+            drift_client.drifted and not client.database_exists(quarantine_database),
+            "capture precondition drift created a quarantine database",
+        )
+        counts["capturePreconditionDriftBlocks"] += 1
+
+        phase = "capture precondition security drift gate"
+        original_capture_security = client.get_security_document(source_database)
+        drifted_capture_security = copy.deepcopy(original_capture_security)
+        capture_cloudant_roles = drifted_capture_security.setdefault("cloudant", {})
+        require(
+            isinstance(capture_cloudant_roles, dict),
+            "preview capture security shape is unsupported",
+        )
+        capture_cloudant_roles[f"preview-capture-drift-{nonce}"] = ["_reader"]
+        security_drift_client = SecurityDriftDuringCapturePreconditions(
+            client,
+            source_database,
+            drifted_capture_security,
+        )
+        try:
+            try:
+                capture_with_current_bindings(
+                    security_drift_client,
+                    source_database,
+                    quarantine_database,
+                )
+            except QuarantineSafetyError as error:
+                require(
+                    "security drifted during capture preconditions" in str(error),
+                    "capture precondition security drift failed for another reason",
+                )
+            else:
+                raise QuarantineSafetyError(
+                    "capture precondition security drift did not block capture"
+                )
+        finally:
+            client.put_preview_security(source_database, original_capture_security)
+        require(
+            security_drift_client.drifted
+            and not client.database_exists(quarantine_database)
+            and client.get_security_document(source_database) == original_capture_security,
+            "capture precondition security drift was not restored exactly",
+        )
+        counts["capturePreconditionSecurityDriftBlocks"] += 1
+
         phase = "ambiguous quarantine capture"
         ambiguous_client = AmbiguousReplicationOnce(client)
         try:
-            capture_quarantine(
+            capture_with_current_bindings(
                 ambiguous_client,
                 source_database,
                 quarantine_database,
-                allow_disposable_preview=True,
             )
         except QuarantineSafetyError as error:
             require(
@@ -397,11 +613,10 @@ def main() -> int:
         )
 
         phase = "retained-target quarantine retry"
-        capture = capture_quarantine(
+        capture = capture_with_current_bindings(
             client,
             source_database,
             quarantine_database,
-            allow_disposable_preview=True,
             resume_existing=True,
         )
         source_attachment = attachment_revision(client, source_database)
@@ -435,11 +650,10 @@ def main() -> int:
         )
 
         phase = "resumed quarantine capture"
-        capture = capture_quarantine(
+        capture = capture_with_current_bindings(
             client,
             source_database,
             quarantine_database,
-            allow_disposable_preview=True,
             resume_existing=True,
         )
 

--- a/scripts/cloudant_quarantine_migration.py
+++ b/scripts/cloudant_quarantine_migration.py
@@ -621,6 +621,77 @@ def require_locked_taxonomy_meanings(documents: Sequence[Mapping[str, Any]]) -> 
         raise QuarantineSafetyError("locked taxonomy meaning differs from the approved mapping")
 
 
+def _require_documents_match_locked_state(
+    documents: Sequence[Mapping[str, Any]],
+    locked_state: StateModel,
+) -> None:
+    """Bind planner winner bodies and conflict arrays to the locked leaf graph."""
+
+    winners = dict(locked_state.winners)
+    leaves_by_document: dict[str, list[LeafRevision]] = {}
+    for leaf in locked_state.leaves:
+        leaves_by_document.setdefault(leaf.document_id, []).append(leaf)
+
+    expected_live_winners: dict[str, str] = {}
+    expected_conflicts: dict[str, list[str]] = {}
+    for document_id, winner_revision in winners.items():
+        winner_leaf = next(
+            (
+                leaf
+                for leaf in leaves_by_document.get(document_id, [])
+                if leaf.revision == winner_revision
+            ),
+            None,
+        )
+        if winner_leaf is None:
+            raise QuarantineSafetyError("locked source winner is absent from its leaf graph")
+        if winner_leaf.deleted:
+            continue
+        expected_live_winners[document_id] = winner_revision
+        expected_conflicts[document_id] = sorted(
+            leaf.revision
+            for leaf in leaves_by_document[document_id]
+            if leaf.revision != winner_revision and not leaf.deleted
+        )
+
+    observed: dict[str, str] = {}
+    for document in documents:
+        document_id = document.get("_id")
+        revision = document.get("_rev")
+        conflicts = document.get("_conflicts", [])
+        if (
+            not isinstance(document_id, str)
+            or not isinstance(revision, str)
+            or document.get("_deleted") is True
+            or document_id in observed
+            or not isinstance(conflicts, list)
+            or not all(isinstance(conflict, str) for conflict in conflicts)
+            or len(conflicts) != len(set(conflicts))
+            or expected_live_winners.get(document_id) != revision
+            or sorted(conflicts) != expected_conflicts.get(document_id)
+        ):
+            raise QuarantineSafetyError("winning document read differs from locked source")
+        observed[document_id] = revision
+    if observed != expected_live_winners:
+        raise QuarantineSafetyError("winning document read differs from locked source")
+
+
+def _require_migration_preconditions(
+    client: Any,
+    database: str,
+    locked_state: StateModel,
+) -> Any:
+    """Verify read-only taxonomy and planner gates before any remote mutation."""
+
+    documents = client.get_all_documents(database, include_conflicts=True)
+    _require_documents_match_locked_state(documents, locked_state)
+    require_locked_taxonomy_meanings(documents)
+    plan = _checked_migration_plan(documents)
+    if plan.running_timer_present:
+        raise QuarantineSafetyError("running timer must be stopped before any remote mutation")
+    return plan
+
+
 def _checked_migration_plan(documents: Sequence[Mapping[str, Any]]) -> Any:
     try:
         return build_migration_plan(documents)
@@ -1000,6 +1071,8 @@ def capture_quarantine(
     *,
     allow_disposable_preview: bool = False,
     resume_existing: bool = False,
+    expected_source_fingerprint: str | None = None,
+    expected_security_hash: str | None = None,
 ) -> CaptureReceipt:
     """Create and verify one Cloudant-native quarantine copy."""
 
@@ -1008,9 +1081,20 @@ def capture_quarantine(
         quarantine_database, allow_disposable_preview=allow_disposable_preview
     )
     _require_no_running_timer(client, source_database)
-
-    security_hash = client.get_security_hash(source_database)
     locked_source = client.get_state_model(source_database)
+    security_hash = client.get_security_hash(source_database)
+    if expected_source_fingerprint is None or expected_security_hash is None:
+        raise QuarantineSafetyError("capture requires exact preflight bindings")
+    if locked_source.fingerprint != expected_source_fingerprint:
+        raise QuarantineSafetyError("source fingerprint differs from preflight expectation")
+    if security_hash != expected_security_hash:
+        raise QuarantineSafetyError("source security differs from preflight expectation")
+    _require_migration_preconditions(client, source_database, locked_source)
+    if client.get_state_model(source_database) != locked_source:
+        raise QuarantineSafetyError("source state drifted during capture preconditions")
+    if client.get_security_hash(source_database) != security_hash:
+        raise QuarantineSafetyError("source security drifted during capture preconditions")
+
     if client.database_exists(quarantine_database):
         if not resume_existing:
             raise QuarantineSafetyError("quarantine database already exists")
@@ -1131,6 +1215,8 @@ def _parser() -> argparse.ArgumentParser:
     capture = modes.add_parser("capture")
     capture.add_argument("--quarantine-database", required=True)
     capture.add_argument("--resume-existing", action="store_true")
+    capture.add_argument("--expected-source-fingerprint", required=True, type=_sha256_argument)
+    capture.add_argument("--expected-security-hash", required=True, type=_sha256_argument)
     _add_mutation_gates(capture)
 
     fence = modes.add_parser("fence")
@@ -1195,14 +1281,27 @@ def execute_cli(
         source_state = client.get_state_model(SOURCE_DATABASE)
         security_hash = client.get_security_hash(SOURCE_DATABASE)
         timer_present = client.get_document(SOURCE_DATABASE, RUNNING_ACTIVITY_ID) is not None
+        migration_plan = None
+        if not timer_present:
+            migration_plan = _require_migration_preconditions(
+                client,
+                SOURCE_DATABASE,
+                source_state,
+            )
         validator = verify_validator(client, SOURCE_DATABASE)
+        if client.get_state_model(SOURCE_DATABASE) != source_state:
+            raise QuarantineSafetyError("source state drifted during preflight")
+        if client.get_security_hash(SOURCE_DATABASE) != security_hash:
+            raise QuarantineSafetyError("source security drifted during preflight")
         report = {
             "mode": "preflight",
             "accountChecksum": client.account_checksum,
             "sourceFingerprint": source_state.fingerprint,
             "securityHash": security_hash,
             "counts": source_state.counts,
+            "migrationCounts": migration_plan.counts if migration_plan is not None else None,
             "runningTimerPresent": timer_present,
+            "lockedTaxonomyMeanings": "verified" if not timer_present else "blocked-by-timer",
             "validatorState": validator["state"],
             "validatorRevision": validator["validatorRevision"],
         }
@@ -1219,6 +1318,8 @@ def execute_cli(
             SOURCE_DATABASE,
             args.quarantine_database,
             resume_existing=args.resume_existing,
+            expected_source_fingerprint=args.expected_source_fingerprint,
+            expected_security_hash=args.expected_security_hash,
         )
         report = {
             "mode": "capture",

--- a/tests/test_cloudant_quarantine_migration.py
+++ b/tests/test_cloudant_quarantine_migration.py
@@ -146,6 +146,7 @@ class CaptureCloudant:
         security=None,
         database_exists=False,
         fail_replication=False,
+        documents=None,
     ):
         self.timer = timer
         self.source_states = list(source_states or [])
@@ -154,6 +155,7 @@ class CaptureCloudant:
         self.security = security or {"cloudant": {"accepted-user": ["_reader"]}}
         self._database_exists = database_exists
         self.fail_replication = fail_replication
+        self.documents = copy.deepcopy(documents if documents is not None else migration_winners())
         self.calls: list[tuple] = []
 
     def get_document(self, database, document_id):
@@ -169,6 +171,10 @@ class CaptureCloudant:
     def get_security_hash(self, database):
         self.calls.append(("security", database))
         return quarantine.canonical_hash(self.security)
+
+    def get_all_documents(self, database, *, include_conflicts):
+        self.calls.append(("all-documents", database, include_conflicts))
+        return copy.deepcopy(self.documents)
 
     def database_exists(self, database):
         self.calls.append(("exists", database))
@@ -188,6 +194,17 @@ class CaptureCloudant:
         return {"ok": True, "history": [{"doc_write_failures": 0}]}
 
 
+def capture_with_bindings(client, expected_state, **kwargs):
+    return quarantine.capture_quarantine(
+        client,
+        SOURCE,
+        QUARANTINE,
+        expected_source_fingerprint=expected_state.fingerprint,
+        expected_security_hash=quarantine.canonical_hash(client.security),
+        **kwargs,
+    )
+
+
 def test_running_timer_blocks_before_any_remote_mutation() -> None:
     client = CaptureCloudant(timer={"_id": "config-running-activity"})
 
@@ -197,23 +214,66 @@ def test_running_timer_blocks_before_any_remote_mutation() -> None:
     assert client.calls == [("get-document", SOURCE, "config-running-activity")]
 
 
-def test_capture_creates_one_exact_database_and_uses_transient_replication() -> None:
-    captured = state(
-        ("_design/existing", "1-design", False),
-        ("task-a", "2-live", False),
-        ("activity-a", "3-winner", False),
-        ("activity-a", "2-loser", False),
-        ("task-deleted", "2-deleted", True),
-        winners={
-            "_design/existing": "1-design",
-            "task-a": "2-live",
-            "activity-a": "3-winner",
-            "task-deleted": "2-deleted",
-        },
+def test_locked_taxonomy_meaning_drift_blocks_before_quarantine_creation() -> None:
+    documents = migration_winners()
+    documents[0]["categories"][0]["label"] = "Meetings"
+    captured = migration_base_state()
+    client = CaptureCloudant(
+        documents=documents,
+        source_states=[captured],
     )
-    client = CaptureCloudant(source_states=[captured, captured], quarantine_state=captured)
 
-    receipt = quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+    with pytest.raises(quarantine.QuarantineSafetyError, match="locked taxonomy meaning"):
+        capture_with_bindings(client, captured)
+
+    assert not any(call[0] in {"create-database", "replicate-once"} for call in client.calls)
+
+
+def test_source_drift_during_capture_preconditions_blocks_before_quarantine_creation() -> None:
+    documents = migration_winners()
+    before = state_for_winner_documents(documents)
+    changed_documents = copy.deepcopy(documents)
+    changed_documents[1]["_rev"] = "3-task-drift"
+    after = state_for_winner_documents(changed_documents)
+    client = CaptureCloudant(source_states=[before, after], documents=documents)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="preconditions"):
+        capture_with_bindings(client, before)
+
+    assert not any(call[0] in {"create-database", "replicate-once"} for call in client.calls)
+
+
+@pytest.mark.parametrize("changed_binding", ["source", "security"])
+def test_capture_binding_mismatch_blocks_before_quarantine_creation(changed_binding) -> None:
+    captured = migration_base_state()
+    client = CaptureCloudant(
+        source_states=[captured],
+        security={},
+    )
+    expected_source = "0" * 64 if changed_binding == "source" else captured.fingerprint
+    actual_security = quarantine.canonical_hash({})
+    expected_security = "0" * 64 if changed_binding == "security" else actual_security
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="expectation"):
+        quarantine.capture_quarantine(
+            client,
+            SOURCE,
+            QUARANTINE,
+            expected_source_fingerprint=expected_source,
+            expected_security_hash=expected_security,
+        )
+
+    assert not any(call[0] in {"create-database", "replicate-once"} for call in client.calls)
+
+
+def test_capture_creates_one_exact_database_and_uses_transient_replication() -> None:
+    captured = migration_base_state()
+    client = CaptureCloudant(
+        source_states=[captured, captured, captured],
+        quarantine_state=captured,
+    )
+
+    receipt = capture_with_bindings(client, captured)
 
     assert receipt.source_database == SOURCE
     assert receipt.quarantine_database == QUARANTINE
@@ -225,46 +285,56 @@ def test_capture_creates_one_exact_database_and_uses_transient_replication() -> 
 
 
 def test_capture_halts_on_source_drift_without_a_persistent_job() -> None:
-    before = state(("task-a", "1-a", False))
-    after = state(("task-a", "2-a", False))
-    client = CaptureCloudant(source_states=[before, after], quarantine_state=before)
+    documents = migration_winners()
+    before = state_for_winner_documents(documents)
+    changed_documents = copy.deepcopy(documents)
+    changed_documents[1]["_rev"] = "3-task-drift"
+    after = state_for_winner_documents(changed_documents)
+    client = CaptureCloudant(
+        source_states=[before, before, after],
+        quarantine_state=before,
+        documents=documents,
+    )
 
     with pytest.raises(quarantine.QuarantineSafetyError, match="source state drifted"):
-        quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+        capture_with_bindings(client, before)
 
     assert ("replicate-once", SOURCE, QUARANTINE) in client.calls
     assert not any(call[0] == "delete-database" for call in client.calls)
 
 
 def test_uncertain_transient_replication_is_safe_to_resume() -> None:
-    source_state = state(("task-a", "1-a", False))
+    source_state = migration_base_state()
     client = CaptureCloudant(
-        source_states=[source_state],
+        source_states=[source_state, source_state],
         quarantine_state=source_state,
         fail_replication=True,
     )
 
     with pytest.raises(quarantine.QuarantineSafetyError, match="uncertain"):
-        quarantine.capture_quarantine(client, SOURCE, QUARANTINE)
+        capture_with_bindings(client, source_state)
 
     client.fail_replication = False
     client._database_exists = True
-    client.source_states = [source_state, source_state]
-    receipt = quarantine.capture_quarantine(client, SOURCE, QUARANTINE, resume_existing=True)
+    client.source_states = [source_state, source_state, source_state]
+    receipt = capture_with_bindings(client, source_state, resume_existing=True)
     assert receipt.state == source_state
 
 
 def test_interrupted_capture_reruns_after_an_existing_source_document_was_edited() -> None:
-    source_state = state(("task-a", "2-edited", False), ("task-b", "1-b", False))
-    stale_quarantine = state(("task-a", "1-original", False))
+    documents = migration_winners()
+    documents[1]["_rev"] = "3-task-edited"
+    source_state = state_for_winner_documents(documents)
+    stale_quarantine = migration_base_state()
     client = CaptureCloudant(
-        source_states=[source_state, source_state],
+        source_states=[source_state, source_state, source_state],
         quarantine_state=stale_quarantine,
         post_replication_quarantine_state=source_state,
         database_exists=True,
+        documents=documents,
     )
 
-    receipt = quarantine.capture_quarantine(client, SOURCE, QUARANTINE, resume_existing=True)
+    receipt = capture_with_bindings(client, source_state, resume_existing=True)
 
     assert receipt.state == source_state
     assert not any(call[0] == "create-database" for call in client.calls)
@@ -272,12 +342,13 @@ def test_interrupted_capture_reruns_after_an_existing_source_document_was_edited
 
     unrelated = state(("task-other", "1-other", False))
     blocked = CaptureCloudant(
-        source_states=[source_state, source_state],
+        source_states=[source_state, source_state, source_state],
         quarantine_state=unrelated,
         database_exists=True,
+        documents=documents,
     )
     with pytest.raises(quarantine.QuarantineSafetyError, match="differs from the source"):
-        quarantine.capture_quarantine(blocked, SOURCE, QUARANTINE, resume_existing=True)
+        capture_with_bindings(blocked, source_state, resume_existing=True)
     assert ("replicate-once", SOURCE, QUARANTINE) in blocked.calls
 
 
@@ -760,18 +831,23 @@ def migration_winners() -> list[dict]:
     ]
 
 
+def state_for_winner_documents(documents):
+    leaves = []
+    winners = {}
+    for document in documents:
+        document_id = document["_id"]
+        revision = document["_rev"]
+        leaves.append((document_id, revision, document.get("_deleted") is True))
+        winners[document_id] = revision
+        leaves.extend((document_id, conflict, False) for conflict in document.get("_conflicts", []))
+        leaves.extend(
+            (document_id, conflict, True) for conflict in document.get("_deleted_conflicts", [])
+        )
+    return state(*leaves, winners=winners)
+
+
 def migration_base_state():
-    return state(
-        ("config-categories", "3-taxonomy", False),
-        ("task-a", "2-task", False),
-        ("activity-a", "4-winner", False),
-        ("activity-a", "3-loser", False),
-        winners={
-            "config-categories": "3-taxonomy",
-            "task-a": "2-task",
-            "activity-a": "4-winner",
-        },
-    )
+    return state_for_winner_documents(migration_winners())
 
 
 def successor(document: dict, revision: str, parent: str) -> dict:
@@ -1168,13 +1244,43 @@ def test_mutating_cli_requires_account_binding_source_confirmation_and_approval(
         )
 
 
+@pytest.mark.parametrize(
+    "omitted_flag",
+    ["--expected-source-fingerprint", "--expected-security-hash"],
+)
+def test_capture_cli_requires_both_exact_preflight_bindings(omitted_flag) -> None:
+    arguments = [
+        "capture",
+        "--quarantine-database",
+        QUARANTINE,
+        "--expected-source-fingerprint",
+        "b" * 64,
+        "--expected-security-hash",
+        "c" * 64,
+        "--expected-account-checksum",
+        "a" * 64,
+        "--confirm-source",
+        SOURCE,
+        "--approve-remote-writes",
+    ]
+    omitted_index = arguments.index(omitted_flag)
+    del arguments[omitted_index : omitted_index + 2]
+
+    with pytest.raises(SystemExit):
+        quarantine._parser().parse_args(arguments)
+
+
 def test_preflight_reports_exact_validator_state_without_database_or_private_values(capsys) -> None:
+    validator_document = {**load_design_document(), "_rev": "1-validator"}
+    documents = [*migration_winners(), validator_document]
+    locked_state = state_for_winner_documents(documents)
+
     class PreflightClient:
         account_checksum = "a" * 64
 
         def get_state_model(self, database):
             assert database == SOURCE
-            return state(("task-a", "1-a", False))
+            return locked_state
 
         def get_security_hash(self, database):
             assert database == SOURCE
@@ -1184,7 +1290,12 @@ def test_preflight_reports_exact_validator_state_without_database_or_private_val
             assert database == SOURCE
             if document_id == migration.RUNNING_ACTIVITY_ID:
                 return None
-            return {**load_design_document(), "_rev": "1-validator"}
+            return validator_document
+
+        def get_all_documents(self, database, *, include_conflicts):
+            assert database == SOURCE
+            assert include_conflicts is True
+            return copy.deepcopy(documents)
 
     result = quarantine.execute_cli(
         ["preflight"],
@@ -1194,9 +1305,106 @@ def test_preflight_reports_exact_validator_state_without_database_or_private_val
 
     assert result["validatorState"] == "compatible"
     assert result["validatorRevision"] == "1-validator"
+    assert result["lockedTaxonomyMeanings"] == "verified"
+    assert result["migrationCounts"]["documentsUpdated"] == 3
     output = capsys.readouterr().out
     assert SOURCE not in output
     assert "secret" not in output
+
+
+def test_preflight_blocks_before_remote_writes_when_locked_taxonomy_meanings_differ() -> None:
+    documents = migration_winners()
+    locked_state = state_for_winner_documents(documents)
+
+    class PreflightClient:
+        account_checksum = "a" * 64
+
+        def get_state_model(self, _database):
+            return locked_state
+
+        def get_security_hash(self, _database):
+            return "b" * 64
+
+        def get_document(self, _database, document_id):
+            if document_id == migration.RUNNING_ACTIVITY_ID:
+                return None
+            return None
+
+        def get_all_documents(self, _database, *, include_conflicts):
+            assert include_conflicts is True
+            mismatched = copy.deepcopy(documents)
+            mismatched[0]["categories"][0]["label"] = "Meetings"
+            return mismatched
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="locked taxonomy meaning"):
+        quarantine.execute_cli(
+            ["preflight"],
+            environ={quarantine.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+            client_factory=lambda _url: PreflightClient(),
+        )
+
+
+def test_preflight_rejects_a_report_built_across_source_state_drift() -> None:
+    documents = migration_winners()
+    before = state_for_winner_documents(documents)
+    changed_documents = copy.deepcopy(documents)
+    changed_documents[1]["_rev"] = "3-task-drift"
+    after = state_for_winner_documents(changed_documents)
+
+    class PreflightClient:
+        account_checksum = "a" * 64
+
+        def __init__(self):
+            self.states = [before, after]
+
+        def get_state_model(self, _database):
+            return self.states.pop(0)
+
+        def get_security_hash(self, _database):
+            return "b" * 64
+
+        def get_document(self, _database, _document_id):
+            return None
+
+        def get_all_documents(self, _database, *, include_conflicts):
+            assert include_conflicts is True
+            return copy.deepcopy(documents)
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="preflight"):
+        quarantine.execute_cli(
+            ["preflight"],
+            environ={quarantine.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+            client_factory=lambda _url: PreflightClient(),
+        )
+
+
+def test_preflight_rejects_stale_winner_bodies_between_stable_state_reads() -> None:
+    locked = migration_base_state()
+
+    class PreflightClient:
+        account_checksum = "a" * 64
+
+        def get_state_model(self, _database):
+            return locked
+
+        def get_security_hash(self, _database):
+            return "b" * 64
+
+        def get_document(self, _database, _document_id):
+            return None
+
+        def get_all_documents(self, _database, *, include_conflicts):
+            assert include_conflicts is True
+            documents = migration_winners()
+            documents[1]["_rev"] = "1-stale-task"
+            return documents
+
+    with pytest.raises(quarantine.QuarantineSafetyError, match="locked source"):
+        quarantine.execute_cli(
+            ["preflight"],
+            environ={quarantine.CREDENTIAL_ENV_VAR: "https://user:secret@example.invalid"},
+            client_factory=lambda _url: PreflightClient(),
+        )
 
 
 def test_delete_quarantine_requires_exact_name_fingerprint_and_confirmation() -> None:


### PR DESCRIPTION
## Summary

- bind quarantine capture to the exact source fingerprint and `_security` hash approved by preflight
- bind the migration planner to the locked revision graph, including exact winners and conflicts
- verify the locked `dat-411` taxonomy meanings and planner structure before any first write
- double-read source state and security around preflight and capture to reject observed drift
- expand the disposable real-Cloudant gate to cover incorrect bindings, source/security drift, stale reads, partial outcomes, and successful capture
- clarify the stability-point and client-quiescence requirements in the design and runbook

## Why

This is a safety follow-up to #109.

The minimal quarantine tool verified the replicated result, but the proposed first production write was not yet bound to the exact read-only preflight the operator approved. The planner's `_all_docs` read also needed to be proven consistent with the locked revision graph. Without those bindings, a stale or changed source view could be used to start a capture that would later fail verification but should never have been attempted.

The fix makes the approved source fingerprint and security hash mandatory, revision-binds the plan, and preserves the post-replication equality check as the authoritative receipt.

## Impact

- no production data was mutated
- no `public/**` or Firebase configuration changed
- after merge, production preflight must be rerun from the exact merged `main` SHA
- the first production write remains the quarantine capture, and any mismatch or drift stops the operation before migration

## Verification

- `npm run verify`
  - Jest: 76 suites, 1,592 tests passed
  - Python: 211 tests passed
  - Playwright: 17 passed, 1 intentional time-of-day skip, 0 failures
  - coverage: 91.07% statements, 79.4% branches, 93.53% functions, 91.97% lines
- staged pre-commit checks: formatting, JavaScript lint, Python lint, and 211 non-browser tests passed
- disposable real-Cloudant gate passed and removed both exact preview databases
- post-gate orphan audit found zero disposable gate databases
- final local code passed a stable, read-only `fortudo-dat-411` production preflight:
  - 600 documents and 13 conflict leaves in the locked source graph
  - locked `work/meetings → Comms` and `work/comms → Meetings` meanings verified
  - 554 planned document updates and 553 planned reference migrations
  - no running timer
  - validator correctly reported as not yet installed
- all 14 compatibility-release assets matched the live Firebase deployment byte-for-byte
- independent distributed-systems review: approved with no blockers
