### PR TITLE
Separate reusable Cloudant migration boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ produced them:
 See `docs/plans/README.md` for the current convention. Do not create new plans under
 `docs/superpowers/`.
 
+Other durable repository documentation is organized by purpose under `docs/reference/`,
+`docs/architecture/`, `docs/operations/`, `docs/product/`, and `docs/migrations/`. Read
+`docs/README.md` before adding or moving documentation. Keep the `docs/` root limited to that index.
+
 ## Commands
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Historical and planned repo tasks for Fortudo.
 - [x] (v2) highlight gaps in schedule with dashed separator and duration label
 
 - [x] (v3) ~~try https://tinybase.org/ for local-first sync, storage, conflict-free replicated data (crdt)~~ local-first sync via PouchDB + CouchDB
-- [x] (v3) enable CouchDB sync: set up IBM Cloudant (free), enable CORS, set `COUCHDB_URL` in the tracked `public/js/config.js` for local testing or override it in CI via the `COUCHDB_URL` repo secret, and add the Cloudant domain to `Content-Security-Policy connect-src` in `firebase.json` (see `docs/COUCHDB-SETUP.md`). The repo default is `COUCHDB_URL = null`, which makes local-only mode explicit. Preview deployments use `preview-<room>` database names to avoid touching production data.
+- [x] (v3) enable CouchDB sync: set up IBM Cloudant (free), enable CORS, set `COUCHDB_URL` in the tracked `public/js/config.js` for local testing or override it in CI via the `COUCHDB_URL` repo secret, and add the Cloudant domain to `Content-Security-Policy connect-src` in `firebase.json` (see `docs/reference/COUCHDB-SETUP.md`). The repo default is `COUCHDB_URL = null`, which makes local-only mode explicit. Preview deployments use `preview-<room>` database names to avoid touching production data.
 - [x] (v3) click on scheduling gap to see list of unscheduled tasks and schedule in gap
 - [x] (v3) upgrade `jest-environment-jsdom` to v30 (breaking) and adjust tests if needed (then remove `overrides` in `package.json`)
 - [x] (v3) rename `dom-handler.js` to `dom-renderer.js` or `view.js` (it's a rendering/view layer, not a feature handler)

--- a/__tests__/brand-system.test.js
+++ b/__tests__/brand-system.test.js
@@ -203,7 +203,7 @@ describe('Fortudo brand system', () => {
     });
 
     test('renders the branded Jelly dedication heart without orphaning it', () => {
-        const brandGuide = read('docs/BRAND.md');
+        const brandGuide = read('docs/reference/BRAND.md');
 
         expect(indexHtml).toMatch(
             /<span class="whitespace-nowrap"\s*>\s*For Cristell\s*<span\s+class="dedication-heart"[\s\S]*?data-dedication-heart[\s\S]*?<\/svg>[\s\S]*?<\/span>\s*<\/span>/
@@ -244,7 +244,7 @@ describe('Fortudo brand system', () => {
 
     test('gives Unscheduled a restrained indigo identity', () => {
         const unscheduledRenderer = read('public/js/tasks/unscheduled-renderer.js');
-        const brandGuide = read('docs/BRAND.md');
+        const brandGuide = read('docs/reference/BRAND.md');
 
         expect(indexHtml).toContain('peer-focus-visible:ring-indigo-400');
         expect(indexHtml).toContain('fa-solid fa-list-ul mr-0.5 sm:mr-1 text-indigo-400/75');
@@ -287,7 +287,7 @@ describe('Fortudo brand system', () => {
     test('uses emerald for positive readiness and documents the complete semantic palette', () => {
         const roomRenderer = read('public/js/room-renderer.js');
         const modalManager = read('public/js/modal-manager.js');
-        const brandGuide = read('docs/BRAND.md');
+        const brandGuide = read('docs/reference/BRAND.md');
 
         expect(roomRenderer).toMatch(
             /synced:\s*\{[^}]*color: 'text-emerald-400'[^}]*label: 'Synced'/s

--- a/docs/CLOUDANT-MIGRATION-TOOLKIT.md
+++ b/docs/CLOUDANT-MIGRATION-TOOLKIT.md
@@ -12,8 +12,8 @@ operation, and which code belongs only to the completed `fortudo-dat-411` taxono
 migration.
 
 The exact completed operation remains documented in
-[Document-contract migration runbook](DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md). Architectural
-motivation and the offline-replica case study remain in
+[Taxonomy identity v1: dat-411 operation runbook](migrations/taxonomy_identity_v1/dat-411-operation-runbook.md).
+Architectural motivation and the offline-replica case study remain in
 [Offline-client migration safety](OFFLINE-CLIENT-MIGRATION-SAFETY.md).
 
 ## Ownership map

--- a/docs/CLOUDANT-MIGRATION-TOOLKIT.md
+++ b/docs/CLOUDANT-MIGRATION-TOOLKIT.md
@@ -1,0 +1,151 @@
+# Cloudant migration toolkit boundaries
+
+## Purpose
+
+Fortudo has reusable Cloudant safety primitives, but it does not have a general-purpose production
+migration engine. This distinction is intentional. Reusing verified state handling reduces risk;
+making data transformations or production targets configurable would hide the decisions that need
+the most review.
+
+This document identifies which code is reusable as-is, which code is a foundation for a future
+operation, and which code belongs only to the completed `fortudo-dat-411` taxonomy-identity-v1
+migration.
+
+The exact completed operation remains documented in
+[Document-contract migration runbook](DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md). Architectural
+motivation and the offline-replica case study remain in
+[Offline-client migration safety](OFFLINE-CLIENT-MIGRATION-SAFETY.md).
+
+## Ownership map
+
+| Category                              | Location                                                          | Stability rule                                                                                                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reusable as-is                        | `scripts/cloudant_migration/state.py`                             | Product-neutral canonical leaf state, counts, and fingerprints. No room, taxonomy, or migration constants.                                                              |
+| Reusable as-is                        | `scripts/cloudant_migration/client.py`                            | Credential-redacting reads, revision-state inspection, and revision-aware document writes. It has no production CLI or database lifecycle methods.                      |
+| Read-only current-contract inspection | `scripts/document_contract_ops.py`                                | Verifies the exact reviewed v1 validator in any explicitly named `fortudo-*` database. It needs a versioned artifact catalog before supporting v2.                      |
+| Migration-family foundation           | `scripts/migrations/taxonomy_identity_v1/planner.py`              | Read-only v1 identity planning for an explicit `fortudo-*` database. Its transformation applies only to the taxonomy-identity-v1 schema transition.                     |
+| Intentionally one-off                 | `scripts/migrations/taxonomy_identity_v1/dat_411_operation.py`    | Exact source lock, locked meanings, quarantine lifecycle, v1 executor, completion marker, and production approval gates. Never parameterize this file for another room. |
+| Exact disposable proof                | `scripts/migrations/taxonomy_identity_v1/disposable_gate.py`      | Proves the completed operation through disposable Cloudant databases. A pass certifies that exact implementation and commit, not future migrations.                     |
+| Browser compatibility foundation      | `public/js/document-contract.js` and `public/js/sync-contract.js` | Central persistence envelope, validator, divergence audit, and recovery behavior. These currently support exactly remote contract v1 and writer envelope v1.            |
+
+Import direction is one-way:
+
+```text
+versioned production operation
+    -> migration-family planner
+    -> reusable Cloudant state/client primitives
+```
+
+Reusable modules must never import a migration-family or production-operation module. Importing a
+write-capable library function is not production authorization; authorization remains in the exact
+operation entry point and its reviewed gates.
+
+## Reusable safety guarantees
+
+The reusable Python layer currently provides:
+
+- Credential and response redaction in raised errors.
+- Stable account-endpoint checksums without exposing the endpoint.
+- Complete current leaf enumeration, including deleted and conflicting leaves.
+- Winner-to-leaf consistency checks.
+- Canonical state counts and fingerprints that exclude opaque `update_seq`.
+- `_security` hashing.
+- Revision-aware document writes; the operation supplies and checks the exact parent revision.
+- Rate-limit retries with bounded backoff.
+
+The completed operation adds, but does not generalize:
+
+- Approved source and quarantine name policies.
+- Native transient replication.
+- Database creation and deletion.
+- Timer, taxonomy, and locked-meaning preconditions.
+- Validator-first fencing.
+- Taxonomy/entity successors and conflict tombstones.
+- Completion-marker semantics.
+
+A future operation may reuse the algorithms behind those additions, but it must supply and prove
+its own target authorization, invariants, and lifecycle gates.
+
+## Starting another room at contract v1
+
+There are two different operations that should not be conflated:
+
+1. Install the exact v1 validator so future revisions must satisfy the document contract.
+2. Rewrite current legacy documents with taxonomy identity and writer metadata.
+
+The read-only validator inspector and v1 planner can assess another explicitly named room today.
+The `dat-411` operation cannot write to it and must not be generalized by changing its source
+constant.
+
+A future fence-only room operation needs:
+
+- A fresh private inventory and explicit room approval.
+- Exact database identity, partitioning, leaf-state fingerprint, `_security` hash, and timer state.
+- Its own native quarantine and verified capture receipt.
+- Installation of the exact v1 validator.
+- Proof that only the validator design document changed and `_security` did not.
+- A retained quarantine/closure decision and known-client exercise.
+
+It must not apply the `dat-411` taxonomy transformation. A full v1 backfill in another room would be
+a separate migration-family operation requiring review of that room's taxonomy, winner/conflict
+state, and invariants.
+
+## Starting a later contract version
+
+A policy-only validator change can usually reuse the Cloudant state, quarantine, CAS, verification,
+and browser recovery foundations. It still needs:
+
+- An immutable validator artifact and checksum for the new remote contract.
+- A browser release that recognizes the exact old and new remote contracts during rollout.
+- A compare-and-set design-document successor rather than a first-install fence.
+- A version-specific golden corpus and disposable real-Cloudant proof.
+- Independent room-by-room installation and verification.
+
+The possible policy change that would prohibit deleting persisted taxonomy identities is recorded
+in [Taxonomy Manager UX Point of View](TAXONOMY-MANAGER-UX-POV.md). That note is product context,
+not migration authorization.
+
+If the persisted writer envelope changes, the operation also needs version-aware encoding, local
+validation, divergence classification, offline behavior, and an explicit expand/contract or strict
+cutover decision. Existing remote leaves may remain grandfathered unless the new guarantee requires
+a backfill. A backfill reuses revision and verification mechanics, not the v1 transformation.
+
+The follow-up browser organization is specified in
+[Phase 2: document-contract version boundaries](plans/implementation/2026-07-23-document-contract-version-boundaries.md).
+
+## Adapter checklist for a future operation
+
+Before adding a new mutating entry point, write down:
+
+- Exact authorized database-name policy.
+- Contract version before and after the operation.
+- Expected account checksum and database identity.
+- Read-only preconditions and source-state lock.
+- Whether a native quarantine is proportionate and how it is retained.
+- Exact intended leaf transitions.
+- Application invariants and cross-document assumptions.
+- Treatment of conflicts, tombstones, attachments, and concurrent writes.
+- Interruption and partial-result classification.
+- Whether completion needs a marker and what verified state it commits to.
+- Sanitized operator output.
+- Disposable Cloudant proof matrix.
+- Production approval and cleanup boundary.
+
+If any of those are unknown, keep the tooling read-only.
+
+## Proof and change policy
+
+Tests and prior Cloudant proofs remain evidence only for unchanged code and unchanged semantics.
+Moving a primitive without changing behavior can retain its characterization tests. Parameterizing a
+target, changing a validator, changing an envelope, or altering a transition invalidates the
+relevant proof and requires a new disposable real-Cloudant gate.
+
+Do not add:
+
+- A configuration-driven production mutation engine.
+- Browser-side database provisioning.
+- A local revision-graph backup or reverse-restore format.
+- Automatic conflict merging or rollback.
+- Credentialed scheduled automation.
+
+Those are outside the minimal migration architecture.

--- a/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
+++ b/docs/DOCUMENT-CONTRACT-MIGRATION-RUNBOOK.md
@@ -2,12 +2,15 @@
 
 ## Current status
 
-The production entity and taxonomy migration is paused until the guarded quarantine implementation
-has passed its disposable Cloudant proof, merged, and received a fresh production approval. The
-browser compatibility release must be deployed and verified separately; operational-only changes
-under `scripts/` and `docs/` do not require or trigger a Firebase deployment. This repository now
-contains a narrowly scoped write-capable command for that later operation. Its presence is not
-authorization to run it against production.
+The guarded `fortudo-dat-411` entity and taxonomy migration completed on 2026-07-23 after the
+compatible browser release, disposable Cloudant proof, native quarantine capture, validator
+installation, revision-bound migration, and post-migration invariant checks passed. The quarantine
+is being retained while the known-device exercise remains open. Retention is a recovery option, not
+authorization for an automated reverse restore.
+
+The production command remains available for read-only verification and eventual deletion of the
+exact retained quarantine. It is a completed, one-off operation, not a general room migration tool.
+No further production mutation is authorized by the command or this runbook.
 
 This is deliberate. The retired tooling attempted to implement a complete revision-graph snapshot
 and restore format locally and treated Cloudant's opaque `update_seq` as a stable content lock.
@@ -19,6 +22,9 @@ The replacement design is [Cloudant Quarantine Migration Design](plans/design/20
 It uses Cloudant-native quarantine replication without a local backup format, reverse restore,
 durable `_replicator` document, or `update_seq` lock.
 
+Reusable primitives, versioned operation boundaries, and future migration requirements are
+documented in [Cloudant migration toolkit boundaries](CLOUDANT-MIGRATION-TOOLKIT.md).
+
 Never paste the Cloudant credential URL, document bodies, descriptions, or private database
 metadata into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only
 in the local process environment.
@@ -28,7 +34,7 @@ in the local process environment.
 Run the production operational preflight:
 
 ```powershell
-python scripts/cloudant_quarantine_migration.py preflight
+python scripts/migrations/taxonomy_identity_v1/dat_411_operation.py preflight
 ```
 
 It verifies winning bodies, conflict arrays, locked labels, and timer state against one
@@ -44,7 +50,7 @@ python scripts/document_contract_ops.py verify --database fortudo-dat-411
 Generate aggregate dry-run counts—for example, for the currently authorized target:
 
 ```powershell
-python scripts/migrate_taxonomy_identity.py --database fortudo-dat-411
+python scripts/migrations/taxonomy_identity_v1/planner.py --database fortudo-dat-411
 ```
 
 The read-only planner accepts any explicit, valid `fortudo-*` database name and has no apply mode.
@@ -58,18 +64,18 @@ credentials, document bodies, descriptions, revision identifiers, or opaque data
 
 ## Guarded migration commands
 
-`scripts/cloudant_quarantine_migration.py` provides `preflight`, `capture`, `fence`, `migrate`, and
-`delete-quarantine`. Production mutations are hard-locked to `fortudo-dat-411`; every mutating mode
-requires the expected account checksum, an exact source confirmation where applicable, and
-`--approve-remote-writes`. Capture additionally requires the exact source fingerprint and
-`_security` hash emitted by the approved preflight, and rejects either mismatch before database
-creation. It creates one exact quarantine database and uses transient `POST /_replicate`; it never
-writes a durable replication document.
+`scripts/migrations/taxonomy_identity_v1/dat_411_operation.py` provides `preflight`, `capture`,
+`fence`, `migrate`, and `delete-quarantine`. Production mutations are hard-locked to
+`fortudo-dat-411`; every mutating mode requires the expected account checksum, an exact source
+confirmation where applicable, and `--approve-remote-writes`. Capture additionally requires the
+exact source fingerprint and `_security` hash emitted by the approved preflight, and rejects either
+mismatch before database creation. It creates one exact quarantine database and uses transient
+`POST /_replicate`; it never writes a durable replication document.
 
 Before this command may be used on production, run the exact disposable proof:
 
 ```powershell
-python scripts/cloudant-quarantine-gate.py
+python scripts/migrations/taxonomy_identity_v1/disposable_gate.py
 ```
 
 The proof creates two random preview databases, exercises capture, retry, fencing, interruption,
@@ -93,9 +99,11 @@ An isolated Firebase preview and `node scripts/cloudant-contract-gate.mjs` verif
 contract behavior. The separate real-Cloudant quarantine gate proves the operational migration
 machinery.
 
-## Gates before production work can resume
+## Gates for any replay or repair
 
-Production writes remain blocked until all of the following are true:
+The completed migration must not be replayed or adapted to another room. If an independently
+reviewed repair ever requires these mutation paths, production writes remain blocked until all of
+the following are true again:
 
 1. The minimal quarantine design is implemented without reintroducing a local snapshot transport,
    custom restore engine, portable dump, or `update_seq` equality gate.

--- a/docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md
+++ b/docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md
@@ -216,7 +216,8 @@ A privacy-conscious client-capability record could report a random device instal
 - `public/js/sync-manager.js`: push-before-pull replication order.
 - `public/js/sw-register.js`: per-browser service-worker activation.
 - `public/js/taxonomy/taxonomy-store.js`: taxonomy normalization and singleton persistence.
-- `scripts/migrate_taxonomy_identity.py`: namespace-scoped, read-only transformation planner.
+- `scripts/migrations/taxonomy_identity_v1/planner.py`: namespace-scoped, read-only
+  transformation planner.
 - `docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md`: proposed minimal
   production recovery and migration gates.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,84 @@
+# Documentation map
+
+Fortudo documentation is organized by purpose rather than by whether the described work is current,
+future, or complete. Status changes over time; the role of a document is the more stable boundary.
+
+The `docs/` root contains this index only.
+
+## Directory map
+
+| Directory                                        | Purpose                                                                |
+| ------------------------------------------------ | ---------------------------------------------------------------------- |
+| [`reference/`](reference/)                       | Durable product conventions and setup references                       |
+| [`architecture/`](architecture/)                 | Assessments, diagnoses, risks, and architectural case studies          |
+| [`operations/`](operations/)                     | Reusable engineering procedures, invariants, and safety boundaries     |
+| [`product/`](product/)                           | Product principles, UX explorations, and unresolved product questions  |
+| [`migrations/`](migrations/)                     | Exact, versioned migration runbooks and completed operation records    |
+| [`plans/design/`](plans/design/)                 | Scoped design decisions and specifications accepted for implementation |
+| [`plans/implementation/`](plans/implementation/) | Executable task, migration, and verification plans                     |
+
+## Current documents
+
+### Reference
+
+- [Fortudo brand reference](reference/BRAND.md)
+- [CouchDB Sync Setup](reference/COUCHDB-SETUP.md)
+
+### Architecture
+
+- [Architecture Assessment](architecture/ARCHITECTURE-ASSESSMENT.md)
+- [Offline Client Migration Safety](architecture/OFFLINE-CLIENT-MIGRATION-SAFETY.md)
+- [Room Identity and Access Risk](architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md)
+
+### Operations
+
+- [Cloudant migration toolkit boundaries](operations/CLOUDANT-MIGRATION-TOOLKIT.md)
+
+### Product
+
+- [Taxonomy Manager UX Point of View](product/TAXONOMY-MANAGER-UX-POV.md)
+
+### Migrations
+
+- [Taxonomy identity v1: dat-411 operation runbook](migrations/taxonomy_identity_v1/dat-411-operation-runbook.md)
+
+The dated design and implementation plan catalogs are described in [Plans](plans/README.md).
+
+## Document lifecycle
+
+```text
+product exploration or architectural diagnosis
+    -> accepted design specification
+    -> implementation plan
+    -> current reference, operational guidance, or completed migration record
+```
+
+Do not rewrite an exploratory or diagnostic document into an implementation plan. Create a dated
+plan that links back to the source reasoning so its evidence, open questions, and historical context
+remain intact.
+
+Future-facing content does not automatically belong under `plans/`:
+
+- An unaccepted UX direction remains a product note.
+- A risk analysis or target architecture remains an architectural diagnosis.
+- A reusable safety contract remains operational guidance.
+- Work moves into `plans/design/` when its scope and decisions are accepted for implementation.
+- A concrete execution sequence belongs in `plans/implementation/`.
+
+Each exploratory, diagnostic, or operational document should state its status and whether it grants
+implementation or production authorization. A passing test, dry run, or historical operation
+record is never authorization for a new production mutation.
+
+## Adding documentation
+
+Before adding a file, identify its intended reader and durable role:
+
+- Place current setup facts and conventions in `reference/`.
+- Place evidence-backed assessments and architectural reasoning in `architecture/`.
+- Place reusable operator and engineering procedures in `operations/`.
+- Place product principles and open UX questions in `product/`.
+- Place exact migration-specific commands and closure records in a versioned `migrations/`
+  subdirectory.
+- Place accepted specifications and executable plans in their existing `plans/` subdirectories.
+
+Update this index when adding or moving a durable document.

--- a/docs/TAXONOMY-MANAGER-UX-POV.md
+++ b/docs/TAXONOMY-MANAGER-UX-POV.md
@@ -1,0 +1,221 @@
+# Taxonomy Manager UX Point of View
+
+- **Status:** Deferred product-design note
+- **Last reviewed:** 2026-07-23
+- **Implementation authorization:** None
+
+## Purpose
+
+Fortudo's taxonomy identity hardening made groups and categories durable identity records rather
+than labels whose meaning is inferred from key text. The current manager exposes the operations
+needed to work with those records, but it also exposes implementation concepts that may not match
+how a person thinks about organizing work.
+
+This note records:
+
+- how the taxonomy manager works today;
+- the product point of view that emerged while exercising it;
+- architectural constraints a future UX must respect; and
+- questions to answer before redesigning the experience.
+
+It is not an implementation plan or a decision to redesign the taxonomy data model.
+
+## Point of view
+
+The taxonomy manager should be organized around user intentions, not identity-management
+mechanics.
+
+A person generally wants to:
+
+- correct a name or presentation;
+- organize something differently;
+- stop using something;
+- resume using something; or
+- declare that something now means a genuinely different thing.
+
+Immutable IDs, legacy keys, reference witnesses, and replacement identities are necessary
+implementation details. The interface should apply their safety properties without requiring the
+person to reason in those terms during ordinary use.
+
+Historical meaning must never change accidentally. When an action does affect how historical
+records are displayed, the interface should say so in language tied to the person's intent.
+
+## Current implementation
+
+### Persistence and identity
+
+- The complete taxonomy is persisted as the singleton `config-categories` document.
+- The document currently uses schema version `3.5` and taxonomy identity version `1`.
+- Groups and categories have immutable UUID identities.
+- Newly created records receive opaque keys derived from their identities rather than their
+  labels.
+- Categories link to their parent through both `groupId` and `groupKey`; the immutable `groupId` is
+  the authoritative identity relationship.
+- Tasks and activities carry the selected category's key, immutable ID, identity version, and
+  writer-contract witness.
+- A label rename does not change a group or category ID, key, or historical assignment. Historical
+  records resolve through the retained identity and display the current label.
+- Unknown JSON extensions are preserved across supported edits.
+
+### Where the manager lives
+
+The manager appears in Settings under Organization and presents separate Groups and Categories
+sections. Both active and archived records remain visible in the manager. Archived records receive
+an `Archived` badge.
+
+The task/category selectors normally omit archived records. A currently selected archived record
+may remain visible so an existing assignment can still be represented.
+
+### Available operations
+
+| Operation                      | Current behavior                                                                   | Historical effect                                             |
+| ------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Add group                      | Creates a new active group with a new opaque identity                              | None                                                          |
+| Add category                   | Creates a new active category under an active group with a new opaque identity     | None                                                          |
+| Rename group                   | Changes its label without changing identity                                        | Historical records display the new label                      |
+| Rename category                | Changes its label without changing identity                                        | Historical records display the new label                      |
+| Change group color family      | Updates the group and recolors child categories that follow the family             | Presentation only                                             |
+| Change category color          | Follows the group family or uses a custom color                                    | Presentation only                                             |
+| Archive                        | Retains identity and records an archive timestamp                                  | Existing history still resolves; new selection is hidden      |
+| Restore                        | Reactivates the same identity if its label is available                            | Existing history and future use share the identity            |
+| Archive and create replacement | Archives the edited record and creates a new active identity                       | Old history remains attached to the archived identity         |
+| Delete category                | Removes the row if this client finds no task, activity, or running-timer reference | No normal restore path; a missed reference becomes unresolved |
+| Delete group                   | Removes the row if it has no child categories and this client finds no references  | No normal restore path; a missed reference becomes unresolved |
+
+The edit forms explain that renaming changes the label shown on historical records. The
+implementation-shaped action **Archive and create replacement** appears inside the edit form when
+the person may only have intended to change a name or color.
+
+There is currently no category-reparenting control in the edit form. A category is assigned to a
+group when created. A category replacement is created in the same group, while a group replacement
+does not automatically transfer child categories.
+
+### Current safeguards and limitations
+
+- Active labels must be unique among groups, and among sibling categories within a group.
+- Archived labels are locked until the record is restored.
+- A category cannot be restored until its parent group is active.
+- Deletion checks this replica's synchronized tasks, activities, and running timer.
+- Group deletion also requires every child category to be removed first.
+- Cloudant validates taxonomy structure, stable identities for retained records, and coherent
+  entity witnesses.
+- Cloudant cannot query other documents from `validate_doc_update`, so it cannot prove that a
+  taxonomy identity is globally unreferenced.
+- An offline replica may contain a reference that the deleting client cannot observe.
+- The current document contract permits an existing taxonomy row to be removed. Removing only the
+  UI affordance would therefore reduce accidental use but would not establish a cross-client
+  invariant.
+
+## Intent-first semantic model
+
+| User intention                         | Identity-safe interpretation                                                                    |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Correct a typo or improve a label      | Rename the existing identity                                                                    |
+| Change color or visual treatment       | Edit presentation on the existing identity                                                      |
+| Move an item                           | Preserve identity while changing organization, if the product decides this is semantically safe |
+| Stop using an item                     | Archive the existing identity                                                                   |
+| Resume using an item                   | Restore the archived identity                                                                   |
+| Change what an item means              | Archive the old identity and create a new one                                                   |
+| Undo an item that has never been saved | Cancel the draft before persistence                                                             |
+| Permanently erase a persisted identity | Probably unsupported in normal product UX                                                       |
+
+This model should guide future interaction design. It does not prescribe the final labels, screens,
+or navigation.
+
+## Current UX tensions
+
+1. **Implementation language is prominent.** "Archive and create replacement" is accurate but asks
+   the person to understand identity mechanics before acting.
+2. **Rename and meaning change share one editor.** The common action and the exceptional semantic
+   fork compete for attention.
+3. **Delete looks simpler than it is.** A trash icon suggests ordinary row removal even though an
+   offline replica prevents the client from proving global non-use.
+4. **Archive is safer but less obviously primary.** It is the appropriate lifecycle action for
+   real categories, yet the interface does not explain why it differs from delete.
+5. **Historical impact is described, not demonstrated.** The copy warns that renaming changes
+   historical labels, but the workflow does not help the person distinguish "same meaning, better
+   name" from "new meaning."
+6. **Archived records remain mixed into management lists.** This preserves access but may become
+   noisy as the taxonomy grows.
+7. **Hierarchy changes are not represented as a user intention.** Creation establishes parentage,
+   but subsequent reorganization has no dedicated flow.
+
+## Working recommendations
+
+These are hypotheses for a future design review, not accepted implementation decisions.
+
+### Prefer lifecycle over deletion
+
+Once a taxonomy identity has been persisted, normal UX should probably offer archive and restore
+instead of permanent deletion. Cancelling an unsaved draft remains ordinary and safe.
+
+If permanent taxonomy deletion is removed as a true invariant, removing buttons is insufficient.
+A compatible client release would need to precede a new document-contract version that rejects the
+removal of existing group or category IDs. That would be a small compatibility rollout, not a
+validator hot-patch.
+
+### Translate identity operations into intent
+
+The interface could ask whether the person is:
+
+- correcting the same category; or
+- creating a different category for future records.
+
+The system can then apply rename or archive-and-replace semantics without making "replacement
+identity" the primary call to action.
+
+### Use progressive disclosure
+
+Common presentation edits should remain direct. Historical and identity consequences should
+appear when an action can change meaning, not as equal-weight controls beside every ordinary edit.
+
+### Give archived records a deliberate home
+
+Archived items should remain discoverable and restorable without dominating the active-management
+view. A separate archived section, filter, or review flow may better express their lifecycle.
+
+## Open questions
+
+- What terminology best distinguishes "same thing, better name" from "different thing going
+  forward"?
+- Should replacement be a guided flow, and what preview of historical versus future behavior
+  should it show?
+- Should taxonomy deletion disappear completely after first persistence?
+- If deletion remains, can it be restricted to an unsynced local draft rather than a persisted
+  identity?
+- Should moving a category between groups preserve identity, create a replacement, or depend on
+  the stated intent?
+- What happens to child categories when a group is archived, restored, or replaced?
+- How should archived items be searched, filtered, and restored?
+- Should the manager show reference counts or examples before lifecycle changes?
+- How should conflicts or offline uncertainty be explained without exposing distributed-systems
+  terminology?
+- Which operations need undo, confirmation, or a recoverable grace period?
+
+## Success criteria for a future redesign
+
+- A person can perform common edits without learning Fortudo's identity model.
+- The difference between correcting a label and changing meaning is clear before saving.
+- Historical records never silently change meaning.
+- Stopping and resuming future use is reversible and easy to understand.
+- Destructive actions do not rely on one replica having globally complete knowledge.
+- Archived records remain resolvable and manageable without cluttering ordinary selection.
+- The same behavior is safe across offline clients, retries, and delayed synchronization.
+- The Cloudant contract enforces every lifecycle invariant that cannot safely depend on client UX
+  alone.
+
+## Scope boundaries
+
+The future review may reconsider taxonomy-management interaction and lifecycle rules. It should not
+implicitly redesign room identity, Cloudant credentials, room authorization, task/activity
+identity, or the taxonomy data model without an explicit architecture decision.
+
+## Current implementation references
+
+- `public/js/settings/taxonomy-settings.js`
+- `public/js/taxonomy/taxonomy-mutations.js`
+- `public/js/taxonomy/taxonomy-store.js`
+- `public/js/taxonomy/taxonomy-identity.js`
+- `public/js/taxonomy/taxonomy-selectors.js`
+- `public/js/document-contract.js`
+- `docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md`

--- a/docs/architecture/ARCHITECTURE-ASSESSMENT.md
+++ b/docs/architecture/ARCHITECTURE-ASSESSMENT.md
@@ -1,5 +1,7 @@
 # Architecture Assessment
 
+**Document type:** Point-in-time architecture assessment
+
 ## Strengths
 
 **Clear domain split** - The current structure is materially better than the earlier single-file shape. Task state lives in `tasks/manager.js`, scheduling logic lives in `reschedule-engine.js`, render concerns live in `dom-renderer.js` plus the task renderers, and boot wiring lives in `app.js`.

--- a/docs/architecture/OFFLINE-CLIENT-MIGRATION-SAFETY.md
+++ b/docs/architecture/OFFLINE-CLIENT-MIGRATION-SAFETY.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-This document records an architectural diagnosis discovered during the entity and taxonomy identity hardening rollout. It is not an authorization to broaden the current production migration or to redesign room identity.
+This document is an architectural diagnosis and case study discovered during the entity and
+taxonomy identity hardening rollout. It is not an authorization to broaden the current production
+migration or to redesign room identity.
 
 ## Executive summary
 

--- a/docs/architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md
+++ b/docs/architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md
@@ -92,35 +92,40 @@ The practical security boundary is therefore the shared Cloudant credential, not
 
 `docs/reference/COUCHDB-SETUP.md` explicitly documents two deployment options:
 
-- **Option A:** embed administrator service credentials for zero-setup room creation;
-- **Option B:** pre-create databases and use database-scoped API keys.
+- **Option A:** manually provision databases and embed one Manager-equivalent service credential
+  that every browser and room shares;
+- **Option B:** manually provision databases and grant one browser credential access to a fixed
+  database or set of databases.
 
 The document recommends Option A as a pragmatic choice for personal or household use and acknowledges that anyone who loads the application can extract the credentials and potentially read, modify, or delete Cloudant data.
 
 That is a real accepted-risk decision. The technical blast radius remains high, but it should not be described as a newly discovered or unaccepted production defect while the documented threat model still applies.
 
-### Assumptions behind the acceptance
+### Current acceptance and corrected boundaries
 
-The recorded decision relies on these assumptions:
+The recorded decision now relies on these explicit assumptions:
 
-- the site URL is not broadly shared;
-- only trusted household members load the application;
-- task data is considered non-sensitive;
-- compromise of remote sync is tolerable because local PouchDB copies exist;
-- room-code obscurity adds a meaningful barrier.
+- Only trusted household members are expected to load the application.
+- The application URL is not intentionally advertised, while URL secrecy is not treated as
+  authentication.
+- The operator accepts that Option A exposes account-wide Cloudant capability to those browsers.
+- The deployment is personal, while task and activity descriptions may still contain private
+  information.
+- The operator accepts the current lack of per-room credentials, invitations, and revocation.
+- The decision must be revisited if users cross trust boundaries, the data becomes more sensitive,
+  the room count grows, or remote loss becomes unacceptable.
 
-### Limitations in the recorded rationale
+The acceptance does **not** rely on any of these as security or recovery guarantees:
 
-Some of those assumptions need correction or explicit reaffirmation:
+- Room-code obscurity: the deployed credential can enumerate databases.
+- A static site URL or CORS allowlist: neither constrains a credential after a browser receives it.
+- Local PouchDB as a backup: remote deletion tombstones and bad revisions can replicate into
+  connected local databases. A disconnected copy may aid manual recovery but is not a backup
+  guarantee.
 
-- A static site URL is not an authentication boundary.
-- Database enumeration by the deployed credential defeats room-code obscurity for a technically capable user.
-- Users may put private information in task or activity descriptions even if the product is intended for low-sensitivity data.
-- Local PouchDB does not categorically prevent data loss. Remote deletion tombstones and malicious revisions can replicate into connected local databases.
-- Offline clients that do not reconnect may retain recoverable copies, but that is not a backup guarantee.
-- The decision did not explicitly evaluate generator collisions, room renaming, per-room blast radius, invitations, or revocation.
-
-The accepted risk should therefore be treated as conditional and periodically reviewed, not as evidence that the architecture has no security debt.
+Generator collisions, room renaming, per-room blast radius, invitations, and revocation remain
+unresolved architectural concerns. The accepted risk is conditional and periodically reviewed, not
+evidence that the architecture has no security debt.
 
 ## Threat and failure scenarios
 
@@ -225,8 +230,8 @@ The following changes are insufficient on their own:
 ## Recommended follow-up
 
 1. Reaffirm or revise the accepted personal/household threat model and assign an owner and review trigger to the decision.
-2. Correct `docs/reference/COUCHDB-SETUP.md` so room-code obscurity and local-copy recovery are not
-   described as stronger guarantees than they provide.
+2. Keep `docs/reference/COUCHDB-SETUP.md` aligned with this diagnosis: room codes, CORS, static URL
+   secrecy, and local replicas must not be described as authentication or backup guarantees.
 3. Classify the non-preview Cloudant databases before designing a room migration scope.
 4. Write a dedicated room identity and authorization design covering backend trust, database ACLs, invitations, revocation, and offline migration.
 5. Prefer an incremental transition from account-wide credentials to room-scoped capabilities before changing database identities.

--- a/docs/architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md
+++ b/docs/architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-This document records an architectural and security diagnosis of Fortudo's room model as observed on 2026-07-21. It does not authorize a room migration, Cloudant permission change, credential rotation, or production write.
+This document records an architectural and security diagnosis of Fortudo's room model as observed
+on 2026-07-21. It does not authorize a room migration, Cloudant permission change, credential
+rotation, or production write.
 
 The repository already accepts browser-visible Cloudant administrator credentials for personal and household use. This diagnosis preserves that historical decision while separating it from additional room-identity risks that were not fully analyzed when the decision was recorded.
 
@@ -19,7 +21,8 @@ The room code is not a true authentication secret. The deployed static applicati
 
 This creates two related but distinct risks:
 
-1. **Accepted credential exposure:** `docs/COUCHDB-SETUP.md` explicitly accepts administrator credentials in the browser for a personal or household threat model.
+1. **Accepted credential exposure:** `docs/reference/COUCHDB-SETUP.md` explicitly accepts
+   administrator credentials in the browser for a personal or household threat model.
 2. **Unresolved room coupling:** display name, immutable database identity, sharing, and access control are not separate concepts. This prevents safe renaming, collision avoidance, scoped authorization, invitation revocation, and independent credential rotation.
 
 Increasing room-code entropy alone would address guessing and accidental collision, but it would not fix account-wide credential exposure or provide room-level authorization.
@@ -87,7 +90,7 @@ The practical security boundary is therefore the shared Cloudant credential, not
 
 ## Existing accepted-risk decision
 
-`docs/COUCHDB-SETUP.md` explicitly documents two deployment options:
+`docs/reference/COUCHDB-SETUP.md` explicitly documents two deployment options:
 
 - **Option A:** embed administrator service credentials for zero-setup room creation;
 - **Option B:** pre-create databases and use database-scoped API keys.
@@ -156,7 +159,8 @@ There is no invitation object or member-specific credential to revoke. Changing 
 Risk severity and risk disposition are different:
 
 - **Inherent blast radius:** high to critical because the deployed credential can affect confidentiality, integrity, and availability across the account.
-- **Current disposition:** accepted for the personal or household threat model documented in `COUCHDB-SETUP.md`.
+- **Current disposition:** accepted for the personal or household threat model documented in
+  `docs/reference/COUCHDB-SETUP.md`.
 - **Residual uncertainty:** the repository does not prove that the threat-model assumptions remain true or that every non-preview database belongs to one trusted household.
 - **Incident status:** no evidence of unauthorized access was established by this diagnosis. Confirming or excluding past access would require a separate audit-log investigation.
 
@@ -221,7 +225,8 @@ The following changes are insufficient on their own:
 ## Recommended follow-up
 
 1. Reaffirm or revise the accepted personal/household threat model and assign an owner and review trigger to the decision.
-2. Correct `COUCHDB-SETUP.md` so room-code obscurity and local-copy recovery are not described as stronger guarantees than they provide.
+2. Correct `docs/reference/COUCHDB-SETUP.md` so room-code obscurity and local-copy recovery are not
+   described as stronger guarantees than they provide.
 3. Classify the non-preview Cloudant databases before designing a room migration scope.
 4. Write a dedicated room identity and authorization design covering backend trust, database ACLs, invitations, revocation, and offline migration.
 5. Prefer an incremental transition from account-wide credentials to room-scoped capabilities before changing database identities.
@@ -230,7 +235,8 @@ The following changes are insufficient on their own:
 
 ## Evidence map
 
-- `docs/COUCHDB-SETUP.md`: accepted credential-exposure decision and security assumptions.
+- `docs/reference/COUCHDB-SETUP.md`: accepted credential-exposure decision and security
+  assumptions.
 - `public/js/room-manager.js`: generated namespace and local saved-room state.
 - `public/js/room-renderer.js`: unrestricted room-code entry flow.
 - `public/js/storage.js`: local database naming.

--- a/docs/migrations/taxonomy_identity_v1/dat-411-operation-runbook.md
+++ b/docs/migrations/taxonomy_identity_v1/dat-411-operation-runbook.md
@@ -1,4 +1,4 @@
-# Document-contract migration runbook
+# Taxonomy identity v1: dat-411 operation runbook
 
 ## Current status
 
@@ -18,12 +18,14 @@ Production observation showed that `update_seq` can change while the application
 so it is not a valid equality gate for this deployment. Maintaining a second replication and restore
 implementation in Python was also unnecessary when Cloudant already implements CouchDB replication.
 
-The replacement design is [Cloudant Quarantine Migration Design](plans/design/2026-07-22-cloudant-quarantine-migration-design.md).
+The replacement design is
+[Cloudant Quarantine Migration Design](../../plans/design/2026-07-22-cloudant-quarantine-migration-design.md).
 It uses Cloudant-native quarantine replication without a local backup format, reverse restore,
 durable `_replicator` document, or `update_seq` lock.
 
 Reusable primitives, versioned operation boundaries, and future migration requirements are
-documented in [Cloudant migration toolkit boundaries](CLOUDANT-MIGRATION-TOOLKIT.md).
+documented in
+[Cloudant migration toolkit boundaries](../../CLOUDANT-MIGRATION-TOOLKIT.md).
 
 Never paste the Cloudant credential URL, document bodies, descriptions, or private database
 metadata into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only

--- a/docs/migrations/taxonomy_identity_v1/dat-411-operation-runbook.md
+++ b/docs/migrations/taxonomy_identity_v1/dat-411-operation-runbook.md
@@ -25,7 +25,7 @@ durable `_replicator` document, or `update_seq` lock.
 
 Reusable primitives, versioned operation boundaries, and future migration requirements are
 documented in
-[Cloudant migration toolkit boundaries](../../CLOUDANT-MIGRATION-TOOLKIT.md).
+[Cloudant migration toolkit boundaries](../../operations/CLOUDANT-MIGRATION-TOOLKIT.md).
 
 Never paste the Cloudant credential URL, document bodies, descriptions, or private database
 metadata into a terminal transcript, issue, pull request, or chat. Set `FORTUDO_CLOUDANT_URL` only

--- a/docs/operations/CLOUDANT-MIGRATION-TOOLKIT.md
+++ b/docs/operations/CLOUDANT-MIGRATION-TOOLKIT.md
@@ -12,9 +12,9 @@ operation, and which code belongs only to the completed `fortudo-dat-411` taxono
 migration.
 
 The exact completed operation remains documented in
-[Taxonomy identity v1: dat-411 operation runbook](migrations/taxonomy_identity_v1/dat-411-operation-runbook.md).
+[Taxonomy identity v1: dat-411 operation runbook](../migrations/taxonomy_identity_v1/dat-411-operation-runbook.md).
 Architectural motivation and the offline-replica case study remain in
-[Offline-client migration safety](OFFLINE-CLIENT-MIGRATION-SAFETY.md).
+[Offline-client migration safety](../architecture/OFFLINE-CLIENT-MIGRATION-SAFETY.md).
 
 ## Ownership map
 
@@ -102,8 +102,8 @@ and browser recovery foundations. It still needs:
 - Independent room-by-room installation and verification.
 
 The possible policy change that would prohibit deleting persisted taxonomy identities is recorded
-in [Taxonomy Manager UX Point of View](TAXONOMY-MANAGER-UX-POV.md). That note is product context,
-not migration authorization.
+in [Taxonomy Manager UX Point of View](../product/TAXONOMY-MANAGER-UX-POV.md). That note is product
+context, not migration authorization.
 
 If the persisted writer envelope changes, the operation also needs version-aware encoding, local
 validation, divergence classification, offline behavior, and an explicit expand/contract or strict
@@ -111,7 +111,7 @@ cutover decision. Existing remote leaves may remain grandfathered unless the new
 a backfill. A backfill reuses revision and verification mechanics, not the v1 transformation.
 
 The follow-up browser organization is specified in
-[Phase 2: document-contract version boundaries](plans/implementation/2026-07-23-document-contract-version-boundaries.md).
+[Phase 2: document-contract version boundaries](../plans/implementation/2026-07-23-document-contract-version-boundaries.md).
 
 ## Adapter checklist for a future operation
 

--- a/docs/plans/design/2026-07-15-violet-rebrand.md
+++ b/docs/plans/design/2026-07-15-violet-rebrand.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-15
 Repo: `~/code/fortudo` (deployed at https://fortudo.web.app/)
-Companion doc: `docs/BRAND.md` (durable brand reference — tokens, naming rules, mark provenance)
+Companion doc: `docs/reference/BRAND.md` (durable brand reference — tokens, naming rules, mark provenance)
 
 **Claude sessions:**
 
@@ -22,7 +22,11 @@ Companion doc: `docs/BRAND.md` (durable brand reference — tokens, naming rules
 
 ## Context
 
-The app's brand was the 💪🏾 emoji (screenshotted into PNGs by `scripts/generate_icons.py`) plus an amber "Fortu-do" wordmark and teal accents. The rebrand replaces this with an owned mark — a flexed-arm silhouette (MDI `arm-flex`, Apache 2.0) with a checkmark knocked out of the bicep — and a violet-on-slate color system. Design rationale and all decisions are in `fortudo-BRAND.md`; this doc is the execution plan.
+The app's brand was the 💪🏾 emoji (screenshotted into PNGs by `scripts/generate_icons.py`) plus an
+amber "Fortu-do" wordmark and teal accents. The rebrand replaces this with an owned mark—a
+flexed-arm silhouette (MDI `arm-flex`, Apache 2.0) with a checkmark knocked out of the bicep—and a
+violet-on-slate color system. Design rationale and all decisions are in
+`docs/reference/BRAND.md`; this doc is the execution plan.
 
 ## Repo state — read first
 
@@ -39,7 +43,7 @@ Production assets are placed at their final paths on the rebrand branch; confirm
 | `public/icons/mark.svg`                                                                      | Transparent mark for the in-app header lockup                                         |
 | `public/icons/icon.svg`                                                                      | Canonical vector source for the icon set                                              |
 | `public/og-image.png`                                                                        | 1200×630 social preview card                                                          |
-| `docs/BRAND.md`                                                                              | Durable brand reference                                                               |
+| `docs/reference/BRAND.md`                                                                    | Durable brand reference                                                               |
 | `docs/plans/design/assets/2026-07-15-logo-concept.svg`                                       | Design artifact (hero, size ladder, lockups)                                          |
 
 If any are missing, stop and ask — do not regenerate assets.

--- a/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
+++ b/docs/plans/design/2026-07-22-cloudant-quarantine-migration-design.md
@@ -21,8 +21,8 @@ The request uses the existing accepted legacy credential as structured authentic
 TLS request body. This creates no new authority and no durable replication document. It is an
 explicitly approved exception to IBM's general preference for scoped replication credentials,
 proportionate to Fortudo's existing browser-visible Manager credential documented in
-[COUCHDB-SETUP.md](../../COUCHDB-SETUP.md) and
-[ROOM-IDENTITY-AND-ACCESS-RISK.md](../../ROOM-IDENTITY-AND-ACCESS-RISK.md). The request body,
+[COUCHDB-SETUP.md](../../reference/COUCHDB-SETUP.md) and
+[ROOM-IDENTITY-AND-ACCESS-RISK.md](../../architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md). The request body,
 credential, URLs, and response details must never be logged.
 
 Normal CouchDB replication transfers all current leaf revisions; `winning_revs_only` must not be

--- a/docs/plans/implementation/2026-03-17-fortudo-activities-cleanup-phase1-5.md
+++ b/docs/plans/implementation/2026-03-17-fortudo-activities-cleanup-phase1-5.md
@@ -42,7 +42,7 @@
 
 **Optional docs touched if behavior/naming changes**
 - `README.md`
-- `docs/ARCHITECTURE-ASSESSMENT.md`
+- `docs/architecture/ARCHITECTURE-ASSESSMENT.md`
 
 ---
 
@@ -438,7 +438,7 @@ git commit -m "refactor: resolve placeholder day-boundary behavior"
 
 **Files:**
 - Modify: `README.md`
-- Modify: `docs/ARCHITECTURE-ASSESSMENT.md` (if architecture language is now stale)
+- Modify: `docs/architecture/ARCHITECTURE-ASSESSMENT.md` (if architecture language is now stale)
 
 - [ ] **Step 1: Run full coverage suite**
 
@@ -473,7 +473,7 @@ Confirm README and any architecture notes describe:
 - [ ] **Step 5: Commit**
 
 ```bash
-git add README.md docs/ARCHITECTURE-ASSESSMENT.md
+git add README.md docs/architecture/ARCHITECTURE-ASSESSMENT.md
 git commit -m "docs: align cleanup architecture and verification guidance"
 ```
 

--- a/docs/plans/implementation/2026-03-17-fortudo-coordinator-phase1-7.md
+++ b/docs/plans/implementation/2026-03-17-fortudo-coordinator-phase1-7.md
@@ -35,7 +35,7 @@
 
 **Optional docs**
 - `docs/plans/design/2026-03-16-fortudo-activities-design.md`
-- `docs/ARCHITECTURE-ASSESSMENT.md`
+- `docs/architecture/ARCHITECTURE-ASSESSMENT.md`
 
 ---
 
@@ -295,7 +295,7 @@ git commit -m "test: lock in coordinator integration boundaries"
 
 **Files:**
 - Modify: `docs/plans/design/2026-03-16-fortudo-activities-design.md`
-- Optionally modify: `docs/ARCHITECTURE-ASSESSMENT.md`
+- Optionally modify: `docs/architecture/ARCHITECTURE-ASSESSMENT.md`
 - Optionally modify: `README.md`
 
 - [ ] **Step 1: Update the design doc to match the actual pre-Activities boundary**
@@ -307,7 +307,8 @@ In `docs/plans/design/2026-03-16-fortudo-activities-design.md`:
 
 - [ ] **Step 2: Update architecture notes only if they are stale**
 
-If `docs/ARCHITECTURE-ASSESSMENT.md` still implies scattered post-action logic in a way that is no longer accurate, tighten the wording. Do not rewrite the whole assessment.
+If `docs/architecture/ARCHITECTURE-ASSESSMENT.md` still implies scattered post-action logic in a
+way that is no longer accurate, tighten the wording. Do not rewrite the whole assessment.
 
 - [ ] **Step 3: Run doc formatting and repo checks**
 
@@ -320,7 +321,7 @@ Expected:
 - [ ] **Step 4: Commit**
 
 ```bash
-git add docs/plans/design/2026-03-16-fortudo-activities-design.md docs/ARCHITECTURE-ASSESSMENT.md README.md
+git add docs/plans/design/2026-03-16-fortudo-activities-design.md docs/architecture/ARCHITECTURE-ASSESSMENT.md README.md
 git commit -m "docs: align coordinator architecture guidance"
 ```
 

--- a/docs/plans/implementation/2026-07-23-document-contract-version-boundaries.md
+++ b/docs/plans/implementation/2026-07-23-document-contract-version-boundaries.md
@@ -1,0 +1,136 @@
+# Phase 2: document-contract version boundaries
+
+**Status:** Follow-up implementation plan; not started.
+
+## Objective
+
+Make the browser's existing v1 document contract an immutable, explicitly versioned artifact and
+separate the version numbers for remote policy, writer envelope, taxonomy identity, and data
+migration. Preserve current v1 behavior exactly.
+
+This phase prepares a clean extension point whether the next change is:
+
+- another room receiving the current v1 fence;
+- a policy-only remote contract v2; or
+- a v2 that changes the persisted writer envelope.
+
+It does not implement any of those operations.
+
+## Preconditions
+
+- The completed `fortudo-dat-411` migration remains healthy.
+- The retained-quarantine and known-device exercise has a documented closure decision.
+- Phase 1's toolkit boundaries and versioned Python operation layout are merged.
+- Any public-file change is treated as a compatibility-release change with a Firebase preview,
+  regenerated service-worker artifact, full verification, and deployment approval.
+
+## Locked behavior
+
+- The installed v1 Cloudant validator source and SHA-256 checksum remain byte-for-byte identical.
+- Current documents continue using writer envelope version 1.
+- Taxonomy identity remains version 1.
+- Remote contract inspection continues to accept only the exact installed v1 artifact.
+- Missing-validator compatibility behavior does not change.
+- Divergence audit, recovery, sync ordering, and user-visible update behavior do not change.
+- No production Cloudant data or design document is written.
+
+## Proposed browser layout
+
+```text
+public/js/contracts/
+  writer-v1.js
+  remote-contract-v1.js
+  registry.js
+
+public/js/document-contract.js
+  compatibility facade for current imports
+
+public/js/sync-contract.js
+  current single-version orchestration
+```
+
+`writer-v1.js` owns persistence-envelope encoding and structural validation for writer version 1.
+`remote-contract-v1.js` owns the immutable Cloudant validator, remote policy metadata, checksum, and
+accepted writer versions. `registry.js` initially exposes only v1; it must not implement speculative
+multi-version negotiation.
+
+Use distinct constants:
+
+```text
+REMOTE_DOCUMENT_CONTRACT_VERSION = 1
+WRITER_ENVELOPE_VERSION = 1
+TAXONOMY_IDENTITY_VERSION = 1
+TAXONOMY_MIGRATION_VERSION = 1
+```
+
+Equal numeric values do not make these interchangeable.
+
+## Machine-verifiable operational artifact
+
+Replace Python's prose-marker extraction from the mixed browser module with one authoritative,
+machine-verifiable path from `remote-contract-v1.js` to the exact Cloudant design document.
+
+Preferred shape:
+
+1. A small Node exporter imports the browser contract module.
+2. It emits the canonical design document without credentials or remote metadata.
+3. Python inspection and migration tooling consumes the emitted artifact.
+4. Tests compare the browser builder, emitted validator source, declared checksum, and Python view.
+
+Do not maintain a second handwritten validator or implement a JavaScript parser in Python.
+
+## Test-first implementation sequence
+
+1. Add characterization tests pinning the current v1 validator source, checksum, design metadata,
+   writer envelope, tombstones, and sanitized rejection codes.
+2. Add tests proving the four version concepts are distinct exports even though each equals `1`.
+3. Add versioned v1 modules and keep `document-contract.js` as a compatibility facade.
+4. Add the machine-verifiable design-document export and switch read-only Python inspection to it.
+5. Prove the golden conformance corpus still agrees between local and Cloudant validation.
+6. Prove startup inspection, divergence audit, recovery classification, and all persistence paths
+   have unchanged results.
+7. Regenerate the service-worker precache and run the complete repository suite.
+8. Deploy an isolated Firebase preview and run browser plus real-Cloudant v1 acceptance.
+9. Review live asset hashes before any production deployment.
+
+## Required verification
+
+Run:
+
+```text
+npm run build:sw-precache
+npm run check:pouchdb
+npm run check:fontawesome
+npm run check:css
+npm run verify
+```
+
+Also require:
+
+- Exact v1 validator checksum equality before and after the refactor.
+- Exact design-document semantic equality.
+- Deployed-preview acceptance.
+- The current real-Cloudant contract gate.
+- Green GitHub CI.
+- No production Cloudant write.
+
+## Explicit deferrals
+
+Do not add during phase 2:
+
+- Remote contract v2.
+- Writer envelope v2.
+- Dual-version room negotiation.
+- Offline envelope selection.
+- A transition or bridge validator.
+- A generic migration adapter class.
+- Another-room fencing.
+- Automatic provisioning, backfill, conflict resolution, or recovery import.
+
+Those behaviors require a concrete migration proposal and their own review.
+
+## Completion criteria
+
+Phase 2 is complete when v1 is represented as an immutable versioned artifact, each version axis is
+named independently, operational tooling consumes the same reviewed artifact without brittle source
+markers, and every current browser/Cloudant behavior remains proven unchanged.

--- a/docs/product/TAXONOMY-MANAGER-UX-POV.md
+++ b/docs/product/TAXONOMY-MANAGER-UX-POV.md
@@ -218,4 +218,4 @@ identity, or the taxonomy data model without an explicit architecture decision.
 - `public/js/taxonomy/taxonomy-identity.js`
 - `public/js/taxonomy/taxonomy-selectors.js`
 - `public/js/document-contract.js`
-- `docs/OFFLINE-CLIENT-MIGRATION-SAFETY.md`
+- `docs/architecture/OFFLINE-CLIENT-MIGRATION-SAFETY.md`

--- a/docs/reference/BRAND.md
+++ b/docs/reference/BRAND.md
@@ -1,5 +1,7 @@
 # Fortudo brand reference
 
+**Document type:** Durable product reference
+
 ## Name
 
 - **Prose / metadata:** `Fortudo` — capital F, no hyphen, no period. Used in `<title>`, manifest, alt text, running text.

--- a/docs/reference/COUCHDB-SETUP.md
+++ b/docs/reference/COUCHDB-SETUP.md
@@ -1,5 +1,7 @@
 # CouchDB Sync Setup (IBM Cloudant)
 
+**Document type:** Operational setup reference
+
 This guide walks through setting up IBM Cloudant (free tier) as the CouchDB sync relay for Fortudo.
 
 Cloudant is a managed CouchDB-compatible database from IBM. The Lite plan is permanently free (not a trial) with 1 GB storage, 20 reads/sec, and 10 writes/sec — more than enough for a personal to-do app.

--- a/docs/reference/COUCHDB-SETUP.md
+++ b/docs/reference/COUCHDB-SETUP.md
@@ -2,16 +2,33 @@
 
 **Document type:** Operational setup reference
 
-This guide walks through setting up IBM Cloudant (free tier) as the CouchDB sync relay for Fortudo.
+This guide walks through setting up IBM Cloudant as the CouchDB sync relay for Fortudo.
 
-Cloudant is a managed CouchDB-compatible database from IBM. The Lite plan is permanently free (not a trial) with 1 GB storage, 20 reads/sec, and 10 writes/sec — more than enough for a personal to-do app.
+Service facts and links in this guide were last checked on **2026-07-23**. Recheck IBM's
+current documentation before provisioning an instance or changing production access.
+
+Cloudant is a managed CouchDB-compatible database from IBM. IBM currently describes the
+[Lite plan](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-ibm-cloud-public) as a free
+evaluation and testing tier with 1 GB of storage, 20 reads/sec, 10 writes/sec, and 5 global
+queries/sec. Those limits are sufficient for Fortudo's observed personal use, but Lite is not
+IBM's recommended production tier. Lite instances created on or after 2025-03-03 are also
+limited to 20 databases; older instances are currently exempt from that database-count limit.
+Because Fortudo uses one database per room, verify the instance's current database capacity
+before adding rooms. See IBM's
+[database-limit notice](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-deprecations-for-ibm-cloudant).
 
 ## 1. Create a Cloudant instance
 
-1. Sign up at [IBM Cloud](https://cloud.ibm.com/registration) (no credit card required for Lite plan).
+1. Sign up at [IBM Cloud](https://cloud.ibm.com/registration).
 2. Go to the [Cloudant catalog page](https://cloud.ibm.com/catalog/services/cloudant).
 3. Select the **Lite** plan.
-4. **Important:** Under authentication, choose **"Use both legacy credentials and IAM"**. PouchDB does not support IAM-only authentication.
+4. **Important for the current Fortudo client:** Under authentication, choose
+   **"Use both legacy credentials and IAM"**. Fortudo's direct browser sync currently uses
+   legacy HTTP Basic credentials and does not implement IBM IAM token exchange or refresh.
+   PouchDB's [remote database options](https://pouchdb.com/api.html) can inject other authorization
+   headers through a custom `fetch`, so IAM-only support is possible with application changes; it
+   is not supported by Fortudo today. IBM recommends IAM-only access where possible, so treat
+   combined mode as an explicit compatibility tradeoff.
 5. Click **Create**.
 
 ## 2. Get your credentials
@@ -29,7 +46,10 @@ The URL with embedded credentials looks like:
 https://<username>:<password>@<host>.cloudantnosqldb.appdomain.cloud
 ```
 
-> **Note:** Service credentials always have Manager-level access. For more restricted access, generate a Cloudant API key (see "Option B" below).
+> **Note:** In combined legacy-and-IAM mode, the generated legacy username and password are
+> equivalent to Manager access. IBM documents this in
+> [Managing access for IBM Cloudant](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-managing-access-for-cloudant).
+> For database-scoped legacy access, see "Option B" below.
 
 ## 3. Enable CORS
 
@@ -39,14 +59,20 @@ The browser needs permission to make cross-origin requests to Cloudant.
 2. Go to **Account** > **CORS**.
 3. Enable CORS and add your Firebase Hosting domains.
 
-For this repo (`fortudo`), allowlist:
+For this repo (`fortudo`), allowlist exact origins:
 
 - Production: `https://fortudo.web.app` and `https://fortudo.firebaseapp.com`
-- Preview channels: `https://fortudo--*.web.app` and `https://fortudo--*.firebaseapp.com` (if wildcards are allowed)
+- Preview channels: each exact active preview URL that needs browser-based Cloudant access
 
-If Cloudant does not accept wildcard domains, add each preview URL explicitly. You can copy the preview URL from the GitHub Actions deploy step or from Firebase Console > Hosting > Channels.
+Cloudant's restricted-origin mode documents exact origins, not glob patterns such as
+`https://fortudo--*.web.app`. Copy the exact preview URL from the GitHub Actions deploy step or
+Firebase Console > Hosting > Channels, add it only while needed, and remove it when the preview
+channel is deleted.
 
-Do **not** use "All domains" in production — restrict to your exact origin.
+Do **not** use "All domains" in production. CORS controls which browser origins may issue
+requests; it does not authenticate users, hide a credential shipped to the browser, or restrict
+non-browser clients. See IBM's
+[CORS security guidance](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-cross-origin-resource-sharing).
 
 ## 4. Manual database provisioning
 
@@ -57,6 +83,23 @@ database does not exist leaves that room local-only and reports that sync is not
 The database must be created by an operator before the room can sync. At present this repository
 intentionally provides no supported production provisioning command. Do not infer that entering a
 room code, possessing the shared credential, or creating local data has provisioned its remote.
+
+The current compatibility release deliberately allows an existing database with no Fortudo
+document-contract validator to sync while reporting `missing-validator`. A missing database,
+partitioned database, corrupt or mismatched validator, or validator newer than the client blocks
+sync. See [sync-contract.js](../../public/js/sync-contract.js).
+
+That tolerance is a rollout state, not the target provisioning design. A future production room is
+intended to be provisioned fence-first:
+
+1. Create the exact empty, nonpartitioned database.
+2. Install and verify the exact current Fortudo validator.
+3. Only then enable client replication.
+
+Until a general fence-first production operation is reviewed, creating a new unfenced remote is an
+explicit compatibility exception rather than routine room setup. An existing nonempty database
+needs its own inventory, state binding, recovery decision, approval, and verified validator
+installation; do not copy the completed `dat-411` write command to another room.
 
 Two credential arrangements remain possible after manual provisioning:
 
@@ -72,53 +115,68 @@ export const COUCHDB_URL =
   'https://<username>:<password>@<host>.cloudantnosqldb.appdomain.cloud';
 ```
 
-**Pros:** No separate API key per room.
-**Cons:** Every room still needs manual provisioning, and the credentials are visible in the browser
-(network tab and JavaScript source). This is an accepted risk for the current personal/household
-deployment, not a suitable public-facing design.
+**Pros:** No separate API-key grant step.
+
+**Cons:** Every room still needs manual provisioning. The Manager-equivalent credential is visible
+in the browser and can operate across the Cloudant account rather than only the active room. This
+is an accepted risk for the current personal/household deployment, not a suitable public-facing
+design.
 
 ### Option B: Manually provision with scoped API keys
 
-Keep admin credentials out of the browser. Create each room's database ahead of time and grant access via a scoped API key.
+Keep the account-wide credential out of the browser. Create the database ahead of time and grant a
+legacy Cloudant API key access only to the database or fixed set of databases the deployment needs.
 
 ```bash
 HOST="https://<username>:<password>@<host>.cloudantnosqldb.appdomain.cloud"
 
-# Create the database
-curl -X PUT "$HOST/fortudo-fox-742"
-
-# Generate a Cloudant API key
+# For an already approved database, generate a Cloudant API key
 curl -X POST "$HOST/_api/v2/api_keys"
 # Returns: {"key": "...", "password": "...", "ok": true}
-
-# Grant the API key read/write/replicate access to the database
-curl -X PUT "$HOST/fortudo-fox-742/_security" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "cloudant": {
-      "YOUR_API_KEY": ["_reader", "_writer", "_replicator"]
-    }
-  }'
 ```
 
-Then in `public/js/config.js`, use the API key credentials:
+Treat both the response and the current database `_security` document as private. Read the current
+`_security` value, add this entry to its existing `cloudant` mapping, then `PUT` the complete merged
+document and reread it:
+
+```json
+"YOUR_API_KEY": ["_reader", "_writer", "_replicator"]
+```
+
+Do not submit a replacement object containing only that entry: doing so can remove existing
+principals or roles. Verify that the intended entry was added and every pre-existing entry is
+unchanged. The three roles are the union needed when the same database participates in both
+directions of PouchDB synchronization: document reads, document writes, and replication
+checkpoints. See IBM's
+[replication permissions](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-replication-guide#permissions).
+
+Then in `public/js/config.js`, use the scoped API-key credentials:
 
 ```js
 export const COUCHDB_URL =
   'https://<api_key>:<api_password>@<host>.cloudantnosqldb.appdomain.cloud';
 ```
 
-You can reuse the same API key across multiple databases by adding it to each database's `_security` document.
+Fortudo currently has one global `COUCHDB_URL`. It can therefore use one scoped API key granted to
+one database or a fixed set of databases, but it cannot select a different credential for each room.
+Granting the same key to more databases broadens that key's blast radius. Distinct room credentials,
+invitations, and revocation require the separate room identity and access redesign.
 
-**Pros:** Scoped access — the API key can only read/write databases you've explicitly granted.
-**Cons:** Manual database creation and permission grants are required.
+**Pros:** The browser credential is limited to the databases explicitly granted.
+
+**Cons:** Manual database creation and permission grants are required; the present client still
+shares one credential across every room it can sync.
 
 ### Recommendation
 
-The current personal deployment accepts Option A's shared-credential risk. Prefer Option B for any
-new security design. In either case, database creation is an operator action, not browser behavior.
-After document-contract enforcement becomes fail-closed, a new production database must also receive
-and verify the required validator before any client is allowed to replicate.
+The current personal deployment accepts Option A's account-wide shared-credential risk. Option B can
+reduce that blast radius for a fixed deployment, but it is not a per-room invitation system. In
+either case, database creation is an operator action, not browser behavior, and fence-first
+provisioning is the intended production posture.
+
+For an existing nonempty room or a migration, start with
+[Cloudant migration toolkit boundaries](../operations/CLOUDANT-MIGRATION-TOOLKIT.md). Its reusable
+read-only components are not blanket authorization to provision, fence, or migrate a database.
 
 ## 5. Connect Fortudo
 
@@ -150,6 +208,10 @@ If you use the GitHub Actions workflow in this repo, the tracked `public/js/conf
 2. Set it to your full Cloudant URL (with credentials).
 
 During the build job, the workflow overwrites `public/js/config.js` only when the secret is present. If the secret is missing (for example on PRs from forks), the tracked local-only default remains in place.
+
+The GitHub repository secret protects the value during CI configuration, but it does **not** remain
+a secret at runtime. The deployed browser must receive `config.js`, so any user who can load the
+application can recover the Cloudant credential.
 
 ## 6. Update Firebase Hosting headers
 
@@ -189,55 +251,110 @@ firebase deploy
 
 ## Security considerations
 
-Credentials (admin or API key) are embedded in `config.js`, which is served as a static file. Anyone who can load the site can view source and extract them. This means they could read, modify, or delete your Cloudant data, or consume your free-tier quota.
+The browser credential is embedded in deployed `config.js`. Anyone who can load the application can
+extract it from the source or network configuration and operate outside the Fortudo UI.
 
-**Why this is acceptable for Fortudo:**
+With Option A, that credential is Manager-equivalent and the potential impact spans the Cloudant
+account: database enumeration, reads, writes, deletion, provisioning, and quota consumption. With
+Option B, impact is limited to the databases and roles granted to that API key.
 
-- The site URL is not publicly shared — only known to household members
-- The data is non-sensitive (daily to-do items)
-- Room codes add a layer of obscurity (someone would need to know or guess a code to find your data)
-- The app works fully offline without sync, so a compromised Cloudant instance is an inconvenience, not a data loss event (your local PouchDB is the source of truth)
+The current personal/household deployment explicitly accepts Option A under this threat model:
 
-**If your threat model changes** (e.g., you share the URL more broadly), consider:
+- Only trusted household members are expected to load the application.
+- The application URL is not intentionally advertised, while recognizing that URL secrecy is not
+  authentication.
+- The operator accepts the account-wide blast radius of exposing the shared credential.
+- Task and activity data may contain private descriptions even though the deployment is intended for
+  personal use.
+- A room code is a database selector and friendly label, not an access-control boundary.
+- Local PouchDB replicas support offline use but are not backups. Remote deletion tombstones or bad
+  revisions can replicate into connected clients; an offline copy may help manual recovery but
+  provides no guarantee.
 
-1. **Firebase Cloud Function as a proxy** — holds Cloudant credentials server-side, the browser never sees them. Firebase Functions has a free tier.
-2. **Firebase Authentication** — gate the app behind Google sign-in. Only authenticated users get the sync URL (served dynamically, not as a static file).
-3. **HTTP gateway** — put Cloudflare Access or similar in front of the site to require a password before the app loads at all.
+Reassess this decision if the audience broadens, rooms cross trust boundaries, the data becomes more
+sensitive, the database count grows, or remote loss is no longer tolerable. The architectural debt
+and future direction are documented in
+[Room identity and access risk](../architecture/ROOM-IDENTITY-AND-ACCESS-RISK.md).
+
+Possible mitigations have different strengths:
+
+1. **Authenticated server-side proxy or control plane:** Keep Cloudant credentials on the server and
+   authorize each user and room operation there. Firebase Authentication can establish identity, but
+   authentication alone is not sufficient if the backend then hands the raw Cloudant credential to
+   the browser.
+2. **Scoped legacy API key:** Limit the current deployment credential to a fixed set of databases.
+   This reduces account-wide blast radius but does not add distinct per-room invitations or
+   revocation to the current client.
+3. **HTTP access gateway:** Reduce who can load the site. This is useful defense in depth but does
+   not constrain a Cloudant credential after an authorized browser receives it.
+4. **Independent recovery copy:** Use a reviewed replication or export process and test recovery.
+   Cloudant's intra-service redundancy provides availability, while IBM recommends
+   [replication or export](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-security#protection-against-data-loss-or-corruption)
+   for additional data redundancy.
 
 ## Gotchas
 
-### Rate limiting looks like CORS errors
+### Distinguish rate limiting from CORS
 
-Cloudant's Lite plan enforces 20 reads/sec and 10 writes/sec. When you hit these limits, the 429 response is missing CORS headers, so the browser reports it as a CORS error — not a rate limit error.
+Cloudant returns HTTP `429 Too Many Requests` when an instance exceeds a request-class capacity
+limit. Fortudo can surface transport failures as a generic sync error, so do not diagnose every
+browser-reported network or CORS failure as either CORS or rate limiting without evidence.
 
-If you see unexpected CORS errors during sync, this is likely the cause. The current sync implementation uses single-shot replication which should stay well within limits for a personal app, but if you hit issues, reduce PouchDB's batch size:
-
-```js
-db.replicate.to(remoteUrl, { batch_size: 5, batches_limit: 1 });
-```
+Check the browser network response when it is available and inspect the instance's Cloudant
+Monitoring metrics for 429s. Ordinary application changes remain in local PouchDB and can sync after
+capacity is available. Operator tooling must use bounded batching and retry with backoff; Fortudo's
+reusable Cloudant client does so. Do not change PouchDB batch settings ad hoc without exercising the
+sync and recovery tests. See IBM's
+[429 guidance](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-usage-and-charges#provisioned-throughput-capacity-and-429-http-responses).
 
 ### Cloudant vs CouchDB differences
 
 Cloudant is CouchDB-compatible but has some limits:
 
+- Max JSON document size: 1 MB
 - Max request size: 11 MB (vs CouchDB's 4 GB default)
 - Max attachment size: 10 MB
-- No `_users` database (auth is via IAM or Cloudant API keys, not CouchDB users)
+- Provisioned throughput limits can return HTTP 429
+- Authentication and authorization include IBM IAM and Cloudant legacy controls; do not assume a
+  self-hosted CouchDB access configuration transfers unchanged
 - No `couch_peruser` plugin
 
-None of these affect Fortudo's use case (small JSON task documents, no attachments).
+The size limits do not affect Fortudo's current small JSON documents, but access configuration,
+throughput, database count, and the current nonpartitioned-database requirement all matter
+operationally. See IBM's
+[Cloudant and CouchDB comparison](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-couchdb-and-cloudant).
 
 ## Cost
 
-**Free.** The Cloudant Lite plan is permanently free with no expiration. If you exceed 1 GB storage, writes are blocked until you delete data or upgrade.
+As of the verification date at the top of this guide, IBM lists Lite as free. This is a current
+service-plan fact, not a promise that pricing or terms can never change.
+
+At more than 1 GB of measured storage, Lite blocks document creates and updates while reads and
+deletes remain available. After data is deleted below the limit, IBM says write access can take up
+to 24 hours to return. Recheck
+[plans and provisioning](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-ibm-cloud-public) and
+[usage and charges](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-usage-and-charges) before
+depending on current limits.
 
 ## Migrating away
 
-If you outgrow Cloudant or want to self-host, you can move to any CouchDB instance:
+Cloudant provides replication and JSON export paths for data portability. Moving to a compatible
+CouchDB is practical, but it is an operation to verify rather than a URL-only switch:
 
 1. Set up CouchDB elsewhere (Docker, Fly.io, a home server, etc.)
-2. Use Cloudant's built-in replication to copy your databases to the new CouchDB
-3. Update `COUCHDB_URL` in `config.js` to point to the new host
-4. Redeploy
+2. Use a reviewed replication or export process with a narrow, rotatable credential.
+3. Verify the expected live, deleted, and conflicting revisions and design documents at the target.
+4. Recreate and verify authorization, `_security`, CORS, validator, provisioning, and hosting
+   configuration; those operational controls do not transfer merely by copying documents.
+5. Update `COUCHDB_URL`, deploy, and exercise synchronization before retiring the source.
 
-The CouchDB replication protocol is an open standard — your data is never locked in.
+Do not put Fortudo's long-lived shared Manager credential into a durable `_replicator` document. A
+deleted replication document can retain credential material in revision history. The completed
+taxonomy migration instead used a bounded transient replication request and verified target state;
+future operator work should choose and review its credential lifecycle explicitly. See
+[Cloudant migration toolkit boundaries](../operations/CLOUDANT-MIGRATION-TOOLKIT.md) and IBM's
+[replication security guidance](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-replication-guide).
+
+The CouchDB replication model gives Fortudo strong data portability, but Cloudant-specific access,
+limits, and operational configuration still require migration work. See IBM's
+[data-portability guidance](https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-data-portability).

--- a/scripts/cloudant_migration/__init__.py
+++ b/scripts/cloudant_migration/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable, product-neutral Cloudant migration safety primitives."""

--- a/scripts/cloudant_migration/client.py
+++ b/scripts/cloudant_migration/client.py
@@ -1,0 +1,328 @@
+"""Credential-redacting Cloudant client for guarded migration operations."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Mapping
+
+from scripts.cloudant_migration.state import (
+    CloudantMigrationSafetyError,
+    StateModel,
+    build_state_model,
+    canonical_hash,
+)
+
+
+LEAF_READ_BATCH_SIZE = 100
+RATE_LIMIT_RETRIES = 6
+RATE_LIMIT_BASE_DELAY_SECONDS = 0.5
+
+
+class CloudantMigrationClient:
+    """Small Cloudant client whose errors never expose credentials or document bodies."""
+
+    def __init__(self, credential_url: str) -> None:
+        parsed = urllib.parse.urlsplit(credential_url)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise CloudantMigrationSafetyError("Cloudant credential URL must use HTTPS")
+        if parsed.username is None or parsed.password is None:
+            raise CloudantMigrationSafetyError("Cloudant credential URL is missing credentials")
+        port = f":{parsed.port}" if parsed.port else ""
+        self._endpoint = urllib.parse.urlunsplit(
+            (parsed.scheme, f"{parsed.hostname}{port}", parsed.path.rstrip("/"), "", "")
+        )
+        self._username = urllib.parse.unquote(parsed.username)
+        self._password = urllib.parse.unquote(parsed.password)
+        token = base64.b64encode(f"{self._username}:{self._password}".encode("utf-8")).decode(
+            "ascii"
+        )
+        self._authorization = f"Basic {token}"
+
+    @property
+    def account_checksum(self) -> str:
+        """Stable non-secret binding for the credential's account endpoint."""
+
+        return hashlib.sha256(self._endpoint.encode("utf-8")).hexdigest()
+
+    def _request(
+        self,
+        method: str,
+        operation: str,
+        path: str,
+        *,
+        body: Mapping[str, Any] | None = None,
+        allow_not_found: bool = False,
+    ) -> Any:
+        encoded_body = None
+        headers = {"Authorization": self._authorization, "Accept": "application/json"}
+        if body is not None:
+            encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self._endpoint}/{path.lstrip('/')}",
+            data=encoded_body,
+            method=method,
+            headers=headers,
+        )
+        for attempt in range(RATE_LIMIT_RETRIES + 1):
+            try:
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    payload = response.read()
+                return json.loads(payload) if payload else {}
+            except urllib.error.HTTPError as error:
+                if allow_not_found and error.code == 404:
+                    return None
+                if error.code == 429 and attempt < RATE_LIMIT_RETRIES:
+                    delay = RATE_LIMIT_BASE_DELAY_SECONDS * (2**attempt)
+                    retry_after = error.headers.get("Retry-After") if error.headers else None
+                    try:
+                        delay = max(delay, float(retry_after))
+                    except (TypeError, ValueError):
+                        pass
+                    time.sleep(min(delay, 8.0))
+                    continue
+                raise CloudantMigrationSafetyError(
+                    f"Cloudant request failed with HTTP {error.code} during {operation}"
+                ) from None
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+                raise CloudantMigrationSafetyError(
+                    f"Cloudant request failed during {operation}"
+                ) from None
+        raise AssertionError("unreachable Cloudant retry state")
+
+    @staticmethod
+    def _database_path(database: str) -> str:
+        return urllib.parse.quote(database, safe="")
+
+    def get_document(self, database: str, document_id: str) -> dict[str, Any] | None:
+        path = f"{self._database_path(database)}/{urllib.parse.quote(document_id, safe='')}"
+        payload = self._request("GET", "document read", path, allow_not_found=True)
+        if payload is None:
+            return None
+        if not isinstance(payload, Mapping):
+            raise CloudantMigrationSafetyError("Cloudant returned an invalid document response")
+        return dict(payload)
+
+    def get_security_hash(self, database: str) -> str:
+        payload = self._request(
+            "GET", "security read", f"{self._database_path(database)}/_security"
+        )
+        if not isinstance(payload, Mapping):
+            raise CloudantMigrationSafetyError("Cloudant returned an invalid security response")
+        return canonical_hash(payload)
+
+    def database_exists(self, database: str) -> bool:
+        payload = self._request(
+            "GET",
+            "database existence read",
+            self._database_path(database),
+            allow_not_found=True,
+        )
+        if payload is None:
+            return False
+        if not isinstance(payload, Mapping) or payload.get("db_name") != database:
+            raise CloudantMigrationSafetyError(
+                "Cloudant reported a different database identity"
+            )
+        return True
+
+    def get_security_document(self, database: str) -> dict[str, Any]:
+        payload = self._request(
+            "GET", "security read", f"{self._database_path(database)}/_security"
+        )
+        if not isinstance(payload, Mapping):
+            raise CloudantMigrationSafetyError("Cloudant returned an invalid security response")
+        return dict(payload)
+
+    def put_document(
+        self, database: str, document: Mapping[str, Any], *, create_only: bool = False
+    ) -> dict[str, Any]:
+        document_id = document.get("_id")
+        if not isinstance(document_id, str) or not document_id:
+            raise CloudantMigrationSafetyError("document write is missing an ID")
+        if create_only and "_rev" in document:
+            raise CloudantMigrationSafetyError(
+                "create-only document must not contain a revision"
+            )
+        operation = "document create" if create_only else "document update"
+        payload = self._request(
+            "PUT",
+            operation,
+            f"{self._database_path(database)}/{urllib.parse.quote(document_id, safe='')}",
+            body=document,
+        )
+        if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+            raise CloudantMigrationSafetyError(
+                "Cloudant returned an invalid document write response"
+            )
+        return dict(payload)
+
+    def get_all_documents(
+        self, database: str, *, include_conflicts: bool
+    ) -> list[dict[str, Any]]:
+        query = "include_docs=true"
+        if include_conflicts:
+            query += "&conflicts=true"
+        payload = self._request(
+            "GET",
+            "winning document read",
+            f"{self._database_path(database)}/_all_docs?{query}",
+        )
+        if not isinstance(payload, Mapping) or not isinstance(payload.get("rows"), list):
+            raise CloudantMigrationSafetyError(
+                "Cloudant returned an invalid winning document response"
+            )
+        documents: list[dict[str, Any]] = []
+        for row in payload["rows"]:
+            if not isinstance(row, Mapping):
+                raise CloudantMigrationSafetyError(
+                    "Cloudant returned an invalid winning document response"
+                )
+            document = row.get("doc")
+            if document is None:
+                continue
+            if not isinstance(document, Mapping):
+                raise CloudantMigrationSafetyError(
+                    "Cloudant returned an invalid winning document response"
+                )
+            documents.append(dict(document))
+        return documents
+
+    def _get_current_leaf_documents(
+        self, database: str, *, include_ancestry: bool
+    ) -> list[dict[str, Any]]:
+        database_path = self._database_path(database)
+        changes = self._request(
+            "GET",
+            "leaf enumeration",
+            f"{database_path}/_changes?since=0&style=all_docs&include_docs=false",
+        )
+        if not isinstance(changes, Mapping) or not isinstance(changes.get("results"), list):
+            raise CloudantMigrationSafetyError(
+                "Cloudant returned an invalid leaf enumeration"
+            )
+        expected: set[tuple[str, str]] = set()
+        for row in changes["results"]:
+            document_id = row.get("id") if isinstance(row, Mapping) else None
+            revision_rows = row.get("changes") if isinstance(row, Mapping) else None
+            if (
+                not isinstance(document_id, str)
+                or not isinstance(revision_rows, list)
+                or not revision_rows
+            ):
+                raise CloudantMigrationSafetyError(
+                    "Cloudant returned an invalid leaf enumeration"
+                )
+            for revision_row in revision_rows:
+                revision = (
+                    revision_row.get("rev") if isinstance(revision_row, Mapping) else None
+                )
+                identity = (document_id, revision)
+                if not isinstance(revision, str) or not revision or identity in expected:
+                    raise CloudantMigrationSafetyError(
+                        "Cloudant returned an invalid leaf enumeration"
+                    )
+                expected.add((document_id, revision))
+
+        leaf_documents: list[dict[str, Any]] = []
+        returned: set[tuple[str, str]] = set()
+        requested = sorted(expected)
+        for offset in range(0, len(requested), LEAF_READ_BATCH_SIZE):
+            batch = requested[offset : offset + LEAF_READ_BATCH_SIZE]
+            payload = self._request(
+                "POST",
+                "leaf body read",
+                f"{database_path}/_bulk_get"
+                f"?revs={'true' if include_ancestry else 'false'}&attachments=false",
+                body={
+                    "docs": [
+                        {"id": document_id, "rev": revision}
+                        for document_id, revision in batch
+                    ]
+                },
+            )
+            if not isinstance(payload, Mapping) or not isinstance(
+                payload.get("results"), list
+            ):
+                raise CloudantMigrationSafetyError(
+                    "Cloudant returned an invalid leaf body response"
+                )
+            for result in payload["results"]:
+                result_id = result.get("id") if isinstance(result, Mapping) else None
+                documents = result.get("docs") if isinstance(result, Mapping) else None
+                if not isinstance(result_id, str) or not isinstance(documents, list):
+                    raise CloudantMigrationSafetyError(
+                        "Cloudant returned an invalid leaf body response"
+                    )
+                for document_result in documents:
+                    document = (
+                        document_result.get("ok")
+                        if isinstance(document_result, Mapping)
+                        else None
+                    )
+                    revision = document.get("_rev") if isinstance(document, Mapping) else None
+                    identity = (result_id, revision)
+                    if (
+                        not isinstance(document, Mapping)
+                        or document.get("_id") != result_id
+                        or not isinstance(revision, str)
+                        or identity not in expected
+                        or identity in returned
+                    ):
+                        raise CloudantMigrationSafetyError(
+                            "Cloudant returned an inconsistent leaf body"
+                        )
+                    returned.add((result_id, revision))
+                    leaf_documents.append(dict(document))
+        if returned != expected:
+            raise CloudantMigrationSafetyError("Cloudant omitted a current leaf body")
+        return leaf_documents
+
+    def get_leaf_documents(self, database: str) -> list[dict[str, Any]]:
+        return self._get_current_leaf_documents(database, include_ancestry=True)
+
+    def get_state_model(self, database: str) -> StateModel:
+        database_path = self._database_path(database)
+        metadata = self._request("GET", "database metadata read", database_path)
+        leaf_documents = self._get_current_leaf_documents(database, include_ancestry=False)
+        all_documents = self._request(
+            "POST",
+            "winner enumeration",
+            f"{database_path}/_all_docs",
+            body={"keys": sorted({document["_id"] for document in leaf_documents})},
+        )
+        if not isinstance(metadata, Mapping) or metadata.get("db_name") != database:
+            raise CloudantMigrationSafetyError("Cloudant returned invalid database metadata")
+        if not isinstance(all_documents, Mapping) or not isinstance(
+            all_documents.get("rows"), list
+        ):
+            raise CloudantMigrationSafetyError(
+                "Cloudant returned an invalid winner enumeration"
+            )
+
+        leaf_rows = [
+            {
+                "id": document["_id"],
+                "rev": document["_rev"],
+                "deleted": document.get("_deleted") is True,
+            }
+            for document in leaf_documents
+        ]
+
+        winners: dict[str, str] = {}
+        for row in all_documents["rows"]:
+            value = row.get("value") if isinstance(row, Mapping) else None
+            document_id = row.get("id") if isinstance(row, Mapping) else None
+            revision = value.get("rev") if isinstance(value, Mapping) else None
+            if not isinstance(document_id, str) or not isinstance(revision, str):
+                raise CloudantMigrationSafetyError(
+                    "Cloudant returned an invalid winner enumeration"
+                )
+            winners[document_id] = revision
+        return build_state_model(leaf_rows, winners)

--- a/scripts/cloudant_migration/state.py
+++ b/scripts/cloudant_migration/state.py
@@ -1,0 +1,159 @@
+"""Canonical Cloudant state models used by guarded migration operations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+class CloudantMigrationSafetyError(RuntimeError):
+    """Raised when a Cloudant migration safety invariant does not hold."""
+
+
+@dataclass(frozen=True, order=True)
+class LeafRevision:
+    """One current non-local revision-tree leaf."""
+
+    document_id: str
+    revision: str
+    deleted: bool
+
+
+@dataclass(frozen=True)
+class StateModel:
+    """Canonical current revision state."""
+
+    leaves: tuple[LeafRevision, ...]
+    winners: tuple[tuple[str, str], ...]
+    counts: dict[str, int]
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class CaptureReceipt:
+    """Verified identity and state of one native Cloudant quarantine capture."""
+
+    source_database: str
+    quarantine_database: str
+    state: StateModel
+    security_hash: str
+    disposable_preview: bool = False
+
+
+def canonical_hash(value: Any) -> str:
+    """Hash a JSON value with deterministic object-key and whitespace handling."""
+
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_state_model(
+    leaf_rows: Sequence[Mapping[str, Any]],
+    winner_revisions: Mapping[str, str],
+) -> StateModel:
+    """Validate and canonicalize the current non-``_local`` leaf graph."""
+
+    leaves: list[LeafRevision] = []
+    seen: set[tuple[str, str]] = set()
+    revisions_by_document: dict[str, set[str]] = {}
+    for row in leaf_rows:
+        document_id = row.get("id")
+        revision = row.get("rev")
+        deleted = row.get("deleted")
+        if isinstance(document_id, str) and document_id.startswith("_local/"):
+            continue
+        if not isinstance(document_id, str) or not document_id:
+            raise CloudantMigrationSafetyError(
+                "leaf enumeration contains an invalid document ID"
+            )
+        if not isinstance(revision, str) or not revision:
+            raise CloudantMigrationSafetyError("leaf enumeration contains an invalid revision")
+        if not isinstance(deleted, bool):
+            raise CloudantMigrationSafetyError(
+                "leaf enumeration contains an invalid deletion state"
+            )
+        identity = (document_id, revision)
+        if identity in seen:
+            raise CloudantMigrationSafetyError(
+                "leaf enumeration contains a duplicate revision"
+            )
+        seen.add(identity)
+        revisions_by_document.setdefault(document_id, set()).add(revision)
+        leaves.append(LeafRevision(document_id, revision, deleted))
+
+    winners: dict[str, str] = {}
+    for document_id, revision in winner_revisions.items():
+        if document_id.startswith("_local/"):
+            continue
+        if not document_id or not isinstance(revision, str) or not revision:
+            raise CloudantMigrationSafetyError("winner enumeration is invalid")
+        winners[document_id] = revision
+
+    if set(winners) != set(revisions_by_document):
+        raise CloudantMigrationSafetyError(
+            "winner enumeration does not match the leaf documents"
+        )
+    for document_id, revision in winners.items():
+        if revision not in revisions_by_document[document_id]:
+            raise CloudantMigrationSafetyError(
+                "winner revision is absent from the current leaf set"
+            )
+
+    canonical_leaves = tuple(sorted(leaves))
+    canonical_winners = tuple(sorted(winners.items()))
+    counts = {
+        "documents": len(revisions_by_document),
+        "liveLeaves": sum(not leaf.deleted for leaf in canonical_leaves),
+        "deletedLeaves": sum(leaf.deleted for leaf in canonical_leaves),
+        "conflictLeaves": sum(
+            max(0, len(revisions) - 1) for revisions in revisions_by_document.values()
+        ),
+    }
+    fingerprint_payload = {
+        "leaves": [[leaf.document_id, leaf.revision, leaf.deleted] for leaf in canonical_leaves],
+        "winners": [list(winner) for winner in canonical_winners],
+    }
+    return StateModel(
+        leaves=canonical_leaves,
+        winners=canonical_winners,
+        counts=counts,
+        fingerprint=canonical_hash(fingerprint_payload),
+    )
+
+
+def add_leaf_to_state(
+    source: StateModel,
+    document_id: str,
+    revision: str,
+    *,
+    deleted: bool,
+) -> StateModel:
+    """Return a state with one new document leaf, failing on identity reuse."""
+
+    if document_id in dict(source.winners):
+        raise CloudantMigrationSafetyError("cannot add a leaf for an existing document")
+    rows = [
+        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
+        for leaf in source.leaves
+    ]
+    rows.append({"id": document_id, "rev": revision, "deleted": deleted})
+    winners = dict(source.winners)
+    winners[document_id] = revision
+    return build_state_model(rows, winners)
+
+
+def remove_document_from_state(source: StateModel, document_id: str) -> StateModel:
+    """Return a state without any leaves or winner for one document."""
+
+    rows = [
+        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
+        for leaf in source.leaves
+        if leaf.document_id != document_id
+    ]
+    winners = dict(source.winners)
+    winners.pop(document_id, None)
+    return build_state_model(rows, winners)

--- a/scripts/document_contract_ops.py
+++ b/scripts/document_contract_ops.py
@@ -17,7 +17,7 @@ from typing import Any, Mapping, Sequence
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.migrate_taxonomy_identity import (
+from scripts.migrations.taxonomy_identity_v1.planner import (
     CREDENTIAL_ENV_VAR,
     CloudantClient,
     MigrationSafetyError,

--- a/scripts/migrations/__init__.py
+++ b/scripts/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit, versioned Fortudo data migration operations."""

--- a/scripts/migrations/taxonomy_identity_v1/__init__.py
+++ b/scripts/migrations/taxonomy_identity_v1/__init__.py
@@ -1,0 +1,1 @@
+"""Version-1 taxonomy identity planning and the completed dat-411 operation."""

--- a/scripts/migrations/taxonomy_identity_v1/dat_411_operation.py
+++ b/scripts/migrations/taxonomy_identity_v1/dat_411_operation.py
@@ -1,36 +1,43 @@
-"""Minimal Cloudant-native quarantine and migration safety operations.
+"""Completed dat-411 taxonomy-identity-v1 quarantine and migration operation.
 
 This module deliberately delegates revision-tree transfer to Cloudant replication.
 It does not implement a local backup format or a reverse-restore path.
+
+Reusable Cloudant state and client primitives live under ``scripts.cloudant_migration``.
+The source lock, taxonomy meanings, completion protocol, and CLI in this module are
+intentionally one-off.
 """
 
 from __future__ import annotations
 
 import argparse
 import copy
-import base64
-import hashlib
 import json
 import os
 import re
 import sys
-import time
-import urllib.error
-import urllib.parse
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 if __package__ in {None, ""}:
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from scripts.document_contract_ops import (
     CONTRACT_DESIGN_ID,
     load_design_document,
     verify_validator,
 )
-from scripts.migrate_taxonomy_identity import (
+from scripts.cloudant_migration.client import CloudantMigrationClient
+from scripts.cloudant_migration.state import (
+    CaptureReceipt,
+    CloudantMigrationSafetyError,
+    LeafRevision,
+    StateModel,
+    build_state_model,
+    remove_document_from_state as _remove_document_from_state,
+)
+from scripts.migrations.taxonomy_identity_v1.planner import (
     CREDENTIAL_ENV_VAR,
     MigrationSafetyError,
     RUNNING_ACTIVITY_ID,
@@ -46,41 +53,8 @@ PREVIEW_QUARANTINE_PATTERN = re.compile(
 )
 QUARANTINE_PATTERN = re.compile(r"fortudo-quarantine-[a-f0-9]{24,64}")
 COMPLETION_MARKER_ID = "config-taxonomy-identity-migration-v1"
-LEAF_READ_BATCH_SIZE = 100
-RATE_LIMIT_RETRIES = 6
-RATE_LIMIT_BASE_DELAY_SECONDS = 0.5
 
-
-class QuarantineSafetyError(RuntimeError):
-    """Raised when a remote mutation safety gate does not hold."""
-
-
-@dataclass(frozen=True, order=True)
-class LeafRevision:
-    """One current non-local revision-tree leaf."""
-
-    document_id: str
-    revision: str
-    deleted: bool
-
-
-@dataclass(frozen=True)
-class StateModel:
-    """Canonical current revision state."""
-
-    leaves: tuple[LeafRevision, ...]
-    winners: tuple[tuple[str, str], ...]
-    counts: dict[str, int]
-    fingerprint: str
-
-
-@dataclass(frozen=True)
-class CaptureReceipt:
-    source_database: str
-    quarantine_database: str
-    state: StateModel
-    security_hash: str
-    disposable_preview: bool = False
+QuarantineSafetyError = CloudantMigrationSafetyError
 
 
 @dataclass(frozen=True)
@@ -105,111 +79,8 @@ class MigrationExecutionResult:
     marker_revision: str
 
 
-class OperationalCloudantClient:
-    """Small write-capable client limited to this migration's Cloudant endpoints."""
-
-    def __init__(self, credential_url: str) -> None:
-        parsed = urllib.parse.urlsplit(credential_url)
-        if parsed.scheme != "https" or not parsed.hostname:
-            raise QuarantineSafetyError("Cloudant credential URL must use HTTPS")
-        if parsed.username is None or parsed.password is None:
-            raise QuarantineSafetyError("Cloudant credential URL is missing credentials")
-        port = f":{parsed.port}" if parsed.port else ""
-        self._endpoint = urllib.parse.urlunsplit(
-            (parsed.scheme, f"{parsed.hostname}{port}", parsed.path.rstrip("/"), "", "")
-        )
-        self._username = urllib.parse.unquote(parsed.username)
-        self._password = urllib.parse.unquote(parsed.password)
-        token = base64.b64encode(f"{self._username}:{self._password}".encode("utf-8")).decode(
-            "ascii"
-        )
-        self._authorization = f"Basic {token}"
-
-    @property
-    def account_checksum(self) -> str:
-        """Stable non-secret binding for the credential's account endpoint."""
-
-        return hashlib.sha256(self._endpoint.encode("utf-8")).hexdigest()
-
-    def _request(
-        self,
-        method: str,
-        operation: str,
-        path: str,
-        *,
-        body: Mapping[str, Any] | None = None,
-        allow_not_found: bool = False,
-    ) -> Any:
-        encoded_body = None
-        headers = {"Authorization": self._authorization, "Accept": "application/json"}
-        if body is not None:
-            encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
-            headers["Content-Type"] = "application/json"
-        request = urllib.request.Request(
-            f"{self._endpoint}/{path.lstrip('/')}",
-            data=encoded_body,
-            method=method,
-            headers=headers,
-        )
-        for attempt in range(RATE_LIMIT_RETRIES + 1):
-            try:
-                with urllib.request.urlopen(request, timeout=60) as response:
-                    payload = response.read()
-                return json.loads(payload) if payload else {}
-            except urllib.error.HTTPError as error:
-                if allow_not_found and error.code == 404:
-                    return None
-                if error.code == 429 and attempt < RATE_LIMIT_RETRIES:
-                    delay = RATE_LIMIT_BASE_DELAY_SECONDS * (2**attempt)
-                    retry_after = error.headers.get("Retry-After") if error.headers else None
-                    try:
-                        delay = max(delay, float(retry_after))
-                    except (TypeError, ValueError):
-                        pass
-                    time.sleep(min(delay, 8.0))
-                    continue
-                raise QuarantineSafetyError(
-                    f"Cloudant request failed with HTTP {error.code} during {operation}"
-                ) from None
-            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
-                raise QuarantineSafetyError(
-                    f"Cloudant request failed during {operation}"
-                ) from None
-        raise AssertionError("unreachable Cloudant retry state")
-
-    @staticmethod
-    def _database_path(database: str) -> str:
-        return urllib.parse.quote(database, safe="")
-
-    def get_document(self, database: str, document_id: str) -> dict[str, Any] | None:
-        path = f"{self._database_path(database)}/{urllib.parse.quote(document_id, safe='')}"
-        payload = self._request("GET", "document read", path, allow_not_found=True)
-        if payload is None:
-            return None
-        if not isinstance(payload, Mapping):
-            raise QuarantineSafetyError("Cloudant returned an invalid document response")
-        return dict(payload)
-
-    def get_security_hash(self, database: str) -> str:
-        payload = self._request(
-            "GET", "security read", f"{self._database_path(database)}/_security"
-        )
-        if not isinstance(payload, Mapping):
-            raise QuarantineSafetyError("Cloudant returned an invalid security response")
-        return canonical_hash(payload)
-
-    def database_exists(self, database: str) -> bool:
-        payload = self._request(
-            "GET",
-            "database existence read",
-            self._database_path(database),
-            allow_not_found=True,
-        )
-        if payload is None:
-            return False
-        if not isinstance(payload, Mapping) or payload.get("db_name") != database:
-            raise QuarantineSafetyError("Cloudant reported a different database identity")
-        return True
+class OperationalCloudantClient(CloudantMigrationClient):
+    """Write-capable client with lifecycle targets locked by this operation."""
 
     def create_database(
         self,
@@ -237,14 +108,6 @@ class OperationalCloudantClient:
         payload = self._request("DELETE", "database delete", self._database_path(database))
         if not isinstance(payload, Mapping) or payload.get("ok") is not True:
             raise QuarantineSafetyError("Cloudant returned an invalid database delete response")
-
-    def get_security_document(self, database: str) -> dict[str, Any]:
-        payload = self._request(
-            "GET", "security read", f"{self._database_path(database)}/_security"
-        )
-        if not isinstance(payload, Mapping):
-            raise QuarantineSafetyError("Cloudant returned an invalid security response")
-        return dict(payload)
 
     def replicate_once(
         self,
@@ -282,267 +145,6 @@ class OperationalCloudantClient:
         if not isinstance(latest, Mapping) or latest.get("doc_write_failures", 0) != 0:
             raise QuarantineSafetyError("replication completed with document write failures")
         return dict(payload)
-
-    def put_document(
-        self, database: str, document: Mapping[str, Any], *, create_only: bool = False
-    ) -> dict[str, Any]:
-        document_id = document.get("_id")
-        if not isinstance(document_id, str) or not document_id:
-            raise QuarantineSafetyError("document write is missing an ID")
-        if create_only and "_rev" in document:
-            raise QuarantineSafetyError("create-only document must not contain a revision")
-        operation = "document create" if create_only else "document update"
-        payload = self._request(
-            "PUT",
-            operation,
-            f"{self._database_path(database)}/{urllib.parse.quote(document_id, safe='')}",
-            body=document,
-        )
-        if not isinstance(payload, Mapping) or payload.get("ok") is not True:
-            raise QuarantineSafetyError("Cloudant returned an invalid document write response")
-        return dict(payload)
-
-    def get_all_documents(self, database: str, *, include_conflicts: bool) -> list[dict[str, Any]]:
-        query = "include_docs=true"
-        if include_conflicts:
-            query += "&conflicts=true"
-        payload = self._request(
-            "GET",
-            "winning document read",
-            f"{self._database_path(database)}/_all_docs?{query}",
-        )
-        if not isinstance(payload, Mapping) or not isinstance(payload.get("rows"), list):
-            raise QuarantineSafetyError("Cloudant returned an invalid winning document response")
-        documents: list[dict[str, Any]] = []
-        for row in payload["rows"]:
-            if not isinstance(row, Mapping):
-                raise QuarantineSafetyError(
-                    "Cloudant returned an invalid winning document response"
-                )
-            document = row.get("doc")
-            if document is None:
-                continue
-            if not isinstance(document, Mapping):
-                raise QuarantineSafetyError(
-                    "Cloudant returned an invalid winning document response"
-                )
-            documents.append(dict(document))
-        return documents
-
-    def _get_current_leaf_documents(
-        self, database: str, *, include_ancestry: bool
-    ) -> list[dict[str, Any]]:
-        database_path = self._database_path(database)
-        changes = self._request(
-            "GET",
-            "leaf enumeration",
-            f"{database_path}/_changes?since=0&style=all_docs&include_docs=false",
-        )
-        if not isinstance(changes, Mapping) or not isinstance(changes.get("results"), list):
-            raise QuarantineSafetyError("Cloudant returned an invalid leaf enumeration")
-        expected: set[tuple[str, str]] = set()
-        for row in changes["results"]:
-            document_id = row.get("id") if isinstance(row, Mapping) else None
-            revision_rows = row.get("changes") if isinstance(row, Mapping) else None
-            if (
-                not isinstance(document_id, str)
-                or not isinstance(revision_rows, list)
-                or not revision_rows
-            ):
-                raise QuarantineSafetyError("Cloudant returned an invalid leaf enumeration")
-            for revision_row in revision_rows:
-                revision = revision_row.get("rev") if isinstance(revision_row, Mapping) else None
-                identity = (document_id, revision)
-                if not isinstance(revision, str) or not revision or identity in expected:
-                    raise QuarantineSafetyError("Cloudant returned an invalid leaf enumeration")
-                expected.add((document_id, revision))
-
-        leaf_documents: list[dict[str, Any]] = []
-        returned: set[tuple[str, str]] = set()
-        requested = sorted(expected)
-        for offset in range(0, len(requested), LEAF_READ_BATCH_SIZE):
-            batch = requested[offset : offset + LEAF_READ_BATCH_SIZE]
-            payload = self._request(
-                "POST",
-                "leaf body read",
-                f"{database_path}/_bulk_get"
-                f"?revs={'true' if include_ancestry else 'false'}&attachments=false",
-                body={
-                    "docs": [
-                        {"id": document_id, "rev": revision} for document_id, revision in batch
-                    ]
-                },
-            )
-            if not isinstance(payload, Mapping) or not isinstance(payload.get("results"), list):
-                raise QuarantineSafetyError("Cloudant returned an invalid leaf body response")
-            for result in payload["results"]:
-                result_id = result.get("id") if isinstance(result, Mapping) else None
-                documents = result.get("docs") if isinstance(result, Mapping) else None
-                if not isinstance(result_id, str) or not isinstance(documents, list):
-                    raise QuarantineSafetyError("Cloudant returned an invalid leaf body response")
-                for document_result in documents:
-                    document = (
-                        document_result.get("ok") if isinstance(document_result, Mapping) else None
-                    )
-                    revision = document.get("_rev") if isinstance(document, Mapping) else None
-                    identity = (result_id, revision)
-                    if (
-                        not isinstance(document, Mapping)
-                        or document.get("_id") != result_id
-                        or not isinstance(revision, str)
-                        or identity not in expected
-                        or identity in returned
-                    ):
-                        raise QuarantineSafetyError("Cloudant returned an inconsistent leaf body")
-                    returned.add((result_id, revision))
-                    leaf_documents.append(dict(document))
-        if returned != expected:
-            raise QuarantineSafetyError("Cloudant omitted a current leaf body")
-        return leaf_documents
-
-    def get_leaf_documents(self, database: str) -> list[dict[str, Any]]:
-        return self._get_current_leaf_documents(database, include_ancestry=True)
-
-    def get_state_model(self, database: str) -> StateModel:
-        database_path = self._database_path(database)
-        metadata = self._request("GET", "database metadata read", database_path)
-        leaf_documents = self._get_current_leaf_documents(database, include_ancestry=False)
-        all_documents = self._request(
-            "POST",
-            "winner enumeration",
-            f"{database_path}/_all_docs",
-            body={"keys": sorted({document["_id"] for document in leaf_documents})},
-        )
-        if not isinstance(metadata, Mapping) or metadata.get("db_name") != database:
-            raise QuarantineSafetyError("Cloudant returned invalid database metadata")
-        if not isinstance(all_documents, Mapping) or not isinstance(
-            all_documents.get("rows"), list
-        ):
-            raise QuarantineSafetyError("Cloudant returned an invalid winner enumeration")
-
-        leaf_rows = [
-            {
-                "id": document["_id"],
-                "rev": document["_rev"],
-                "deleted": document.get("_deleted") is True,
-            }
-            for document in leaf_documents
-        ]
-
-        winners: dict[str, str] = {}
-        for row in all_documents["rows"]:
-            value = row.get("value") if isinstance(row, Mapping) else None
-            document_id = row.get("id") if isinstance(row, Mapping) else None
-            revision = value.get("rev") if isinstance(value, Mapping) else None
-            if not isinstance(document_id, str) or not isinstance(revision, str):
-                raise QuarantineSafetyError("Cloudant returned an invalid winner enumeration")
-            winners[document_id] = revision
-        return build_state_model(leaf_rows, winners)
-
-
-def canonical_hash(value: Any) -> str:
-    """Hash a JSON value with deterministic object-key and whitespace handling."""
-
-    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode(
-        "utf-8"
-    )
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def build_state_model(
-    leaf_rows: Sequence[Mapping[str, Any]],
-    winner_revisions: Mapping[str, str],
-) -> StateModel:
-    """Validate and canonicalize the current non-``_local`` leaf graph."""
-
-    leaves: list[LeafRevision] = []
-    seen: set[tuple[str, str]] = set()
-    revisions_by_document: dict[str, set[str]] = {}
-    for row in leaf_rows:
-        document_id = row.get("id")
-        revision = row.get("rev")
-        deleted = row.get("deleted")
-        if isinstance(document_id, str) and document_id.startswith("_local/"):
-            continue
-        if not isinstance(document_id, str) or not document_id:
-            raise QuarantineSafetyError("leaf enumeration contains an invalid document ID")
-        if not isinstance(revision, str) or not revision:
-            raise QuarantineSafetyError("leaf enumeration contains an invalid revision")
-        if not isinstance(deleted, bool):
-            raise QuarantineSafetyError("leaf enumeration contains an invalid deletion state")
-        identity = (document_id, revision)
-        if identity in seen:
-            raise QuarantineSafetyError("leaf enumeration contains a duplicate revision")
-        seen.add(identity)
-        revisions_by_document.setdefault(document_id, set()).add(revision)
-        leaves.append(LeafRevision(document_id, revision, deleted))
-
-    winners: dict[str, str] = {}
-    for document_id, revision in winner_revisions.items():
-        if document_id.startswith("_local/"):
-            continue
-        if not document_id or not isinstance(revision, str) or not revision:
-            raise QuarantineSafetyError("winner enumeration is invalid")
-        winners[document_id] = revision
-
-    if set(winners) != set(revisions_by_document):
-        raise QuarantineSafetyError("winner enumeration does not match the leaf documents")
-    for document_id, revision in winners.items():
-        if revision not in revisions_by_document[document_id]:
-            raise QuarantineSafetyError("winner revision is absent from the current leaf set")
-
-    canonical_leaves = tuple(sorted(leaves))
-    canonical_winners = tuple(sorted(winners.items()))
-    counts = {
-        "documents": len(revisions_by_document),
-        "liveLeaves": sum(not leaf.deleted for leaf in canonical_leaves),
-        "deletedLeaves": sum(leaf.deleted for leaf in canonical_leaves),
-        "conflictLeaves": sum(
-            max(0, len(revisions) - 1) for revisions in revisions_by_document.values()
-        ),
-    }
-    fingerprint_payload = {
-        "leaves": [[leaf.document_id, leaf.revision, leaf.deleted] for leaf in canonical_leaves],
-        "winners": [list(winner) for winner in canonical_winners],
-    }
-    return StateModel(
-        leaves=canonical_leaves,
-        winners=canonical_winners,
-        counts=counts,
-        fingerprint=canonical_hash(fingerprint_payload),
-    )
-
-
-def add_leaf_to_state(
-    source: StateModel,
-    document_id: str,
-    revision: str,
-    *,
-    deleted: bool,
-) -> StateModel:
-    """Return a state with one new document leaf, failing on identity reuse."""
-
-    if document_id in dict(source.winners):
-        raise QuarantineSafetyError("cannot add a leaf for an existing document")
-    rows = [
-        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
-        for leaf in source.leaves
-    ]
-    rows.append({"id": document_id, "rev": revision, "deleted": deleted})
-    winners = dict(source.winners)
-    winners[document_id] = revision
-    return build_state_model(rows, winners)
-
-
-def _remove_document_from_state(source: StateModel, document_id: str) -> StateModel:
-    rows = [
-        {"id": leaf.document_id, "rev": leaf.revision, "deleted": leaf.deleted}
-        for leaf in source.leaves
-        if leaf.document_id != document_id
-    ]
-    winners = dict(source.winners)
-    winners.pop(document_id, None)
-    return build_state_model(rows, winners)
 
 
 def _require_source_database(database: str, *, allow_disposable_preview: bool = False) -> None:

--- a/scripts/migrations/taxonomy_identity_v1/disposable_gate.py
+++ b/scripts/migrations/taxonomy_identity_v1/disposable_gate.py
@@ -1,4 +1,4 @@
-"""Disposable real-Cloudant proof for the minimal quarantine migration machinery."""
+"""Disposable real-Cloudant proof for the dat-411 taxonomy-identity-v1 operation."""
 
 from __future__ import annotations
 
@@ -13,9 +13,9 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 if __package__ in {None, ""}:
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from scripts.cloudant_quarantine_migration import (
+from scripts.migrations.taxonomy_identity_v1.dat_411_operation import (
     COMPLETION_MARKER_ID,
     PREVIEW_QUARANTINE_PATTERN,
     PREVIEW_SOURCE_PATTERN,
@@ -27,7 +27,10 @@ from scripts.cloudant_quarantine_migration import (
     install_fence,
 )
 from scripts.document_contract_ops import CONTRACT_DESIGN_ID, load_design_document
-from scripts.migrate_taxonomy_identity import CREDENTIAL_ENV_VAR, RUNNING_ACTIVITY_ID
+from scripts.migrations.taxonomy_identity_v1.planner import (
+    CREDENTIAL_ENV_VAR,
+    RUNNING_ACTIVITY_ID,
+)
 
 
 def require(condition: bool, message: str) -> None:

--- a/scripts/migrations/taxonomy_identity_v1/planner.py
+++ b/scripts/migrations/taxonomy_identity_v1/planner.py
@@ -5,6 +5,10 @@ aggregate dry-run counts. Its transformation is derived from that database's cur
 taxonomy rows; no room labels are hardcoded here. It has no backup, restore, or write
 capability. Document bodies, database names, opaque database metadata, and credentials
 are never printed.
+
+This module is reusable only for the taxonomy-identity-v1 migration family. It is
+deliberately separate from product-neutral Cloudant migration primitives and from the
+exact dat-411 production operation.
 """
 
 from __future__ import annotations

--- a/tests/migrations/__init__.py
+++ b/tests/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for explicit, versioned migration operations."""

--- a/tests/migrations/taxonomy_identity_v1/__init__.py
+++ b/tests/migrations/taxonomy_identity_v1/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the taxonomy-identity-v1 migration family."""

--- a/tests/migrations/taxonomy_identity_v1/test_dat_411_operation.py
+++ b/tests/migrations/taxonomy_identity_v1/test_dat_411_operation.py
@@ -11,8 +11,10 @@ from pathlib import Path
 
 import pytest
 
-from scripts import cloudant_quarantine_migration as quarantine
-from scripts import migrate_taxonomy_identity as migration
+from scripts.cloudant_migration import client as cloudant_client
+from scripts.cloudant_migration import state as cloudant_state
+from scripts.migrations.taxonomy_identity_v1 import dat_411_operation as quarantine
+from scripts.migrations.taxonomy_identity_v1 import planner as migration
 from scripts.document_contract_ops import CONTRACT_DESIGN_ID, load_design_document
 
 
@@ -29,7 +31,7 @@ def state(*leaves: tuple[str, str, bool], winners: dict[str, str] | None = None)
         winners = {}
         for row in rows:
             winners.setdefault(row["id"], row["rev"])
-    return quarantine.build_state_model(rows, winners)
+    return cloudant_state.build_state_model(rows, winners)
 
 
 def test_state_model_is_order_independent_and_covers_deleted_and_conflicting_leaves() -> None:
@@ -46,8 +48,8 @@ def test_state_model_is_order_independent_and_covers_deleted_and_conflicting_lea
         "_design/example": "1-design",
     }
 
-    first = quarantine.build_state_model(leaves, winners)
-    second = quarantine.build_state_model(
+    first = cloudant_state.build_state_model(leaves, winners)
+    second = cloudant_state.build_state_model(
         list(reversed(leaves)), dict(reversed(list(winners.items())))
     )
 
@@ -77,7 +79,7 @@ def test_state_model_is_order_independent_and_covers_deleted_and_conflicting_lea
 )
 def test_state_model_rejects_inconsistent_enumeration(leaves, winners, message) -> None:
     with pytest.raises(quarantine.QuarantineSafetyError, match=message):
-        quarantine.build_state_model(leaves, winners)
+        cloudant_state.build_state_model(leaves, winners)
 
 
 def test_replication_document_is_one_shot_unfiltered_and_uses_structured_auth() -> None:
@@ -170,7 +172,7 @@ class CaptureCloudant:
 
     def get_security_hash(self, database):
         self.calls.append(("security", database))
-        return quarantine.canonical_hash(self.security)
+        return cloudant_state.canonical_hash(self.security)
 
     def get_all_documents(self, database, *, include_conflicts):
         self.calls.append(("all-documents", database, include_conflicts))
@@ -200,7 +202,7 @@ def capture_with_bindings(client, expected_state, **kwargs):
         SOURCE,
         QUARANTINE,
         expected_source_fingerprint=expected_state.fingerprint,
-        expected_security_hash=quarantine.canonical_hash(client.security),
+        expected_security_hash=cloudant_state.canonical_hash(client.security),
         **kwargs,
     )
 
@@ -251,7 +253,7 @@ def test_capture_binding_mismatch_blocks_before_quarantine_creation(changed_bind
         security={},
     )
     expected_source = "0" * 64 if changed_binding == "source" else captured.fingerprint
-    actual_security = quarantine.canonical_hash({})
+    actual_security = cloudant_state.canonical_hash({})
     expected_security = "0" * 64 if changed_binding == "security" else actual_security
 
     with pytest.raises(quarantine.QuarantineSafetyError, match="expectation"):
@@ -278,7 +280,7 @@ def test_capture_creates_one_exact_database_and_uses_transient_replication() -> 
     assert receipt.source_database == SOURCE
     assert receipt.quarantine_database == QUARANTINE
     assert receipt.state == captured
-    assert receipt.security_hash == quarantine.canonical_hash(client.security)
+    assert receipt.security_hash == cloudant_state.canonical_hash(client.security)
     assert ("create-database", QUARANTINE, False) in client.calls
     assert ("replicate-once", SOURCE, QUARANTINE) in client.calls
     assert all("job" not in call[0] for call in client.calls)
@@ -629,7 +631,7 @@ def test_operational_client_reads_leaf_bodies_in_bounded_batches(monkeypatch) ->
     monkeypatch.setattr(client, "_request", request)
 
     assert len(client.get_leaf_documents(SOURCE)) == 101
-    assert batch_sizes == [quarantine.LEAF_READ_BATCH_SIZE, 1]
+    assert batch_sizes == [cloudant_client.LEAF_READ_BATCH_SIZE, 1]
 
 
 def test_operational_client_writes_only_exact_database_replication_and_document_targets(
@@ -717,7 +719,7 @@ def test_operational_transport_sanitizes_http_error_bodies_credentials_and_urls(
             private_body,
         )
 
-    monkeypatch.setattr(quarantine.urllib.request, "urlopen", fail)
+    monkeypatch.setattr(cloudant_client.urllib.request, "urlopen", fail)
 
     with pytest.raises(quarantine.QuarantineSafetyError) as error:
         client.create_database(QUARANTINE, partitioned=False)
@@ -762,8 +764,8 @@ def test_operational_transport_retries_rate_limits_without_exposing_response(
             )
         return Response()
 
-    monkeypatch.setattr(quarantine.urllib.request, "urlopen", rate_limited_then_succeed)
-    monkeypatch.setattr(quarantine.time, "sleep", delays.append)
+    monkeypatch.setattr(cloudant_client.urllib.request, "urlopen", rate_limited_then_succeed)
+    monkeypatch.setattr(cloudant_client.time, "sleep", delays.append)
 
     assert client.database_exists(QUARANTINE) is True
     assert attempts == 3
@@ -1081,7 +1083,7 @@ class MigrationCloudant:
         if database == QUARANTINE:
             return migration_base_state()
         if self.marker is not None:
-            return quarantine.add_leaf_to_state(
+            return cloudant_state.add_leaf_to_state(
                 self.complete_state,
                 quarantine.COMPLETION_MARKER_ID,
                 self.marker["_rev"],
@@ -1160,7 +1162,7 @@ def test_executor_writes_taxonomy_entities_tombstone_then_separate_completion_ma
 
 def test_executor_blocks_unexpected_final_revision_before_writing_marker() -> None:
     _base, _plan, _settled, leaves, complete = fully_migrated_fixture()
-    unexpected = quarantine.add_leaf_to_state(
+    unexpected = cloudant_state.add_leaf_to_state(
         complete, "task-unexpected", "1-unexpected", deleted=False
     )
     client = MigrationCloudant(final_state_override=unexpected)

--- a/tests/migrations/taxonomy_identity_v1/test_planner.py
+++ b/tests/migrations/taxonomy_identity_v1/test_planner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts import migrate_taxonomy_identity as migration
+from scripts.migrations.taxonomy_identity_v1 import planner as migration
 
 
 TARGET_DATABASE = "fortudo-dat-411"

--- a/tests/test_cloudant_migration_architecture.py
+++ b/tests/test_cloudant_migration_architecture.py
@@ -1,0 +1,35 @@
+"""Repository boundaries for reusable Cloudant migration safety code."""
+
+from __future__ import annotations
+
+import inspect
+
+from scripts.cloudant_migration import client, state
+from scripts.migrations.taxonomy_identity_v1 import dat_411_operation
+
+
+def test_reusable_cloudant_modules_exclude_product_and_operation_constants() -> None:
+    reusable_source = "\n".join(
+        [
+            inspect.getsource(client),
+            inspect.getsource(state),
+        ]
+    )
+
+    assert "fortudo-dat-411" not in reusable_source
+    assert "work/meetings" not in reusable_source
+    assert "work/comms" not in reusable_source
+    assert "config-taxonomy-identity-migration-v1" not in reusable_source
+
+
+def test_dat_411_operation_retains_exact_production_lock() -> None:
+    assert dat_411_operation.SOURCE_DATABASE == "fortudo-dat-411"
+    assert (
+        dat_411_operation.COMPLETION_MARKER_ID
+        == "config-taxonomy-identity-migration-v1"
+    )
+
+
+def test_operation_reuses_canonical_state_types() -> None:
+    assert dat_411_operation.StateModel is state.StateModel
+    assert dat_411_operation.OperationalCloudantClient.__mro__[1] is client.CloudantMigrationClient


### PR DESCRIPTION
## Summary

- extract product-neutral Cloudant state and credential-redacting client primitives into `scripts/cloudant_migration/`
- move the completed taxonomy-identity-v1 planner, disposable proof, and `fortudo-dat-411` operation under an explicitly versioned migration package
- add architecture tests that keep room names, taxonomy meanings, and completion-marker constants out of the reusable core
- document the reusable/foundation/one-off ownership model and the follow-up phase for browser contract-version boundaries
- update the production runbook to record the completed migration and retain the exact quarantine-management path
- capture the deferred Taxonomy Manager UX point of view, including the possible no-delete policy change
- correct the Cloudant setup and accepted-risk references to match current IBM/PouchDB behavior, manual fence-first provisioning, exact CORS origins, scoped-key limitations, rate-limit handling, and recovery boundaries

## Why

The working migration code mixed reusable Cloudant safety mechanics with the intentionally one-off
`dat-411` transformation and production authorization gates. That made it difficult to tell what
could be reused safely for another room or contract version.

This PR clarifies those boundaries without introducing a configurable production migration engine.
The `dat-411` source lock, locked meanings, v1 completion protocol, and approval flags remain
one-off. Future operations must provide and prove their own targets, invariants, and lifecycle
gates.

The production migration and documentation audit also exposed stale setup claims around IAM-only
support, wildcard preview origins, room-code obscurity, local replicas as backups, and per-room API
keys. The corrected reference distinguishes the accepted personal/household credential tradeoff
from actual authentication and recovery guarantees while leaving room identity and access redesign
out of scope.

## Impact

- no browser/runtime behavior changes
- no public asset or service-worker changes
- no Firebase deployment required
- no Cloudant or production writes performed
- operational command paths are renamed; no compatibility wrappers are retained
- the existing `delete-quarantine` capability remains available in the versioned `dat_411_operation.py` entry point
- documentation now records the account-wide shared-credential acceptance and fence-first future-room posture; it does not implement room identity or credential redesign

## Verification

- ESLint and Prettier passed
- Ruff passed
- focused Python suite: 91 passed
- complete non-browser Python suite: 214 passed
- Jest: 76 suites, 1,592 tests passed
- coverage: 91.07% statements, 79.40% branches, 93.53% functions, 91.97% lines
- local Playwright: 18 passed
- documentation internal-link validation passed
- staged and unstaged diff checks passed
